### PR TITLE
Cut egg laying cooldown from 12 seconds to 2

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1407,7 +1407,7 @@
 	action_icon = 'icons/Xeno/actions/construction.dmi'
 	desc = "Create an egg that will grow a larval hugger after a short delay. Empty eggs can have huggers inserted into them."
 	ability_cost = 200
-	cooldown_duration = 2 SECONDS
+	cooldown_duration = 8 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LAY_EGG,
 	)

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1407,7 +1407,7 @@
 	action_icon = 'icons/Xeno/actions/construction.dmi'
 	desc = "Create an egg that will grow a larval hugger after a short delay. Empty eggs can have huggers inserted into them."
 	ability_cost = 200
-	cooldown_duration = 12 SECONDS
+	cooldown_duration = 2 SECONDS
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_LAY_EGG,
 	)


### PR DESCRIPTION
## About The Pull Request
Cuts egg laying cooldown from 12 seconds to 8.
## Why It's Good For The Game
Eggs are fun and iconic.
## Changelog
:cl:
balance: Xeno egg laying cooldown reduced from 12 seconds to 8 seconds
/:cl:
