### PR TITLE
Adjusts SOM req access.

### DIFF
--- a/code/datums/jobs/job/sonsofmars.dm
+++ b/code/datums/jobs/job/sonsofmars.dm
@@ -163,7 +163,7 @@ What you lack alone, you gain standing shoulder to shoulder with the men and wom
 
 /datum/job/som/squad/engineer
 	title = SOM_SQUAD_ENGINEER
-	access = list (ACCESS_SOM_DEFAULT,ACCESS_SOM_ENGINEERING,ALL_ANTAGONIST_ACCESS)
+	access = list (ACCESS_SOM_DEFAULT,ACCESS_SOM_REQUESITIONS,ACCESS_SOM_ENGINEERING,ALL_ANTAGONIST_ACCESS)
 	paygrade = "SOM_E3"
 	comm_title = "Eng"
 	total_positions = 12
@@ -328,7 +328,7 @@ You may not be a fully-fledged doctor, but you stand between life and death when
 
 /datum/job/som/squad/leader
 	title = SOM_SQUAD_LEADER
-	access = list (ACCESS_SOM_DEFAULT,ACCESS_SOM_SQUADLEADER,ALL_ANTAGONIST_ACCESS)
+	access = list (ACCESS_SOM_DEFAULT,ACCESS_SOM_REQUESITIONS,ACCESS_SOM_SQUADLEADER,ALL_ANTAGONIST_ACCESS)
 	req_admin_notify = TRUE
 	paygrade = "SOM_S3"
 	comm_title = JOB_COMM_TITLE_SQUAD_LEADER

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -646,7 +646,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	shuttle_id = "supplysom"
 	faction = FACTION_SOM
 	home_id = "supply_som"
-	req_one_access = list(213, 210, 208)
+	req_access = list(213)
 
 /obj/machinery/computer/supplycomp/clf
 	shuttle_id = "supplyclf"

--- a/code/modules/reqs/supply.dm
+++ b/code/modules/reqs/supply.dm
@@ -646,7 +646,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 	shuttle_id = "supplysom"
 	faction = FACTION_SOM
 	home_id = "supply_som"
-	req_access = list(213)
+	req_one_access = list(213, 210, 208)
 
 /obj/machinery/computer/supplycomp/clf
 	shuttle_id = "supplyclf"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hey Vide. Did a bit of pondering though it's taken a while to get along to it. But with how little players the SOM usually get, perhaps allowing certain squad roles to use req would be a nice bit of QOL.

In this PR, those roles are the SOM squad engineer and squad leader.

## Why It's Good For The Game

With the lesser numbers SOM typically has, I think it'd be convenient to make it so atleast 1 or two squad roles can get to it in an emergency.