### PR TITLE
Makes erp panel actions that require grabs not require humans to grab…

### DIFF
--- a/ntf_modular/code/datums/sexcon/sexcon.dm
+++ b/ntf_modular/code/datums/sexcon/sexcon.dm
@@ -526,7 +526,7 @@
 		var/grab_bypass = (action.aggro_grab_instead_same_tile && userino.get_highest_grab_state_on(target) == GRAB_AGGRESSIVE)
 		if(!same_tile && !grab_bypass)
 			return FALSE
-	if(action.require_grab)
+	if(action.require_grab && (!isxeno(target) || !ishuman(user))) //don't ask humans to grab xenos, because they can't
 		var/grabstate = userino.get_highest_grab_state_on(target)
 		if(grabstate == null || grabstate < action.required_grab_state)
 			return FALSE


### PR DESCRIPTION
… xenos
## About The Pull Request
Makes erp panel actions that require grabs not require humans to grab xenos, because they can't
## Why It's Good For The Game
Lets humans do more things to xenos
## Changelog
:cl:
fix: Humans can do erp actions to xenos without grabbing them even what that would normally be required, since humans can't grab xenos.
/:cl:
