### PR TITLE
Fix incorruptible generators starting corrupted

### DIFF
--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -31,14 +31,20 @@ GLOBAL_VAR_INIT(generators_on_ground, 0)
 /obj/machinery/power/geothermal/Initialize(mapload)
 	. = ..()
 	RegisterSignals(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED), PROC_REF(activate_corruption))
-	update_icon()
 	SSminimaps.add_marker(src, MINIMAP_FLAG_ALL, image('icons/UI_icons/map_blips.dmi', null, "generator", ABOVE_FLOAT_LAYER))
 
 	if(is_ground_level(z))
 		GLOB.generators_on_ground += 1
 
+	if(!is_corruptible)
+		corrupted = FALSE
+
 	if(corrupted)
 		corrupt(corrupted)
+	else
+		update_icon()
+		if(is_on)
+			start_processing()
 
 /obj/machinery/power/geothermal/Destroy() //just in case
 	if(is_ground_level(z))


### PR DESCRIPTION

## About The Pull Request
Fixes incorruptible generators starting corrupted.
## Why It's Good For The Game
If they're incorruptible it doesn't make sense for them to start corrupted.
## Changelog
:cl:
fix: Fixed incorruptible generators starting out corrupted.
/:cl:
