### PR TITLE
Adds latejoin survivor spawns on top of all roundstart survivor spawns

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -8091,6 +8091,7 @@
 /area/bigredv2/outside/filtration_plant)
 "cZU" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_alarm{
 	dir = 4
@@ -8182,6 +8183,7 @@
 /area/bigredv2/outside/marshal_office)
 "dkJ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "dnx" = (
@@ -8452,6 +8454,7 @@
 /area/bigredv2/caves/southwest)
 "dSP" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
 "dVz" = (
@@ -10212,6 +10215,7 @@
 "hOL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "hPq" = (
@@ -11511,6 +11515,7 @@
 "kvX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "kxw" = (
@@ -12564,6 +12569,7 @@
 /area/bigredv2/outside/virology)
 "mZU" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
 "mZZ" = (
@@ -13813,6 +13819,7 @@
 /area/bigredv2/outside/c)
 "pRP" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 4
 	},
@@ -14405,6 +14412,7 @@
 /area/bigredv2/outside/hydroponics)
 "rkx" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "rlw" = (
@@ -16990,6 +16998,7 @@
 /area/bigredv2/outside/virology)
 "wQm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "wSJ" = (

--- a/_maps/map_files/Colony1/Colony1.dmm
+++ b/_maps/map_files/Colony1/Colony1.dmm
@@ -1086,6 +1086,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "bAj" = (
@@ -3777,6 +3778,7 @@
 	})
 "eSX" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "eUg" = (
@@ -10447,6 +10449,7 @@
 	})
 "oiu" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "oix" = (
@@ -12151,6 +12154,7 @@
 	},
 /obj/effect/ai_node,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "qqK" = (
@@ -15899,6 +15903,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "vxV" = (

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -19364,6 +19364,7 @@
 /area/ice_colony/exterior/underground/caves/rock)
 "eIV" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/ice_colony/surface/engineering/tool)
 "eKa" = (
@@ -19864,6 +19865,7 @@
 /area/ice_colony/underground/hallway/north_west)
 "fry" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 8
 	},
@@ -20744,6 +20746,7 @@
 /area/ice_colony/surface/bar/bar)
 "gIW" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/yellow2,
 /area/ice_colony/surface/substation/smes)
 "gJe" = (
@@ -21075,6 +21078,7 @@
 /area/ice_colony/exterior/surface/clearing/south)
 "hit" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/shuttle/dropship/five,
 /area/ice_colony/underground/responsehangar)
 "hiV" = (
@@ -22363,6 +22367,7 @@
 /area/ice_colony/surface/garage/one)
 "jdf" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/bar)
 "jdB" = (
@@ -22937,6 +22942,7 @@
 /area/ice_colony/surface/garage/one)
 "jRI" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_w)
@@ -23403,6 +23409,7 @@
 /area/ice_colony/underground/crew/chapel)
 "kvM" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/green/whitegreen{
 	dir = 10
 	},
@@ -23979,6 +23986,7 @@
 /area/ice_colony/surface/bar/canteen)
 "lqO" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command)
 "lrc" = (
@@ -24982,6 +24990,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 5
 	},
@@ -26661,6 +26670,7 @@
 /area/ice_colony/surface/clinic/lobby)
 "oIi" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/container_yard)
 "oIy" = (
@@ -28590,6 +28600,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/shuttle/dropship/fourteen,
 /area/ice_colony/surface/hangar/beta)
 "rsg" = (
@@ -28832,6 +28843,7 @@
 /area/ice_colony/underground/storage)
 "rFJ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/disposals)
 "rFS" = (
@@ -29795,6 +29807,7 @@
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "sKY" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	on = 1
@@ -29837,6 +29850,7 @@
 /area/ice_colony/surface/substation/smes)
 "sQn" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/ice_colony/surface/dorms)
 "sQr" = (
@@ -33156,6 +33170,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_e)
 "xjj" = (

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -271,6 +271,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/brown{
 	dir = 9
 	},
@@ -454,6 +455,7 @@
 "ann" = (
 /obj/structure/closet/coffin/open,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/chapel{
 	dir = 1
 	},
@@ -1734,6 +1736,7 @@
 /area/lv624/ground/sand1)
 "aRg" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/lv624/lazarus/corporate_affairs)
 "aRl" = (
@@ -3912,6 +3915,7 @@
 	})
 "cuY" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
@@ -5703,6 +5707,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/green/whitegreen{
 	dir = 8
 	},
@@ -5903,6 +5908,7 @@
 /area/lv624/ground/caves/rock)
 "evx" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 5
 	},
@@ -6448,6 +6454,7 @@
 "fbO" = (
 /obj/item/toy/inflatable_duck,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/liquid/water/river,
 /area/lv624/lazarus/fitness)
 "fbQ" = (
@@ -7203,6 +7210,7 @@
 /area/lv624/lazarus/kitchen)
 "fQf" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
@@ -8572,6 +8580,7 @@
 	})
 "hld" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
@@ -10692,6 +10701,7 @@
 /area/lv624/lazarus/corporate_affairs)
 "jlE" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/platebotc,
 /area/lv624/lazarus/quartstorage/outdoors)
 "jlH" = (
@@ -10988,6 +10998,7 @@
 /area/lv624/lazarus/tablefort)
 "jCs" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 5
 	},
@@ -11262,6 +11273,7 @@
 /area/lv624/lazarus/quartstorage/dome)
 "jOu" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -12871,6 +12883,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/purple/taupepurple{
 	dir = 9
 	},
@@ -17491,6 +17504,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},
@@ -19869,6 +19883,7 @@
 	})
 "sDw" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/lv624/ground/jungle8{
 	outside = 0
@@ -20623,6 +20638,7 @@
 /area/lv624/lazarus/main_hall)
 "tqS" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/spawner/random/engineering/wood,
 /turf/open/floor/plating,
 /area/lv624/lazarus/quartstorage)
@@ -21686,6 +21702,7 @@
 /area/mainship/patrol_base/som)
 "usH" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
 	},
@@ -22346,6 +22363,7 @@
 /area/lv624/ground/compound/n)
 "uZs" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/tile/vault{
 	dir = 8
@@ -22947,6 +22965,7 @@
 /area/lv624/lazarus/quartstorage)
 "vDe" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
 "vEk" = (

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -318,6 +318,7 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/purple,
 /area/magmoor/civilian/dorms)
 "alG" = (
@@ -1066,6 +1067,7 @@
 /area/magmoor/cave/northwest)
 "aMv" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/blue/corner{
 	dir = 1
 	},
@@ -3161,6 +3163,7 @@
 /area/magmoor/command/lobby)
 "cgv" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
 "cgC" = (
@@ -6896,6 +6899,7 @@
 "eHP" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
 "eIj" = (
@@ -8092,6 +8096,7 @@
 /area/magmoor/cargo/storage/south)
 "fAJ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/taupeblue,
 /area/magmoor/civilian/dorms)
 "fAY" = (
@@ -8447,6 +8452,7 @@
 /area/magmoor/compound/southeast)
 "fLe" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
@@ -9026,6 +9032,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
@@ -10976,6 +10983,7 @@
 "hHK" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/shower)
 "hHU" = (
@@ -15580,6 +15588,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/magmoor/command/office)
 "kPQ" = (
@@ -17564,6 +17573,7 @@
 /area/magmoor/security/lobby)
 "mlZ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
 "mmo" = (
@@ -20780,6 +20790,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean)
@@ -24991,6 +25002,7 @@
 /area/magmoor/landing/two)
 "rHK" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/lobby)
@@ -26685,6 +26697,7 @@
 /area/magmoor/engi/storage)
 "sSk" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
 "sSX" = (
@@ -29912,6 +29925,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/magmoor/cargo/freezer)
 "vcB" = (
@@ -31528,6 +31542,7 @@
 /area/magmoor/cave/northwest)
 "wqc" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/magmoor/civilian/dorms)
 "wqD" = (
@@ -31539,6 +31554,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/magmoor/medical/breakroom)

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -448,6 +448,7 @@
 /area/orion_outpost/ground/underground/caveS)
 "ct" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/engineering)
 "cw" = (
@@ -8010,6 +8011,7 @@
 /area/orion_outpost/surface/building/administration)
 "Nd" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
 "Ne" = (
@@ -9869,6 +9871,7 @@
 /area/orion_outpost/surface/building/breakroom)
 "VU" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/administration)
 "VV" = (
@@ -10509,6 +10512,7 @@
 /area/orion_outpost/surface/building/bunker)
 "Zb" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/brig)
 "Zc" = (

--- a/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
+++ b/_maps/map_files/Prison_Station_FOP/Prison_Station_FOP.dmm
@@ -5704,6 +5704,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/darkred,
 /area/prison/security/checkpoint/maxsec_highsec)
 "asU" = (
@@ -16819,6 +16820,7 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
 "bba" = (
@@ -18735,6 +18737,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/cleanmarked,
 /area/prison/canteen)
 "bhc" = (
@@ -18769,6 +18772,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/prison/kitchen,
 /area/prison/kitchen)
@@ -23773,6 +23777,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/south/north)
 "bxp" = (
@@ -27736,6 +27741,7 @@
 /area/prison/cellblock/mediumsec/south)
 "bKD" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/bright_clean,
 /area/prison/holding/holding2)
 "bKE" = (
@@ -36064,6 +36070,7 @@
 /area/prison/security/monitoring/protective)
 "cmv" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -36985,6 +36992,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/prison/disposal)
 "cpu" = (
@@ -37756,6 +37764,7 @@
 /area/prison/pirate)
 "csr" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/carpet,
 /area/prison/pirate)
 "css" = (
@@ -40237,6 +40246,7 @@
 	dir = 6
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/prison/residential/central)
 "dXl" = (
@@ -40251,6 +40261,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/prison/yellow{
 	dir = 1
@@ -40783,6 +40794,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/red,
 /area/prison/cellblock/highsec/south/north)
 "fgf" = (
@@ -41154,12 +41166,14 @@
 	},
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/prison/security/monitoring/highsec)
 "gnb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/red/corner,
 /area/prison/cellblock/highsec/north/south)
 "gnd" = (
@@ -41264,6 +41278,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/south)
 "gCu" = (
@@ -41317,6 +41332,7 @@
 /area/prison/cellblock/highsec/north/south)
 "gGZ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/cellstripe{
 	dir = 8
 	},
@@ -41405,6 +41421,7 @@
 /area/prison/cellblock/mediumsec/north)
 "gPc" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/prison/maintenance/residential/access/north)
 "gPp" = (
@@ -42313,6 +42330,7 @@
 /area/prison/hangar/main)
 "iYm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/bright_clean,
 /area/prison/visitation)
 "iYA" = (
@@ -42478,6 +42496,7 @@
 /area/prison/engineering/atmos)
 "jqt" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/prison,
 /area/prison/security/monitoring/highsec)
@@ -42598,10 +42617,12 @@
 /area/prison/research)
 "jEP" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/prison/cellblock/vip)
 "jEZ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/green{
 	dir = 8
 	},
@@ -42793,6 +42814,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/north)
 "kaY" = (
@@ -42886,6 +42908,7 @@
 /area/prison/cellblock/lowsec/ne)
 "kpA" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/bright_clean/two,
 /area/prison/holding/holding1)
 "kpB" = (
@@ -43015,6 +43038,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/prison/cellblock/mediumsec/north)
 "kGQ" = (
@@ -43124,6 +43148,7 @@
 /area/prison/research/secret/biolab)
 "kWF" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/medsec)
 "kWG" = (
@@ -44621,6 +44646,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/prison/residential/south)
@@ -44726,6 +44752,7 @@
 /area/prison/hangar/civilian)
 "oRV" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/highsec/north/north)
@@ -44985,6 +45012,7 @@
 /area/prison/hallway/central)
 "pEh" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/yellow,
 /area/prison/cellblock/mediumsec/south)
 "pEl" = (
@@ -45559,6 +45587,7 @@
 "qST" = (
 /obj/structure/window/reinforced,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/green,
 /area/prison/quarters/staff)
 "qTo" = (
@@ -45645,6 +45674,7 @@
 /area/prison/research/secret/biolab)
 "rdQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/plate,
 /area/prison/recreation/highsec/n)
 "reb" = (
@@ -45777,6 +45807,7 @@
 /area/prison/residential/central)
 "rqp" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/prison/residential/central)
 "rqK" = (
@@ -46440,6 +46471,7 @@
 "sHr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/prison/quarters/research)
 "sHD" = (
@@ -46931,6 +46963,7 @@
 /area/prison/cellblock/mediumsec/east)
 "tXr" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/plate,
 /area/prison/cellblock/mediumsec/south)
 "tXM" = (
@@ -47846,6 +47879,7 @@
 /area/prison/cellblock/highsec/north/north)
 "wmW" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/carpet,
 /area/prison/chapel)
 "wmY" = (
@@ -48153,6 +48187,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/prison/chapel)
 "xcb" = (
@@ -48237,6 +48272,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/yellow/corner{
 	dir = 8
 	},
@@ -48277,6 +48313,7 @@
 /area/prison/cellblock/mediumsec/west)
 "xwA" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/prison/hangar_storage/research)
 "xwG" = (
@@ -48565,6 +48602,7 @@
 /area/prison/cellblock/mediumsec/south)
 "yiA" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/prison/laundry)

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -3082,6 +3082,7 @@
 "oC" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/brown2{
 	dir = 6
 	},
@@ -4115,6 +4116,7 @@
 /area/outpost/cargo/security)
 "tk" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -5001,6 +5003,7 @@
 "xq" = (
 /obj/structure/bed/chair/office/dark,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/office)
 "xs" = (
@@ -5129,6 +5132,7 @@
 /area/outpost/lz1)
 "yd" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/blue2{
 	dir = 8
@@ -5253,6 +5257,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
@@ -5877,6 +5882,7 @@
 /area/outpost/yard/central)
 "Bz" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
 "BB" = (
@@ -6131,6 +6137,7 @@
 "CT" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "CU" = (
@@ -6218,6 +6225,7 @@
 /area/outpost/yard/north_east)
 "Dt" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "Du" = (
@@ -8398,6 +8406,7 @@
 "NJ" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/arrivals)
 "NK" = (
@@ -8559,6 +8568,7 @@
 /area/outpost/yard/south)
 "Ov" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
@@ -9549,6 +9559,7 @@
 "Tj" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -9991,6 +10002,7 @@
 /area/outpost/engineering/engine)
 "Vm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
 "Vo" = (

--- a/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
+++ b/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
@@ -3681,6 +3681,7 @@
 /area/lv624/ground/caves/central1)
 "uU" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/ground,
 /area/vapor_processing/west_compound)
 "uV" = (
@@ -3740,6 +3741,7 @@
 /area/maintenance/substation)
 "vE" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grass,
 /area/lv624/ground/compound/c)
 "vM" = (
@@ -3903,6 +3905,7 @@
 /area/lv624/ground/caves/west1)
 "yH" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -4226,6 +4229,7 @@
 /area/lv624/lazarus/medbay)
 "Dr" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5262,10 +5266,12 @@
 /area/lv624/lazarus/engineering)
 "Th" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/prison/yellow,
 /area/lv624/lazarus/engineering)
@@ -5415,6 +5421,7 @@
 /area/shuttle/drop1/lz1)
 "VC" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
@@ -5524,6 +5531,7 @@
 /area/space)
 "WQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grass,
 /area/lv624/ground/compound/se)
 "WR" = (

--- a/_maps/map_files/antagmap/antagmap.dmm
+++ b/_maps/map_files/antagmap/antagmap.dmm
@@ -9387,6 +9387,7 @@
 /obj/item/bedsheet/brown,
 /obj/effect/decal/cleanable/blood/splatter/cum,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/item/clothing/under/lewd/panties,
 /turf/open/floor/plating/ground/dirt,
 /area/antag_ship/clf_base/hallways/outside)

--- a/_maps/map_files/corsat/corsat.dmm
+++ b/_maps/map_files/corsat/corsat.dmm
@@ -2607,6 +2607,7 @@
 "blT" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/corsat/sigma/dorms)
@@ -5083,6 +5084,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/corsat/gamma/residential/east)
 "cph" = (
@@ -7476,6 +7478,7 @@
 /area/corsat/gamma/hangar/checkpoint)
 "dpU" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/turf_decal/tile/corsatcorner/lighpurple{
 	dir = 4
 	},
@@ -7969,6 +7972,7 @@
 /area/corsat/omega/hangar/office)
 "dBL" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/residential/east)
 "dBN" = (
@@ -10997,6 +11001,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/corsat/gamma/residential/east)
 "eUi" = (
@@ -11085,6 +11090,7 @@
 /area/corsat/omega/complex)
 "eWu" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
@@ -11207,6 +11213,7 @@
 /area/corsat/gamma/sigmaremote)
 "faZ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -12690,6 +12697,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -12973,6 +12981,7 @@
 /area/corsat/omega/hallways)
 "fOH" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
@@ -18189,6 +18198,7 @@
 /area/corsat/sigma/dorms)
 "iiO" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -19237,6 +19247,7 @@
 "iJg" = (
 /obj/structure/bed/chair/comfy/beige,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/carpet,
 /area/corsat/gamma/residential/lounge)
 "iJr" = (
@@ -21321,6 +21332,7 @@
 /area/corsat/sigma/cargo)
 "jEs" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/turf_decal/tile/full/black,
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/sigmaremote)
@@ -24687,6 +24699,7 @@
 /area/corsat/gamma/cargo/disposal)
 "lah" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/turf_decal/tile/corsatstraight/brown,
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/cargo/disposal)
@@ -25179,6 +25192,7 @@
 /area/corsat/gamma/cargo/disposal)
 "llg" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/corsat/gamma/residential/showers)
@@ -30559,6 +30573,7 @@
 /area/corsat/emergency_access)
 "nwi" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/darkgray,
 /area/corsat/theta/airlock/east)
 "nwt" = (
@@ -30759,6 +30774,7 @@
 /area/corsat/omega/complex)
 "nAm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/corsat/gamma/residential/lavatory)
 "nAD" = (
@@ -37871,6 +37887,7 @@
 /area/corsat/gamma/engineering)
 "qFe" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/grayscale/round/black,
 /area/corsat/gamma/engineering)
@@ -38322,6 +38339,7 @@
 /area/corsat/sigma/south/engineering)
 "qPb" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/round/black,
 /area/corsat/gamma/airlock/north)
 "qPM" = (
@@ -38357,6 +38375,7 @@
 /area/corsat/sigma/cargo)
 "qQv" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/round,
 /area/corsat/gamma/medbay)
 "qQz" = (
@@ -39446,6 +39465,7 @@
 /area/corsat/sigma/hangar/monorail)
 "rrX" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/darkgray,
 /area/corsat/sigma/southeast/datalab)
 "rse" = (
@@ -43150,6 +43170,7 @@
 /area/corsat/sigma/southeast/datalab)
 "sUT" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/bar,
 /area/corsat/gamma/canteen)
 "sUX" = (
@@ -46653,6 +46674,7 @@
 /area/corsat/theta/airlock/east/id)
 "unK" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/darkgray,
 /area/corsat/sigma/southeast/dataoffice)
 "unX" = (

--- a/_maps/map_files/deltastation/deltastation.dmm
+++ b/_maps/map_files/deltastation/deltastation.dmm
@@ -5927,6 +5927,7 @@
 /area/deltastation/asteroidcaves/westerncaves)
 "bkZ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/engineering/supermatter/room)
 "bla" = (
@@ -14402,6 +14403,7 @@
 "cZM" = (
 /obj/effect/turf_decal/tile/transparent/neutral/fourcorners,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/cargo/lobby)
 "cZO" = (
@@ -16646,6 +16648,7 @@
 /obj/effect/turf_decal/tile/transparent/neutral/fourcorners,
 /obj/structure/cable,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/science/research)
 "dxx" = (
@@ -45719,6 +45722,7 @@
 	dir = 10
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/engineering/storage/tech)
 "jnf" = (
@@ -48673,6 +48677,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/deltastation/service/library/abandoned)
 "jUA" = (
@@ -59739,6 +59744,7 @@
 /obj/effect/turf_decal/tile/transparent/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/engineering/supermatter/room)
 "mgW" = (
@@ -60486,6 +60492,7 @@
 /area/deltastation/commons/storage/primary)
 "mpK" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron/grimy,
 /area/deltastation/service/library)
 "mpL" = (
@@ -61021,6 +61028,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/security/brig)
 "mwe" = (
@@ -83297,6 +83305,7 @@
 /area/deltastation/command/bridge)
 "qUT" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/iron,
 /area/deltastation/hallway/primary/fore)
 "qVu" = (

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -5688,6 +5688,7 @@
 /area/desert_dam/exterior/valley/valley_wilderness)
 "aJq" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
@@ -28149,6 +28150,7 @@
 /area/desert_dam/building/administration/control_room)
 "dRB" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/hanger)
@@ -29458,6 +29460,7 @@
 /area/desert_dam/building/medical/office1)
 "evS" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30757,6 +30760,7 @@
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "flm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/lobby)
 "flo" = (
@@ -34613,6 +34617,7 @@
 /area/desert_dam/interior/dam_interior/lobby)
 "hKC" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -36624,6 +36629,7 @@
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "iZN" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/desert_dam/building/church)
 "iZW" = (
@@ -37693,6 +37699,7 @@
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "jHQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -37953,6 +37960,7 @@
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "jSF" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -38247,6 +38255,7 @@
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "jZD" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -38785,6 +38794,7 @@
 /area/desert_dam/building/medical/office1)
 "krc" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -40963,6 +40973,7 @@
 /area/desert_dam/interior/dam_interior/smes_main)
 "lLh" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -41703,6 +41714,7 @@
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "mnV" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/neutral,
 /area/desert_dam/interior/dam_interior/engine_room)
 "mnX" = (
@@ -43761,6 +43773,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "nHr" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
@@ -45130,6 +45143,7 @@
 /area/desert_dam/interior/east_engineering)
 "oAh" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
 "oAx" = (
@@ -45347,6 +45361,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
 "oJi" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/green/whitegreen,
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "oJq" = (
@@ -45529,6 +45544,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "oNP" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45956,6 +45972,7 @@
 /area/desert_dam/building/dorms/hallway_westwing)
 "oZA" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
@@ -47613,6 +47630,7 @@
 "pVe" = (
 /obj/item/trash/pistachios,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/disposals)
 "pVj" = (
@@ -47711,6 +47729,7 @@
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "pYo" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/whiteyellow/corner{
 	dir = 4
@@ -48195,6 +48214,7 @@
 /area/desert_dam/building/medical/east_wing_hallway)
 "qna" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison,
@@ -49755,6 +49775,7 @@
 /area/desert_dam/interior/dam_interior/break_room)
 "rlj" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/building/warehouse/loading)
@@ -50559,6 +50580,7 @@
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "rNG" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
@@ -53299,6 +53321,7 @@
 /area/desert_dam/exterior/valley/valley_crashsite)
 "tuG" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -53398,6 +53421,7 @@
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "tyi" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
@@ -54720,6 +54744,7 @@
 /area/desert_dam/building/cafeteria/cafeteria)
 "uot" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/office1)
@@ -56762,6 +56787,7 @@
 /area/desert_dam/interior/east_engineering)
 "vAT" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/desert_dam/building/telecommunication)
 "vBg" = (
@@ -57078,6 +57104,7 @@
 "vKX" = (
 /obj/structure/bed/chair,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
 	on = 1
@@ -57446,6 +57473,7 @@
 /area/desert_dam/exterior/valley/valley_medical)
 "vXm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
@@ -59815,6 +59843,7 @@
 /area/desert_dam/exterior/valley/valley_wilderness)
 "xso" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -61198,6 +61227,7 @@
 /area/desert_dam/building/medical/north_wing_hallway)
 "yjm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,

--- a/_maps/map_files/desparity/desparity.dmm
+++ b/_maps/map_files/desparity/desparity.dmm
@@ -437,6 +437,7 @@
 /area/lv624/lazarus/hydroponics)
 "cB" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/green/greentaupe{
 	dir = 10
 	},
@@ -2018,6 +2019,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "kN" = (
@@ -3507,6 +3509,7 @@
 /area/lv624/lazarus/medbay)
 "sy" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/fitness)
 "sA" = (
@@ -4289,6 +4292,7 @@
 	dir = 9
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/lv624/lazarus/chapel)
 "wF" = (
@@ -5356,6 +5360,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
 "BM" = (
@@ -5832,6 +5837,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "Et" = (
@@ -5923,6 +5929,7 @@
 /area/lv624/lazarus/bar)
 "ER" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "EW" = (

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -391,6 +391,7 @@
 	name = "bedroll"
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "anL" = (
@@ -2187,6 +2188,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "bva" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -3755,6 +3757,7 @@
 	name = "bedroll"
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "cBr" = (
@@ -4498,6 +4501,7 @@
 /area/gelida/indoors/a_block/dorm_north)
 "cYy" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 6
 	},
@@ -5205,6 +5209,7 @@
 "dxx" = (
 /obj/structure/bed/chair/comfy,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "dxy" = (
@@ -6122,6 +6127,7 @@
 /area/gelida/indoors/c_block/mining)
 "ebg" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "ebr" = (
@@ -8556,6 +8562,7 @@
 /area/gelida/outdoors/colony_streets/north_street)
 "fGk" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "fGo" = (
@@ -13191,6 +13198,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison,
@@ -13303,6 +13311,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "iLM" = (
@@ -15605,6 +15614,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "kom" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
@@ -16746,6 +16756,7 @@
 /obj/structure/platform_decoration,
 /obj/item/reagent_containers/food/drinks/flask/marine,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -17309,6 +17320,7 @@
 	},
 /obj/item/shard,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -17357,6 +17369,7 @@
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "lwd" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "lwk" = (
@@ -17999,6 +18012,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "lSo" = (
@@ -20919,6 +20933,7 @@
 "nNU" = (
 /obj/item/shard,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 1
 	},
@@ -21235,6 +21250,7 @@
 /area/gelida/indoors/a_block/fitness)
 "nZi" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
@@ -21416,6 +21432,7 @@
 	name = "bedroll"
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -22278,6 +22295,7 @@
 /area/gelida/indoors/a_block/fitness)
 "oIO" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
@@ -22559,6 +22577,7 @@
 /area/gelida/indoors/c_block/mining)
 "oSL" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 9
 	},
@@ -22871,6 +22890,7 @@
 	name = "bedroll"
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -25226,6 +25246,7 @@
 /area/gelida/indoors/a_block/kitchen)
 "qBz" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -27504,6 +27525,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating{
 	dir = 8
 	},
@@ -31807,6 +31829,7 @@
 /area/gelida/indoors/b_block/bar)
 "uVl" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/admin)
 "uVp" = (
@@ -34289,6 +34312,7 @@
 /obj/structure/platform_decoration,
 /obj/structure/bed/roller,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},

--- a/_maps/map_files/icy_caves/icy_caves.dmm
+++ b/_maps/map_files/icy_caves/icy_caves.dmm
@@ -2019,6 +2019,7 @@
 	dir = 5
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/office)
 "lh" = (
@@ -2340,6 +2341,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/garage)
 "mL" = (
@@ -2878,6 +2880,7 @@
 /area/icy_caves/outpost/mining/west)
 "pC" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/icy_caves/outpost/outside/center)
 "pD" = (
@@ -3164,6 +3167,7 @@
 /area/icy_caves/outpost/mining/east)
 "qO" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/icy_caves/outpost/mining/west)
 "qP" = (
@@ -3198,6 +3202,7 @@
 "qW" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -3236,6 +3241,7 @@
 /area/icy_caves/outpost/mining/east)
 "rd" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -3619,6 +3625,7 @@
 /area/icy_caves/outpost/medbay)
 "sv" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/engineering)
 "sw" = (
@@ -3903,6 +3910,7 @@
 /area/icy_caves/outpost/LZ2)
 "tM" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/plating/ground/snow/layer0,
@@ -4121,6 +4129,7 @@
 "uQ" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/medbay)
@@ -4412,6 +4421,7 @@
 /area/icy_caves/caves/northwestmonorail)
 "wg" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/icy_caves/outpost/dorms)
 "wh" = (
@@ -4940,6 +4950,7 @@
 /area/icy_caves/outpost/garage)
 "yK" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/refinery)
 "yO" = (
@@ -6030,6 +6041,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/brown2{
 	dir = 8
@@ -6882,6 +6894,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/dorms)
 "HY" = (
@@ -7131,6 +7144,7 @@
 /area/icy_caves/outpost/garage)
 "Ji" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/structure/cable,
 /turf/open/floor/tile/dark,
@@ -7270,6 +7284,7 @@
 /area/icy_caves/caves/northwestmonorail)
 "JM" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/green2,
 /area/icy_caves/outpost/medbay)
 "JN" = (
@@ -8173,6 +8188,7 @@
 /area/icy_caves/caves/alienstuff)
 "Ob" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/research)
 "Oc" = (
@@ -8335,6 +8351,7 @@
 /area/icy_caves/caves/northwestmonorail)
 "OQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/kitchen,
 /area/icy_caves/outpost/kitchen)
 "OR" = (
@@ -8442,6 +8459,7 @@
 /area/icy_caves/caves/alienstuff)
 "Pt" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
@@ -8701,6 +8719,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/brown2,
 /area/icy_caves/outpost/refinery)
 "QI" = (
@@ -8973,6 +8992,7 @@
 "Sa" = (
 /obj/structure/bed,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/icy_caves/outpost/dorms)
 "Sb" = (
@@ -9124,6 +9144,7 @@
 /area/icy_caves/outpost/outside)
 "SV" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/icy_caves/outpost/outside/center)
 "SW" = (
@@ -9571,6 +9592,7 @@
 /area/icy_caves/outpost/security)
 "Vf" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/manifold4w/green/hidden,
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -9660,6 +9682,7 @@
 /area/icy_caves/outpost/garage)
 "VA" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood/broken,
 /area/icy_caves/caves/underground_cafeteria)
 "VB" = (
@@ -9998,6 +10021,7 @@
 /area/icy_caves/caves/northwestmonorail)
 "Xf" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},

--- a/_maps/map_files/lavaoutpost/LavaOutpost.dmm
+++ b/_maps/map_files/lavaoutpost/LavaOutpost.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ae" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/south)
 "af" = (
@@ -1530,6 +1531,7 @@
 /area/lavaland/cave/southwest)
 "qB" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark2,
 /area/lavaland/civilian)
 "qK" = (
@@ -3200,6 +3202,7 @@
 /area/lavaland/engie/refine)
 "Il" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/refine)
 "Im" = (
@@ -3419,6 +3422,7 @@
 "Kr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/engine)
 "Kt" = (
@@ -3657,6 +3661,7 @@
 /area/lavaland/cave/central)
 "MW" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/marking,
 /area/lavaland/cave/central)
 "MX" = (
@@ -3728,6 +3733,7 @@
 /area/lavaland/medical)
 "Oi" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/asteroidfloor,
 /area/lavaland/cave/northeast)
 "Ok" = (
@@ -3754,6 +3760,7 @@
 /area/lavaland/security/nuke)
 "Os" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/east)

--- a/_maps/map_files/riptide/riptide.dmm
+++ b/_maps/map_files/riptide/riptide.dmm
@@ -2321,6 +2321,7 @@
 /area/riptide/inside/abandonedsec)
 "bHm" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood/thatch,
 /area/riptide/inside/tikihut)
 "bHr" = (
@@ -6278,6 +6279,7 @@
 	pixel_y = -3
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood/alt_three,
 /area/riptide/inside/beachmotel)
 "erK" = (
@@ -13615,6 +13617,7 @@
 /area/riptide/outside/southislands)
 "jJc" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/freezer,
 /area/riptide/inside/medical/offices)
 "jJg" = (
@@ -14535,6 +14538,7 @@
 /obj/item/storage/bag/trash,
 /obj/item/trash/cigbutt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grimy,
 /area/riptide/inside/syndicatestarboard)
 "kog" = (
@@ -20332,6 +20336,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/riptide/inside/tikihut)
 "ooc" = (
@@ -21381,6 +21386,7 @@
 /area/riptide/inside/warehouse)
 "oVL" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/ground/concrete,
 /area/riptide/inside/warehouse)
 "oWL" = (
@@ -29069,6 +29075,7 @@
 "tSX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
@@ -32938,6 +32945,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/ground,
 /area/riptide/outside/northislands)
 "wHe" = (

--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -4026,6 +4026,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
 "cYO" = (
@@ -7536,6 +7537,7 @@
 	on = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
@@ -11708,6 +11710,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
@@ -12988,6 +12991,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/lightred/full,
 /area/slumbridge/inside/colony/southerndome)
@@ -21514,6 +21518,7 @@
 /area/slumbridge/inside/prison/outerringsouth)
 "pTG" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/slumbridge/outside/southwest)
@@ -22549,6 +22554,7 @@
 /area/slumbridge/inside/prison/outerringsouth)
 "qFB" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/colony/kitchen)
 "qFG" = (

--- a/_maps/modularmaps/big_red/barracks.dmm
+++ b/_maps/modularmaps/big_red/barracks.dmm
@@ -159,6 +159,7 @@
 /area/bigredv2/outside/admin_building)
 "fY" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -166,6 +167,7 @@
 /area/bigredv2/outside/admin_building)
 "gj" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/admin_building)
 "gk" = (

--- a/_maps/modularmaps/big_red/bigredchapelvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredchapelvar1.dmm
@@ -145,6 +145,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/chapel{
 	dir = 4
 	},

--- a/_maps/modularmaps/big_red/bigredchapelvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredchapelvar2.dmm
@@ -62,6 +62,7 @@
 /area/bigredv2/outside/chapel)
 "nQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
 	},

--- a/_maps/modularmaps/big_red/bigreddormvar1.dmm
+++ b/_maps/modularmaps/big_red/bigreddormvar1.dmm
@@ -34,6 +34,7 @@
 "hT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
 "iG" = (
@@ -297,6 +298,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
 "RW" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
@@ -247,6 +247,7 @@
 /area/bigredv2/outside/engineering)
 "lE" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "mo" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
@@ -636,6 +636,7 @@
 /area/bigredv2/caves/southwest)
 "Gp" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "Gv" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -522,6 +522,7 @@
 /area/bigredv2/outside/engineering)
 "vw" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "vR" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
@@ -498,6 +498,7 @@
 /area/bigredv2/caves/southwest)
 "Aq" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "Au" = (

--- a/_maps/modularmaps/big_red/bigredgeneralstorevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredgeneralstorevar1.dmm
@@ -592,6 +592,7 @@
 /area/bigredv2/outside/general_store)
 "Gp" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "Gw" = (

--- a/_maps/modularmaps/big_red/bigredgeneralstorevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredgeneralstorevar2.dmm
@@ -594,6 +594,7 @@
 /area/bigredv2/outside/general_store)
 "IV" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "Jm" = (

--- a/_maps/modularmaps/big_red/bigredofficevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar1.dmm
@@ -236,6 +236,7 @@
 /area/bigredv2/outside/office_complex)
 "ld" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -268,6 +269,7 @@
 "mh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "mq" = (

--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -1634,6 +1634,7 @@
 /area/bigredv2/outside/office_complex)
 "Yo" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},

--- a/_maps/modularmaps/big_red/bigredofficevar3.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar3.dmm
@@ -831,6 +831,7 @@
 /area/bigredv2/outside/c)
 "OJ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -900,6 +901,7 @@
 "Sh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "Sk" = (

--- a/_maps/modularmaps/big_red/operation.dmm
+++ b/_maps/modularmaps/big_red/operation.dmm
@@ -550,6 +550,7 @@
 /area/bigredv2/outside/admin_building)
 "wQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "wR" = (
@@ -1189,6 +1190,7 @@
 /area/bigredv2/outside/admin_building)
 "PN" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
 "Qc" = (
@@ -1318,6 +1320,7 @@
 /area/bigredv2/outside/admin_building)
 "UC" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/admin_building)
 "UF" = (

--- a/_maps/modularmaps/corsatdome/corsatdomebigred.dmm
+++ b/_maps/modularmaps/corsatdome/corsatdomebigred.dmm
@@ -687,6 +687,7 @@
 /area/corsat/sigma/biodome)
 "nw" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/black,
 /area/corsat/sigma/airlock/control)
 "nJ" = (
@@ -1721,6 +1722,7 @@
 /area/corsat/sigma/biodome)
 "GT" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/corsat/sigma/biodome/scrapyard)
 "Hg" = (

--- a/_maps/modularmaps/groundhq/ntcgroundhq.dmm
+++ b/_maps/modularmaps/groundhq/ntcgroundhq.dmm
@@ -4370,6 +4370,7 @@
 	})
 "eSX" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/mainship/mono,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "eSY" = (

--- a/_maps/modularmaps/lv624/atmospherics.dmm
+++ b/_maps/modularmaps/lv624/atmospherics.dmm
@@ -285,6 +285,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},

--- a/_maps/modularmaps/lv624/auxbotany.dmm
+++ b/_maps/modularmaps/lv624/auxbotany.dmm
@@ -311,6 +311,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/green/whitegreen{
 	dir = 8
 	},

--- a/_maps/modularmaps/lv624/internal_affairs.dmm
+++ b/_maps/modularmaps/lv624/internal_affairs.dmm
@@ -188,6 +188,7 @@
 /area/lv624/lazarus/internal_affairs)
 "qp" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
@@ -208,6 +209,7 @@
 /area/lv624/lazarus/internal_affairs)
 "sS" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
 "tF" = (

--- a/_maps/modularmaps/lv624/medbayone.dmm
+++ b/_maps/modularmaps/lv624/medbayone.dmm
@@ -452,6 +452,7 @@
 /area/lv624/lazarus/medbay)
 "MQ" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 2
 	},
@@ -469,6 +470,7 @@
 /area/lv624/lazarus/medbay)
 "NL" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 2

--- a/_maps/modularmaps/lv624/robotics.dmm
+++ b/_maps/modularmaps/lv624/robotics.dmm
@@ -176,6 +176,7 @@
 /area/lv624/lazarus/robotics)
 "uR" = (
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/ai_node,
 /turf/open/floor/tile/vault{
 	dir = 8

--- a/_maps/modularmaps/lv624/telecomms.dmm
+++ b/_maps/modularmaps/lv624/telecomms.dmm
@@ -163,6 +163,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/brown{
 	dir = 9
 	},

--- a/_maps/modularmaps/oscaroutpost/oscarsouthvar7.dmm
+++ b/_maps/modularmaps/oscaroutpost/oscarsouthvar7.dmm
@@ -394,6 +394,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/oscar_outpost/village/abandonedbase)
 "lx" = (


### PR DESCRIPTION

## About The Pull Request
Adds latejoin survivor spawns on top of all roundstart survivor spawns
## Why It's Good For The Game
Without this survivors spawn on the marine ship, which is a bit immersion breaking.
## Changelog
:cl:
fix: Latejoin survivors now spawn on the ground instead of the ship
/:cl:
