### PR TITLE
text emphasis for emotes.

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -53,10 +53,6 @@
 	if(!msg)
 		return
 
-	var/end = copytext(msg, length(message))
-	if(!(end in list("!", ".", "?", ":", "\"", "-")))
-		msg += "."
-
 	if(intentional)
 		user.log_message(msg, LOG_EMOTE)
 	var/dchatmsg = "[prefix]<b>[user]</b> [msg]"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -58,7 +58,7 @@
 
 
 /datum/emote/custom/run_emote(mob/user, params, type_override, intentional = FALSE, prefix)
-	message = params
+	message = user.say_emphasis(params)
 	return ..()
 
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -50,7 +50,7 @@
 	if(!message)
 		return
 
-	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = trim(copytext_char(say_emphasis(message), 1, MAX_MESSAGE_LEN))
 
 	// Italicize it
 	message = "<i>[message]</i>"
@@ -66,7 +66,7 @@
 	if(!message)
 		return
 
-	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = trim(copytext_char(say_emphasis(message), 1, MAX_MESSAGE_LEN))
 
 	// Italicize it
 	message = "<i>[message]</i>"


### PR DESCRIPTION

## About The Pull Request

- you can now use bold/italics/underlines for emotes

- removed that thing that adds punctuation because it doesn't work with emotes/subtler well. it's not hard to add a period

## Why It's Good For The Game

you can now bold, italicize and use underlines for emotes.

punctuation thing got removed because having a period added at the end of your statement when subtlering/emoting is goofy. it's also not really that hard to just punctuate yourself.

## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:
