### PR TITLE
Adds Survivor-Heavy Extended variant gamemode

### DIFF
--- a/code/datums/gamemodes/extendedsurv.dm
+++ b/code/datums/gamemodes/extendedsurv.dm
@@ -1,0 +1,29 @@
+/datum/game_mode/infestation/extended_plus/extended_surv
+	name = "Extended - Survivor-Heavy"
+	config_tag = "Extended - Survivor-Heavy"
+	valid_job_types = list(
+		/datum/job/terragov/command/commanddoll = 1,
+		/datum/job/terragov/squad/engineer = 1,
+		/datum/job/terragov/squad/corpsman = 1,
+		/datum/job/other/prisoner = 2,
+		/datum/job/xenomorph = 8,
+		/datum/job/xenomorph/queen = 1,
+		/datum/job/clf/medic = 3,
+		/datum/job/som/command/staffofficer = 1,
+		/datum/job/som/squad/medic = 1,
+		/datum/job/som/squad/engineer = 1,
+		/datum/job/other/prisonersom = 2,
+		/datum/job/survivor/assistant = -1,
+		/datum/job/survivor/scientist = -1,
+		/datum/job/survivor/doctor = -1,
+		/datum/job/survivor/liaison = -1,
+		/datum/job/survivor/security = -1,
+		/datum/job/survivor/civilian = -1,
+		/datum/job/survivor/chef = -1,
+		/datum/job/survivor/botanist = -1,
+		/datum/job/survivor/atmos = -1,
+		/datum/job/survivor/chaplain = -1,
+		/datum/job/survivor/miner = -1,
+		/datum/job/survivor/salesman = -1,
+		/datum/job/survivor/marshal = -1
+	)

--- a/config/modes.txt
+++ b/config/modes.txt
@@ -27,6 +27,10 @@ mode Survival
 	requiredplayers 4
 endmode
 
+mode Extended - Survivor-Heavy
+	requiredplayers 0
+endmode
+
 mode Zombie Crash
 	requiredplayers 2
 endmode

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -531,6 +531,7 @@ F// DM Environment file for baystation12.dme.
 #include "code\datums\gamemodes\extended.dm"
 #include "code\datums\gamemodes\extendedmini.dm"
 #include "code\datums\gamemodes\extendedplus.dm"
+#include "code\datums\gamemodes\extendedsurv.dm"
 #include "code\datums\gamemodes\hvh.dm"
 #include "code\datums\gamemodes\infestation.dm"
 #include "code\datums\gamemodes\nuclear_war.dm"


### PR DESCRIPTION

## About The Pull Request
Since there seem to have been some problems with survival recently, I thought this would be a fun and easy-to-code alternative.  Adds a variant of Extended in which survivor slots are unlimited and non-survivor slots are very limited. 
## Why It's Good For The Game
Should help spice things up, give more variety of gamemodes.
## Changelog
:cl:
add: Added Survivor-Heavy Extended gamemode, an extended variant in which survivor slots are unlimited and non-survivor slots are very limited.
/:cl:
