### PR TITLE
Makes restart votes work

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -186,7 +186,7 @@ SUBSYSTEM_DEF(vote)
 				break
 		if(!active_admins)
 			// No delay in case the restart is due to lag
-			SSticker.Reboot("Restart vote successful.", "restart vote", 1)
+			SSticker.Reboot("Restart vote successful.", 1)
 		else
 			to_chat(world, "<span style='boltnotice'>Notice:Restart vote will not restart the server automatically because there are active admins on.</span>")
 			message_admins("A restart vote has passed, but there are active admins on with +SERVER, so it has been canceled. If you wish, you may restart the server.")


### PR DESCRIPTION

## About The Pull Request
Fixes a bug that made successful restart votes with no active admins run into a runtime error when trying to restart the server, resulting in it not restarting.
## Why It's Good For The Game
Restart votes are useful and should work as intended.
## Changelog
:cl:
fix: Fixed restart votes never actually restarting the server.
/:cl:
