### PR TITLE
ERP pronoun fixes

### DIFF
--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/ear_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/ear_sex.dm
@@ -13,7 +13,7 @@
 	return TRUE
 
 /datum/sex_action/ear_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] slides their cock into [target]'s ear!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] cock into [target]'s ear!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/ear_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
@@ -44,7 +44,7 @@
 	target.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/ear_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] pulls their cock out of [target]'s ear."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out of [target]'s ear."))
 
 /datum/sex_action/ear_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/facesitting.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/facesitting.dm
@@ -20,12 +20,12 @@
 
 /datum/sex_action/facesitting/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] sits their butt on [target]'s face!"))
+	user.visible_message(span_warning("[user] sits [user.p_their()] butt on [target]'s face!"))
 
 /datum/sex_action/facesitting/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	var/verbstring = pick(list("rubs", "smushes", "forces"))
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] [verbstring] their butt against [target] face."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] [verbstring] [user.p_their()] butt against [target] face."))
 	target.make_sucking_noise()
 	do_thrust_animate(user, target)
 
@@ -69,7 +69,7 @@
 	return TRUE
 
 /datum/sex_action/facesittingtwo/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] sits their cunt on [target]'s face!"))
+	user.visible_message(span_warning("[user] sits [user.p_their()] cunt on [target]'s face!"))
 
 /datum/sex_action/facesittingtwo/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	var/verbstring = pick(list("rubs", "smushes", "forces"))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/footjob.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/footjob.dm
@@ -17,11 +17,11 @@
 
 /datum/sex_action/footjob/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] puts their feet on [target]'s cock..."))
+	user.visible_message(span_warning("[user] puts [user.p_their()] feet on [target]'s cock..."))
 
 /datum/sex_action/footjob/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] jerks [target]'s cock with their feet..."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] jerks [target]'s cock with [user.p_their()] feet..."))
 	playsound(user, 'ntf_modular/sound/misc/mat/fingering.ogg', 30, TRUE, -2)
 
 	user.sexcon.perform_sex_action(target, 2, 4, TRUE)
@@ -30,7 +30,7 @@
 
 /datum/sex_action/footjob/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] stops jerking [target] off with their feet."))
+	user.visible_message(span_warning("[user] stops jerking [target] off with [user.p_their()] feet."))
 
 /datum/sex_action/footjob/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(target.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/force_thighjob.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/force_thighjob.dm
@@ -15,11 +15,11 @@
 
 /datum/sex_action/force_thighjob/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] moves their thighs between [target]'s cock..."))
+	user.visible_message(span_warning("[user] moves [user.p_their()] thighs around [target]'s cock..."))
 
 /datum/sex_action/force_thighjob/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] jerks [target]'s cock with their thighs..."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] jerks [target]'s cock with [user.p_their()] thighs..."))
 
 	playsound(user, 'ntf_modular/sound/misc/mat/fingering.ogg', 30, TRUE, -2)
 	do_thrust_animate(target, user)
@@ -30,7 +30,7 @@
 
 /datum/sex_action/force_thighjob/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] stops jerking [target] off with their thighs..."))
+	user.visible_message(span_warning("[user] stops jerking [target] off with [user.p_their()] thighs..."))
 
 /datum/sex_action/force_thighjob/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(target.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/frotting.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/frotting.dm
@@ -16,7 +16,7 @@
 
 /datum/sex_action/frotting/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] shoves his cock against [target]'s own!"))
+	user.visible_message(span_warning("[user] shoves [user.p_their()] cock against [target]'s own!"))
 
 /datum/sex_action/frotting/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
@@ -31,4 +31,4 @@
 
 /datum/sex_action/frotting/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] lets go off both their cocks."))
+	user.visible_message(span_warning("[user] lets go of both their cocks."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/nipple_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/nipple_sex.dm
@@ -14,7 +14,7 @@
 	return TRUE
 
 /datum/sex_action/nipple_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] slides their cock into [target]'s nipple!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] cock into [target]'s nipple!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/nipple_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
@@ -37,7 +37,7 @@
 	target.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/nipple_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] pulls their cock out of [target]'s nipple."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out of [target]'s nipple."))
 
 /datum/sex_action/nipple_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/rub_body.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/rub_body.dm
@@ -14,7 +14,7 @@
 
 /datum/sex_action/rub_body/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] places their hands onto [target]..."))
+	user.visible_message(span_warning("[user] places [user.p_their()] hands onto [target]..."))
 
 /datum/sex_action/rub_body/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/scissoring.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/scissoring.dm
@@ -17,7 +17,7 @@
 
 /datum/sex_action/scissoring/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] spreads her legs and aligns her cunt against [target]'s own!"))
+	user.visible_message(span_warning("[user] spreads [user.p_their()] legs and aligns [user.p_their()] cunt against [target]'s own!"))
 
 /datum/sex_action/scissoring/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/tailpegging_anal.dm
@@ -18,12 +18,12 @@
 
 /datum/sex_action/tailpegging_anal/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] slides their tail into [target]'s butt!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] tail into [target]'s butt!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/tailpegging_anal/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [target]'s butt with their tail."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [target]'s butt with [user.p_their()] tail."))
 	playsound(target, 'ntf_modular/sound/misc/mat/segso.ogg', 50, TRUE)
 	do_thrust_animate(user, target)
 
@@ -36,4 +36,4 @@
 
 /datum/sex_action/tailpegging_anal/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls their tail out of [target]'s butt."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] tail out of [target]'s butt."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/tailpegging_vaginal.dm
@@ -17,12 +17,12 @@
 
 /datum/sex_action/tailpegging_vaginal/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] slides their tail into [target]'s cunt!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] tail into [target]'s cunt!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/tailpegging_vaginal/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [target]'s cunt with their tail."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [target]'s cunt with [user.p_their()] tail."))
 	playsound(target, 'ntf_modular/sound/misc/mat/segso.ogg', 50, TRUE)
 	do_thrust_animate(user, target)
 
@@ -34,4 +34,4 @@
 
 /datum/sex_action/tailpegging_vaginal/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls their tail out of [target]'s cunt."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] tail out of [target]'s cunt."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/thighjob.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/thighjob.dm
@@ -13,7 +13,7 @@
 
 /datum/sex_action/thighjob/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] grabs [target]'s thighs and shoves his cock inbetween!"))
+	user.visible_message(span_warning("[user] grabs [target]'s thighs and shoves [user.p_their()] cock inbetween!"))
 
 /datum/sex_action/thighjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
@@ -26,4 +26,4 @@
 
 /datum/sex_action/thighjob/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls his cock out from inbetween [target]'s thighs."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out from inbetween [target]'s thighs."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/titjob.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/titjob.dm
@@ -13,7 +13,7 @@
 
 /datum/sex_action/titjob/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] grabs [target]'s tits and shoves his cock inbetween!"))
+	user.visible_message(span_warning("[user] grabs [target]'s tits and shoves [user.p_their()] cock inbetween!"))
 
 /datum/sex_action/titjob/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
@@ -25,4 +25,4 @@
 
 /datum/sex_action/titjob/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls his cock out from inbetween [target]'s tits."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out from inbetween [target]'s tits."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/deviant/tonguebath.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/deviant/tonguebath.dm
@@ -14,11 +14,11 @@
 
 /datum/sex_action/tonguebath/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] sticks their tongue out, getting close to [target]..."))
+	user.visible_message(span_warning("[user] sticks [user.p_their()] tongue out, getting close to [target]..."))
 
 /datum/sex_action/tonguebath/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] bathes [target]'s body with their tongue..."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] bathes [target]'s body with [user.p_their()] tongue..."))
 	user.make_sucking_noise()
 
 	user.sexcon.perform_sex_action(target, 0.5, 0, TRUE)

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_blowjob.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_blowjob.dm
@@ -16,12 +16,12 @@
 
 /datum/sex_action/force_blowjob/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] forces [target]'s head down to swallow and suck on his cock!"))
+	user.visible_message(span_warning("[user] forces [target]'s head down to swallow and suck on [user.p_their()] cock!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/force_blowjob/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck his cock."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck [user.p_their()] cock."))
 	target.make_sucking_noise()
 	do_thrust_animate(target, user)
 
@@ -43,7 +43,7 @@
 
 /datum/sex_action/force_blowjob/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls his cock out of [target]'s throat."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out of [target]'s throat."))
 
 /datum/sex_action/force_blowjob/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_crotch_nuzzle.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_crotch_nuzzle.dm
@@ -16,18 +16,18 @@
 
 /datum/sex_action/force_crotch_nuzzle/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] forces [target]'s head against their crotch!"))
+	user.visible_message(span_warning("[user] forces [target]'s head against [user.p_their()] crotch!"))
 
 /datum/sex_action/force_crotch_nuzzle/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to nuzzle their crotch."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to nuzzle [user.p_their()] crotch."))
 
 	user.sexcon.perform_sex_action(user, 0.5, 0, TRUE)
 	target.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/force_crotch_nuzzle/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls [target]'s head away from their crotch."))
+	user.visible_message(span_warning("[user] pulls [target]'s head away from [user.p_their()] crotch."))
 
 /datum/sex_action/force_crotch_nuzzle/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_cunnilingus.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_cunnilingus.dm
@@ -18,11 +18,11 @@
 
 /datum/sex_action/force_cunnilingus/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] forces [target]'s head against her cunt!"))
+	user.visible_message(span_warning("[user] forces [target]'s head against [user.p_their()] cunt!"))
 
 /datum/sex_action/force_cunnilingus/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck her cunt."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck [user.p_their()] cunt."))
 	target.make_sucking_noise()
 	do_thrust_animate(target, user)
 

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_ear_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_ear_sex.dm
@@ -17,37 +17,35 @@
 	return TRUE
 
 /datum/sex_action/force_ear_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] forces [target]'s head down to fuck their ear!"))
+	user.visible_message(span_warning("[user] forces [user.p_their()] ear against [target]'s cock!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/force_ear_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [target]'s ear forcibly."))
-	target.make_sucking_noise()
-
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to fuck [user.p_their()] ear."))
+	user.make_sucking_noise()
 	user.sexcon.perform_sex_action(user, 2, 4, TRUE)
-	if(user.sexcon.check_active_ejaculation())
-		user.visible_message(span_love("[user] cums into [target]'s ear!"))
-		user.sexcon.cum_into()
-		if(isxeno(user))
-			var/mob/living/carbon/xenomorph/X = user
-			X.impregify(target, "ear")
+	user.sexcon.handle_passive_ejaculation()
 
-	var/datum/sex_controller/sc = user.sexcon
-
-	if(user.sexcon.considered_limp())
-		user.sexcon.perform_sex_action(target, 1.2, 3, FALSE)
+	if(target.sexcon.considered_limp())
+		target.sexcon.perform_sex_action(target, 1.2, 3, FALSE)
 	else
-		user.sexcon.perform_sex_action(target, 2.4, 7, FALSE)
-		if(sc.force > SEX_FORCE_HIGH)
+		target.sexcon.perform_sex_action(target, 2.4, 7, FALSE)
+		if(user.sexcon.force > SEX_FORCE_HIGH)
 			user.adjust_ear_damage(0.2)
-		if(sc.force > SEX_FORCE_HIGH)
+		if(user.sexcon.force > SEX_FORCE_HIGH)
 			if(prob(15))
-				to_chat(user, span_warning("I feel something squish against my tip..."))
-			target.adjustBrainLoss(0.2)
-	target.sexcon.handle_passive_ejaculation()
+				to_chat(target, span_warning("I feel something squish against my tip..."))
+			user.adjustBrainLoss(0.2)
+			
+	if(target.sexcon.check_active_ejaculation())
+		target.visible_message(span_lovebold("[target] cums into [user]'s ear!"))
+		target.sexcon.cum_into()
+		if(isxeno(target))
+			var/mob/living/carbon/xenomorph/X = target
+			X.impregify(user, "ear")
 
 /datum/sex_action/force_ear_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] pulls their cock out of [target]'s ear."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] ear away from [target]'s cock."))
 
 /datum/sex_action/force_ear_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_foot_lick.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_foot_lick.dm
@@ -16,13 +16,13 @@
 
 /datum/sex_action/force_foot_lick/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] shoves their feet against [target]'s head!"))
+	user.visible_message(span_warning("[user] shoves [user.p_their()] feet against [target]'s head!"))
 
 /datum/sex_action/force_foot_lick/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to lick his feet."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to lick [user.p_their()] feet."))
 	target.make_sucking_noise()
 
 /datum/sex_action/force_foot_lick/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls their feet away from [target]'s head."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] feet away from [target]'s head."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_footjob.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_footjob.dm
@@ -18,7 +18,7 @@
 
 /datum/sex_action/force_footjob/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] grabs [target]'s feet and clamps them around his cock!"))
+	user.visible_message(span_warning("[user] grabs [target]'s feet and clamps them around [user.p_their()] cock!"))
 
 /datum/sex_action/force_footjob/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))
@@ -30,4 +30,4 @@
 
 /datum/sex_action/force_footjob/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls his cock out from inbetween [target]'s feet."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out from inbetween [target]'s feet."))

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_nipple_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_nipple_sex.dm
@@ -16,11 +16,11 @@
 	return TRUE
 
 /datum/sex_action/force_nipple_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	target.visible_message(span_warning("[user] grabs [target] and shoves their cock into their own nipple!"))
+	target.visible_message(span_warning("[user] grabs [target] and shoves [target.p_their()] cock into [user.p_their()]  own nipple!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/force_nipple_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks their nipple against [target]'s cock forcibly."))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fucks [user.p_their()]  nipple against [target]'s cock forcibly."))
 	target.make_sucking_noise()
 
 	user.sexcon.perform_sex_action(user, 2, 4, TRUE)
@@ -38,7 +38,7 @@
 	target.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/force_nipple_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] pulls [target]'s cock out of their nipple."))
+	user.visible_message(span_warning("[user] pulls [target]'s cock out of [user.p_their()]  nipple."))
 
 /datum/sex_action/force_nipple_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_nuzzle_armpit.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_nuzzle_armpit.dm
@@ -16,11 +16,11 @@
 
 /datum/sex_action/force_armpit_nuzzle/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] forces [target]'s head against their armpit!"))
+	user.visible_message(span_warning("[user] forces [target]'s head against [user.p_their()] armpit!"))
 
 /datum/sex_action/force_armpit_nuzzle/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to nuzzle their armpit."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to nuzzle [user.p_their()]  armpit."))
 	do_thrust_animate(target, user)
 
 	user.sexcon.perform_sex_action(user, 0.5, 0, TRUE)
@@ -28,7 +28,7 @@
 
 /datum/sex_action/force_armpit_nuzzle/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls [target]'s head away from their armpit."))
+	user.visible_message(span_warning("[user] pulls [target]'s head away from [user.p_their()] armpit."))
 
 /datum/sex_action/force_armpit_nuzzle/is_finished(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_rimming.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_rimming.dm
@@ -16,11 +16,11 @@
 
 /datum/sex_action/force_rimming/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] shoves [target]'s head against his butt!"))
+	user.visible_message(span_warning("[user] shoves [target]'s head against [user.p_their()] butt!"))
 
 /datum/sex_action/force_rimming/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to rim his butt."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to rim [user.p_their()] butt."))
 	target.make_sucking_noise()
 	do_thrust_animate(target, user)
 
@@ -32,7 +32,7 @@
 
 /datum/sex_action/force_rimming/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls [target]'s head away from his butt."))
+	user.visible_message(span_warning("[user] pulls [target]'s head away from [user.p_their()] butt."))
 
 /datum/sex_action/force_rimming/is_finished(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_suck_balls.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_suck_balls.dm
@@ -14,11 +14,11 @@
 	return TRUE
 
 /datum/sex_action/force_suck_balls/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] forces [target]'s head down to swallow and suck on their balls!"))
+	user.visible_message(span_warning("[user] forces [target]'s head down to swallow and suck on [user.p_their()] balls!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/force_suck_balls/on_perform(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck their balls."))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck [user.p_their()]  balls."))
 	target.make_sucking_noise()
 
 	user.sexcon.perform_sex_action(user, 2, 4, TRUE)
@@ -37,7 +37,7 @@
 	target.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/force_suck_balls/on_finish(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] pulls their balls out of [target]'s mouth."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] balls out of [target]'s mouth."))
 
 /datum/sex_action/force_suck_balls/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/force/force_suck_nipples.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/force/force_suck_nipples.dm
@@ -16,11 +16,11 @@
 	return TRUE
 
 /datum/sex_action/force_suck_nipples/on_start(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] forces [target]'s head down to suck on their nipples!"))
+	user.visible_message(span_warning("[user] forces [target]'s head down to suck on [user.p_their()] nipples!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/force_suck_nipples/on_perform(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck their nipples."))
+	user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] forces [target] to suck [user.p_their()] nipples."))
 	target.make_sucking_noise()
 
 	user.sexcon.perform_sex_action(user, 2, 4, TRUE)
@@ -34,7 +34,7 @@
 	target.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/force_suck_nipples/on_finish(mob/living/carbon/user, mob/living/carbon/target)
-	user.visible_message(span_warning("[user] pulls their nipples out of [target]'s mouth."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] nipples out of [target]'s mouth."))
 
 /datum/sex_action/force_suck_nipples/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_anus.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_anus.dm
@@ -13,11 +13,11 @@
 
 /datum/sex_action/masturbate_anus/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] starts fingering their butt..."))
+	user.visible_message(span_warning("[user] starts fingering [user.p_their()] butt..."))
 
 /datum/sex_action/masturbate_anus/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fingers their butt..."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fingers [user.p_their()] butt..."))
 	playsound(user, 'ntf_modular/sound/misc/mat/fingering.ogg', 30, TRUE, -2)
 
 	user.sexcon.perform_sex_action(user, 2, 6, TRUE)
@@ -25,7 +25,7 @@
 
 /datum/sex_action/masturbate_anus/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] stops fingering their butt."))
+	user.visible_message(span_warning("[user] stops fingering [user.p_their()] butt."))
 
 /datum/sex_action/masturbate_anus/is_finished(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_breasts.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_breasts.dm
@@ -16,18 +16,18 @@
 
 /datum/sex_action/masturbate_breasts/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] starts rubbing her breasts..."))
+	user.visible_message(span_warning("[user] starts rubbing [user.p_their()] breasts..."))
 
 /datum/sex_action/masturbate_breasts/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fondles her breasts..."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] fondles [user.p_their()] breasts..."))
 
 	user.sexcon.perform_sex_action(user, 1, 4, TRUE)
 	user.sexcon.handle_passive_ejaculation()
 
 /datum/sex_action/masturbate_breasts/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] stops fondling her breasts."))
+	user.visible_message(span_warning("[user] stops fondling [user.p_their()] breasts."))
 
 /datum/sex_action/masturbate_breasts/is_finished(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_penis.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_penis.dm
@@ -19,7 +19,7 @@
 	user.visible_message(span_warning("[user] starts jerking off..."))
 
 /datum/sex_action/masturbate_penis/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	var/chosen_verb = pick(list("jerks his cock", "strokes his cock", "masturbates", "jerks off"))
+	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
 	if(user.sexcon.do_message_signature("[type]"))
 		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] [chosen_verb]..."))
 	playsound(user, 'ntf_modular/sound/misc/mat/fingering.ogg', 30, TRUE, -2)

--- a/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_penis_over.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_penis_over.dm
@@ -17,7 +17,7 @@
 	user.visible_message(span_warning("[user] starts jerking over [target]..."))
 
 /datum/sex_action/masturbate_penis_over/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
-	var/chosen_verb = pick(list("jerks his cock", "strokes his cock", "masturbates", "jerks off"))
+	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
 	if(user.sexcon.do_message_signature("[type]"))
 		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] [chosen_verb] over [target]"))
 	playsound(user, 'ntf_modular/sound/misc/mat/fingering.ogg', 30, TRUE, -2)

--- a/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_vagina.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/masturbate/masturbate_vagina.dm
@@ -15,11 +15,11 @@
 
 /datum/sex_action/masturbate_vagina/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] starts stroking her clit..."))
+	user.visible_message(span_warning("[user] starts stroking [user.p_their()] clit..."))
 
 /datum/sex_action/masturbate_vagina/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)
 	if(user.sexcon.do_message_signature("[type]"))
-		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] strokes her clit..."))
+		user.visible_message(user.sexcon.spanify_force("[user] [user.sexcon.get_generic_force_adjective()] strokes [user.p_their()] clit..."))
 	playsound(user, 'ntf_modular/sound/misc/mat/fingering.ogg', 30, TRUE, -2)
 
 	user.sexcon.perform_sex_action(user, 2, 4, TRUE)

--- a/ntf_modular/code/datums/sexcon/sex_actions/oral/crotch_nuzzle.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/oral/crotch_nuzzle.dm
@@ -14,7 +14,7 @@
 
 /datum/sex_action/crotch_nuzzle/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] moves their head against [target]'s crotch..."))
+	user.visible_message(span_warning("[user] moves [user.p_their()] head against [target]'s crotch..."))
 
 /datum/sex_action/crotch_nuzzle/on_perform(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.do_message_signature("[type]"))

--- a/ntf_modular/code/datums/sexcon/sex_actions/oral/nuzzle_armpit.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/oral/nuzzle_armpit.dm
@@ -14,7 +14,7 @@
 
 /datum/sex_action/armpit_nuzzle/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] moves their head against [target]'s armpit..."))
+	user.visible_message(span_warning("[user] moves [user.p_their()] head against [target]'s armpit..."))
 
 
 /datum/sex_action/armpit_nuzzle/on_perform(mob/living/carbon/human/user, mob/living/carbon/human/target)

--- a/ntf_modular/code/datums/sexcon/sex_actions/sex/anal_ride_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/sex/anal_ride_sex.dm
@@ -20,7 +20,7 @@
 
 /datum/sex_action/anal_ride_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] gets on top of [target] and begins riding them with their butt!"))
+	user.visible_message(span_warning("[user] gets on top of [target] and begins riding them with [user.p_their()] butt!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/anal_ride_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)

--- a/ntf_modular/code/datums/sexcon/sex_actions/sex/anal_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/sex/anal_sex.dm
@@ -15,7 +15,7 @@
 
 /datum/sex_action/anal_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] slides his cock into [target]'s butt!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] cock into [target]'s butt!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/anal_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
@@ -41,7 +41,7 @@
 
 /datum/sex_action/anal_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls his cock out of [target]'s ass."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out of [target]'s ass."))
 
 /datum/sex_action/anal_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/sex/throat_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/sex/throat_sex.dm
@@ -15,7 +15,7 @@
 
 /datum/sex_action/throat_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] slides his cock into [target]'s throat!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] cock into [target]'s throat!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/throat_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
@@ -44,7 +44,7 @@
 
 /datum/sex_action/throat_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls his cock out of [target]'s throat."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out of [target]'s throat."))
 
 /datum/sex_action/throat_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)
 	if(user.sexcon.finished_check())

--- a/ntf_modular/code/datums/sexcon/sex_actions/sex/vaginal_ride_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/sex/vaginal_ride_sex.dm
@@ -20,7 +20,7 @@
 
 /datum/sex_action/vaginal_ride_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] gets on top of [target] and begins riding them with their cunt!"))
+	user.visible_message(span_warning("[user] gets on top of [target] and begins riding them with [user.p_their()] cunt!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/vaginal_ride_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)

--- a/ntf_modular/code/datums/sexcon/sex_actions/sex/vaginal_sex.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/sex/vaginal_sex.dm
@@ -15,7 +15,7 @@
 
 /datum/sex_action/vaginal_sex/on_start(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] slides their cock into [target]'s cunt!"))
+	user.visible_message(span_warning("[user] slides [user.p_their()] cock into [target]'s cunt!"))
 	playsound(target, list('ntf_modular/sound/misc/mat/insert (1).ogg','ntf_modular/sound/misc/mat/insert (2).ogg'), 20, TRUE)
 
 /datum/sex_action/vaginal_sex/on_perform(mob/living/carbon/user, mob/living/carbon/target)
@@ -42,7 +42,7 @@
 
 /datum/sex_action/vaginal_sex/on_finish(mob/living/carbon/user, mob/living/carbon/target)
 	..()
-	user.visible_message(span_warning("[user] pulls their cock out of [target]'s cunt."))
+	user.visible_message(span_warning("[user] pulls [user.p_their()] cock out of [target]'s cunt."))
 
 
 /datum/sex_action/vaginal_sex/is_finished(mob/living/carbon/user, mob/living/carbon/target)


### PR DESCRIPTION

## About The Pull Request
Fixes a bunch of pronouns in erp panel actions and a few typos. Also fixes the force ear action having user and target reversed, which made it redundant with the other ear action and also was not what you'd expect from the name of it.
## Why It's Good For The Game
Makes things looks nicer and more grammatically correct.
## Changelog
:cl:
fix: Fixed wrong pronouns being used in some ERP panel actions
fix: Fixed force ear ERP action having user and target reversed
/:cl:
