### PR TITLE
Hypersleep fix

### DIFF
--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -346,14 +346,11 @@
 
 //	ghostize(FALSE) //We want to make sure they are not kicked to lobby.
 
-	var/client/C = client
 	var/mob/new_player/NP = new()
-	var/mob/N = C.mob
-	NP.name = C.mob.name
-	C.screen.Cut()
-	C.mob.mind.transfer_to(NP, TRUE)
+	client?.screen?.Cut()
+	NP.key = key
 
-	qdel(N)
+	qdel(src)
 
 /mob/living/carbon/human/despawn()
 	assigned_squad?.remove_from_squad(src)


### PR DESCRIPTION

## About The Pull Request
Fixed an error that caused SSD players put in hypersleep to not be deleted.
## Why It's Good For The Game
Not stuck with ssd players lying around.  
## Changelog
:cl:
fix: Putting SSD players in hypersleep works again
/:cl:
