### PR TITLE
Lets ghosts/lobbied players see all factions on manifest

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -23,6 +23,7 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 	var/list/heads = list()
 	var/list/xeno = list()
 	var/list/misc = list()
+	var/list/other = list()
 	var/list/isactive = list()
 	var/list/squads = list()
 	var/list/support = list()
@@ -75,8 +76,12 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 			squads[name] = squad_name
 			mar[name] = rank
 			department = 1
-		if(!department && !(name in heads) && (rank in GLOB.jobs_regular_all))
-			misc[name] = rank
+		if(!department && !(name in heads))
+			if(rank in GLOB.jobs_regular_all)
+				misc[name] = rank
+			else
+				if(ooc)
+					other[name] = rank
 	// Adds xenomorphs to the game manifest if it's being polled from the game lobby or ghosts
 	if(ooc)
 		for(var/mob/living/carbon/xenomorph/X in GLOB.xeno_mob_list)
@@ -129,6 +134,11 @@ GLOBAL_DATUM_INIT(datacore, /datum/datacore, new)
 		dat += "<tr><th colspan=3>Miscellaneous</th></tr>"
 		for(var/name in misc)
 			dat += "<tr[even ? " class='alt'" : ""]><td>[misc[name]]</td><td>[name]</td><td>[isactive[name]]</td></tr>"
+			even = !even
+	if(length(other) > 0)
+		dat += "<tr><th colspan=3>Other</th></tr>"
+		for(var/name in other)
+			dat += "<tr[even ? " class='alt'" : ""]><td>[other[name]]</td><td>[name]</td><td>[isactive[name]]</td></tr>"
 			even = !even
 	// beno bois & gorls
 	if(length(xeno) > 0)


### PR DESCRIPTION

## About The Pull Request
Lets ghosts/lobbied players see all factions on manifest
## Why It's Good For The Game
Lets people see how many people are actually active before joining and helps them decide which faction to join.
## Changelog
:cl:
add: Let ghosts and people in the lobby see all factions in the game manifest.
/:cl:
