### PR TITLE
Feature: Examining a xeno now shows if they are disconnected / ghosted.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -270,6 +270,12 @@
 
 	. += "</span>"
 
+	if(has_brain() && stat != DEAD)
+		if(!key)
+			. += "[span_deadsay("They are fast asleep. It doesn't look like they are waking up anytime soon.")]\n"
+		else if(!client)
+			. += "[span_xenowarning("They don't seem responsive.")]\n"
+
 	if(hivenumber != XENO_HIVE_NORMAL)
 		var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
 		. += "It appears to belong to the [hive.prefix]hive"


### PR DESCRIPTION
## About The Pull Request

Adds text on inspect for disconnected / ghosted xenomorphs.

![image](https://github.com/EaglePhntm/NTFvsAlien/assets/59719612/c3f13289-1f40-44d1-8c92-cd81c9a72308)

## Why It's Good For The Game

Humans have it, why not xenos.

## Changelog

:cl: Casper
add: Adds ghosted / disconnected examine text to xenos.
/:cl: