### PR TITLE
Adds lv624small

### DIFF
--- a/_maps/lv624small.json
+++ b/_maps/lv624small.json
@@ -1,0 +1,14 @@
+{
+    "map_name": "LV624Small",
+    "map_path": "map_files/LV624Small",
+    "map_file": "LV624Small.dmm",
+	"disk_sets": {
+		"basic": 1
+	},
+    "armor": "jungle",
+	"quickbuilds": 2000,
+	"announce_text": "A faint distress signal has been picked up by our scanners, which have tracked the source to a third generation colony, known as LV-624. Through use of bluespace drive tech, the ship has jumped within range of the colony. NTC, gear up and get ready to respond!",
+	"traits":[{
+		"weather_acidrain": true
+	}]
+}

--- a/_maps/map_files/LV624/LV624.dmm
+++ b/_maps/map_files/LV624/LV624.dmm
@@ -2054,6 +2054,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 4
 	},
@@ -2701,7 +2702,7 @@
 /turf/closed/wall/r_wall,
 /area/lv624/lazarus/secure_storage)
 "boY" = (
-/obj/effect/landmark/patrol_point/tgmc_12,
+/obj/effect/landmark/patrol_point/tgmc_11,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle5)
 "bpj" = (
@@ -3310,6 +3311,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 4
 	},
@@ -5555,9 +5557,11 @@
 /turf/closed/wall,
 /area/lv624/lazarus/quartstorage)
 "ebN" = (
-/obj/effect/landmark/patrol_point/som/som_24,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/east1)
+/area/lv624/ground/jungle3)
 "ebP" = (
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 1
@@ -5949,7 +5953,7 @@
 "exE" = (
 /obj/structure/flora/jungle/vines,
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/landmark/patrol_point/som/som_12,
+/obj/effect/landmark/patrol_point/som/som_11,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "eyk" = (
@@ -6724,10 +6728,6 @@
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/sandtemple/garbledradio)
-"fof" = (
-/obj/effect/landmark/patrol_point/som/som_22,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/east1)
 "foG" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/tile/dark/brown2/corner{
@@ -6895,10 +6895,6 @@
 	dir = 8
 	},
 /area/lv624/lazarus/fitness)
-"fxE" = (
-/obj/effect/landmark/patrol_point/tgmc_22,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/west1)
 "fxN" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -7584,7 +7580,7 @@
 	},
 /area/lv624/lazarus/sleep_female)
 "ggI" = (
-/obj/effect/landmark/patrol_point/tgmc_14,
+/obj/effect/landmark/patrol_point/tgmc_11,
 /turf/open/floor/plating/ground/dirtgrassborder{
 	dir = 4
 	},
@@ -7906,7 +7902,7 @@
 	ceiling = 6
 	})
 "gAy" = (
-/obj/effect/landmark/patrol_point/som/som_13,
+/obj/effect/landmark/patrol_point/som/som_11,
 /turf/open/ground/grass,
 /area/lv624/ground/jungle3)
 "gAE" = (
@@ -8292,6 +8288,10 @@
 /obj/machinery/door/poddoor/mainship{
 	id = "corporate_blast";
 	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/internal_affairs)
@@ -9025,9 +9025,15 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central2)
 "hGB" = (
-/obj/effect/landmark/patrol_point/tgmc_23,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/west1)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
 "hGO" = (
 /obj/machinery/newscaster{
 	dir = 8
@@ -11008,6 +11014,10 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central3)
 "jDe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/internal_affairs)
 "jDl" = (
@@ -11759,11 +11769,11 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "knS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
-	dir = 4;
-	on = 1
-	},
 /obj/effect/ai_node,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/internal_affairs)
 "koo" = (
@@ -12965,7 +12975,7 @@
 /turf/open/floor/plating/asteroidwarning/down,
 /area/deltastation/commons/dorms/barracks{
 	name = "CLF Bunks";
-	outside = s
+	outside = 0
 	})
 "lBK" = (
 /obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
@@ -14045,7 +14055,7 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/secure_storage)
 "mBS" = (
-/obj/structure/door/mineral_door/wood,
+/obj/structure/mineral_door/wood,
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/deltastation/engineering/lobby{
@@ -14922,7 +14932,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/lv624/lazarus/internal_affairs)
@@ -16097,7 +16107,7 @@
 /area/lv624/lazarus/bar)
 "oMV" = (
 /obj/structure/flora/jungle/vines,
-/obj/effect/landmark/patrol_point/som/som_14,
+/obj/effect/landmark/patrol_point/som/som_11,
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/ground/ruin)
 "oMX" = (
@@ -16653,6 +16663,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/lv624/lazarus/internal_affairs)
 "pvx" = (
@@ -16696,7 +16707,7 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage/dome)
 "pyc" = (
-/obj/structure/door/mineral_door/wood,
+/obj/structure/mineral_door/wood,
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/structure/cable,
@@ -17302,6 +17313,9 @@
 /area/lv624/lazarus/research)
 "qgf" = (
 /obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
@@ -19367,7 +19381,7 @@
 /area/lv624/lazarus/sandtemple/garbledradio)
 "sac" = (
 /obj/effect/ai_node,
-/obj/effect/landmark/patrol_point/tgmc_13,
+/obj/effect/landmark/patrol_point/tgmc_11,
 /turf/open/floor/plating/ground/dirtgrassborder/corner,
 /area/lv624/ground/jungle5)
 "sae" = (
@@ -20216,9 +20230,16 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/lv624/lazarus/quart)
 "sXN" = (
-/obj/effect/landmark/patrol_point/tgmc_21,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/west1)
+/area/lv624/ground/jungle3)
 "sYe" = (
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/dirt,
@@ -20367,15 +20388,6 @@
 /obj/structure/flora/jungle/vines,
 /turf/closed/wall,
 /area/lv624/lazarus/overgrown)
-"tek" = (
-/obj/machinery/door/airlock/mainship/medical/glass/free_access{
-	dir = 1;
-	name = "\improper Leisure Dome"
-	},
-/turf/open/floor/tile/purple/whitepurple{
-	dir = 5
-	},
-/area/lv624/lazarus/fitness)
 "teE" = (
 /turf/open/floor/tile/green/greentaupe{
 	dir = 9
@@ -22926,6 +22938,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 4
 	},
@@ -23826,7 +23839,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle1)
 "wtF" = (
-/obj/effect/landmark/patrol_point/som/som_23,
+/obj/effect/landmark/patrol_point/som/som_21,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/east1)
 "wui" = (
@@ -24313,9 +24326,17 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/hydroponics/aux)
 "wOK" = (
-/obj/effect/landmark/patrol_point/som/som_21,
-/turf/open/floor/plating/ground/dirt,
-/area/lv624/ground/caves/east1)
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
 "wON" = (
 /obj/machinery/light{
 	dir = 8
@@ -24579,7 +24600,7 @@
 /turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
 /area/lv624/lazarus/overgrown)
 "wZr" = (
-/obj/effect/landmark/patrol_point/tgmc_24,
+/obj/effect/landmark/patrol_point/tgmc_21,
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/west1)
 "wZK" = (
@@ -32959,7 +32980,7 @@ gKr
 gKr
 gKr
 gKr
-fxE
+wZr
 abc
 abc
 abc
@@ -33817,7 +33838,7 @@ gKr
 gKr
 gKr
 gKr
-hGB
+wZr
 abc
 abc
 abc
@@ -35249,7 +35270,7 @@ evp
 evp
 evp
 aym
-sXN
+wZr
 abc
 abc
 abc
@@ -39688,10 +39709,10 @@ rAp
 rAp
 cIp
 rDU
-wXm
-caQ
-xFL
-ffO
+hGB
+ebN
+edi
+sXN
 xhU
 xFL
 pyH
@@ -62939,7 +62960,7 @@ vTi
 vTi
 pmS
 mYJ
-jDe
+elZ
 doz
 pmS
 vTi
@@ -63800,7 +63821,7 @@ vyQ
 lQa
 dco
 anp
-fnp
+jDe
 doz
 dco
 vyQ
@@ -64087,7 +64108,7 @@ wdi
 dco
 dco
 vpc
-fnp
+jDe
 dSR
 dco
 dco
@@ -65773,7 +65794,7 @@ reF
 kDA
 kDA
 aJp
-tek
+eVA
 xhp
 ual
 xhp
@@ -66669,7 +66690,7 @@ aES
 aES
 rpf
 pmS
-vTi
+wOK
 nyG
 vTi
 pmS
@@ -84016,7 +84037,7 @@ fbc
 qHx
 sMD
 tYf
-fof
+wtF
 aah
 aah
 aah
@@ -86317,7 +86338,7 @@ mcN
 dUK
 aah
 mcN
-ebN
+wtF
 aah
 aah
 dUK
@@ -86599,7 +86620,7 @@ tYf
 tYf
 tYf
 tYf
-wOK
+wtF
 aah
 aah
 dUK

--- a/_maps/map_files/LV624Small/LV624Small.dmm
+++ b/_maps/map_files/LV624Small/LV624Small.dmm
@@ -1,0 +1,66088 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aae" = (
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/tablefort)
+"aam" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/powercell,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"abd" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 8;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/ground/grass/grass2,
+/area/lv624/lazarus/overgrown)
+"abq" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"abt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"abO" = (
+/obj/structure/cryofeed/right,
+/obj/effect/turf_decal/warning_stripes/linethick{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"abQ" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"abV" = (
+/obj/structure/computerframe,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"abW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"acv" = (
+/obj/structure/barricade/wooden,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"acF" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"acG" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/misc/cigarettes,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"acR" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/kitchen)
+"acY" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/tablefort)
+"aeI" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"afJ" = (
+/mob/living/simple_animal/mouse,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"afW" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"agt" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"ahd" = (
+/turf/open/floor/tile/chapel,
+/area/lv624/lazarus/chapel)
+"ahw" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
+"ahA" = (
+/turf/closed/mineral/smooth/indestructible,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"ahB" = (
+/obj/effect/turf_decal/tracks/human1/wet{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/lazarus/spaceport)
+"ahO" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"aiv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"aiE" = (
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"ajt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"ajE" = (
+/obj/structure/lamarr/destroyed,
+/obj/structure/sign/kiddieplaque{
+	dir = 4
+	},
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"ajP" = (
+/obj/structure/largecrate/supply/medicine/iv,
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"akQ" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"akS" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/under/CM_uniform,
+/obj/item/clothing/suit/armor/det_suit,
+/obj/item/binoculars,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/security)
+"akY" = (
+/obj/structure/fence,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"alw" = (
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/landmark/sensor_tower,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"aly" = (
+/obj/structure/largecrate/supply/generator,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"alL" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/marking/loadingarea{
+	dir = 1
+	},
+/area/lv624/ground/sand2)
+"ama" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/toilet)
+"amk" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/turf/open/floor/podhatch/floor,
+/area/lv624/lazarus/internal_affairs)
+"amB" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/robotics)
+"amT" = (
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"ank" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"ann" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"anu" = (
+/obj/item/clothing/suit/armor/vest,
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"anw" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
+	},
+/area/lv624/lazarus/main_hall)
+"anK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"anN" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"aof" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"aoi" = (
+/obj/structure/stairs/seamless{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"aom" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle4)
+"aox" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport2)
+"aoE" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"aoQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"aoW" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"apo" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"apA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"apI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport)
+"apO" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"aqi" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light/corner{
+	dir = 1
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"aqk" = (
+/obj/structure/stairs/corner_seamless,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"aqr" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/obj/item/stack/sheet/wood,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"aqt" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"aqE" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/sandwiches/grilled_cheese_sandwich,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"arD" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/ground/filtration)
+"arQ" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"asc" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Storage Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"ase" = (
+/obj/effect/spawner/random/misc/soap/regularweighted,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"asf" = (
+/obj/machinery/button/door{
+	id = "clfarmoury";
+	name = "Armory button"
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"asY" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"ata" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/floodlight/colony,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"atv" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"atA" = (
+/obj/structure/closet/coffin/open,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"atC" = (
+/obj/machinery/door/airlock/medical{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"atU" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/secure_storage)
+"atY" = (
+/obj/structure/rack,
+/obj/item/radio/survivor,
+/obj/machinery/light,
+/obj/item/radio/survivor,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"aud" = (
+/obj/structure/punching_bag,
+/obj/effect/turf_decal/box/white,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"auz" = (
+/obj/structure/table,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"auH" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/mime,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"auL" = (
+/obj/structure/cable,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"auO" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"ave" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/compound/c)
+"avs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"avy" = (
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"avC" = (
+/obj/structure/table/mainship,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"avK" = (
+/obj/machinery/hydroponics,
+/obj/structure/sink,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"avP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/obj/machinery/computer/autodoc_console,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"avR" = (
+/obj/structure/bed/alien,
+/obj/effect/landmark/start/job/clf/breeder,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"awe" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"awj" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"awl" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"awu" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"awT" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"awY" = (
+/obj/structure/table,
+/obj/effect/spawner/random/misc/folder/nooffset,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"axD" = (
+/obj/item/clothing/mask/gas,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"aya" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"ayc" = (
+/obj/machinery/door_control{
+	dir = 1;
+	id = "corporate_blast";
+	name = "Dome Lockdown"
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"ayi" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/canteen)
+"ayz" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"ayU" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/machinery/light,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"azz" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/turf/open/floor/tile/red/redtaupe,
+/area/lv624/lazarus/security)
+"azA" = (
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"azJ" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"azY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"aAk" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"aAq" = (
+/obj/structure/platform,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"aAt" = (
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport2)
+"aBd" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"aBo" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"aBq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"aBz" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"aBI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"aBX" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"aCb" = (
+/obj/structure/largecrate,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"aCY" = (
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/ground/sand3)
+"aDb" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"aDx" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"aDN" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/ground/caves/central5/garbledradio)
+"aEe" = (
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"aEf" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/engineering/powercell,
+/obj/effect/spawner/random/misc/folder/nooffset,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"aEw" = (
+/turf/open/ground/coast/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"aFp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"aFI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/mining/brace,
+/obj/item/shard,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/caves/central1/garbledradio)
+"aFT" = (
+/turf/closed/wall,
+/area/lv624/lazarus/canteen)
+"aGH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
+"aGQ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"aGW" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"aHa" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle6)
+"aHg" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"aHt" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"aHx" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"aHB" = (
+/obj/structure/cargo_container/green{
+	dir = 8
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"aHD" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"aHG" = (
+/turf/closed/wall/sulaco,
+/area/lv624/ground/sand5)
+"aHH" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/lazarus/quartstorage/outdoors)
+"aIe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2{
+	dir = 10
+	},
+/area/lv624/lazarus/atmos)
+"aIy" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"aII" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"aJh" = (
+/obj/structure/table/reinforced/flipped,
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"aJN" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"aKp" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"aLb" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle1)
+"aMq" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/ne)
+"aMI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"aNN" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle3)
+"aPm" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/obj/item/clothing/mask/breath,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"aPr" = (
+/obj/structure/showcase/yaut,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"aPw" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"aPA" = (
+/obj/item/weapon/sword/machete,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"aQk" = (
+/obj/effect/decal/remains/human,
+/obj/item/frame/table,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/lazarus/research)
+"aQm" = (
+/obj/structure/foamedmetal,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"aQn" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"aQB" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"aRf" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"aRw" = (
+/obj/structure/bed/stool,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"aRK" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle3)
+"aRN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"aRW" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/canteen)
+"aSs" = (
+/turf/open/floor/tile/whiteyellow{
+	dir = 1
+	},
+/area/lv624/lazarus/main_hall)
+"aSA" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"aSC" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"aSN" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"aSR" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/fourteen,
+/area/lv624/lazarus/sandtemple)
+"aSS" = (
+/obj/structure/bed/chair/wood/normal,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"aTA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"aTD" = (
+/obj/structure/bedsheetbin,
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 6
+	},
+/obj/machinery/light/small,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"aTK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/ammo_magazine/pistol,
+/obj/item/ammo_magazine/pistol,
+/obj/item/ammo_magazine/pistol,
+/obj/item/ammo_magazine/pistol,
+/obj/item/weapon/gun/pistol/rt3,
+/obj/item/weapon/gun/pistol/rt3,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"aTM" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "\improper Nexus Dome Chapel"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/chapel)
+"aTU" = (
+/turf/closed/wall/sulaco,
+/area/lv624/lazarus/crashed_ship)
+"aUc" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/machinery/light,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"aUA" = (
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"aUP" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"aUT" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Leisure Dome"
+	},
+/turf/open/floor/elevatorshaft,
+/area/lv624/lazarus/bar)
+"aUU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"aVc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"aVg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/dark/brown2,
+/area/lv624/lazarus/atmos)
+"aVj" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"aVs" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"aVG" = (
+/obj/structure/stairs/seamless,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"aWa" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/start/latejoinclf,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"aXd" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"aXf" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"aXA" = (
+/obj/structure/curtain/shower,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"aXE" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"aXY" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall,
+/area/lv624/ground/jungle5)
+"aYn" = (
+/obj/structure/largecrate/supply,
+/obj/item/clothing/under/rank/engineer,
+/obj/item/clothing/under/rank/engineer,
+/obj/item/clothing/under/rank/security/corp,
+/obj/item/clothing/under/rank/security/corp,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"aYC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"aYO" = (
+/turf/closed/wall,
+/area/lv624/ground/river1)
+"aYU" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6/garbledradio)
+"aYV" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"aYW" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"aYX" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"aZe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"aZK" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"bai" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	name = "Armoury";
+	id = "clfarmoury"
+	},
+/turf/open/floor/plating/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"baJ" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"baR" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"bbJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"bcb" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"bco" = (
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"bcv" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"bdK" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"bdM" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"bep" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/sterile/white,
+/area/mainship/patrol_base/som)
+"beH" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand6)
+"beR" = (
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"bfj" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"bfk" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand5)
+"bfr" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"bfu" = (
+/obj/structure/window_frame/wood,
+/turf/open/floor/wood/broken,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"bgh" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/wall/r_wall/chigusa,
+/area/mainship/patrol_base/som)
+"bgk" = (
+/obj/machinery/chem_master/condimaster,
+/obj/structure/table,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"bgE" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/internal_affairs)
+"bgK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"bhe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"bho" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"bhH" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"bhP" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
+"biI" = (
+/obj/alien/egg/hugger,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"biM" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"bjw" = (
+/obj/structure/table,
+/obj/item/tool/multitool,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"bjB" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"bjI" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"bkq" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"bkK" = (
+/obj/structure/largecrate,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"bkS" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"blb" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/tablefort)
+"blc" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"blA" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"blE" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/stairs/corner_seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"blH" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/floodlight/colony,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"blV" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"bmo" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/chemical/colony,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"bmv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"bmY" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"bmZ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"bne" = (
+/obj/structure/flora/grass/green,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"bnu" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"bnC" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"bnY" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"boc" = (
+/obj/item/spacecash/c100,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"bow" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"boE" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"boN" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"bpk" = (
+/obj/structure/largecrate/random/case/double,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"bpp" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/captain)
+"bpr" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"bpy" = (
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/central5/garbledradio)
+"bpW" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
+"bqw" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/hydroponics)
+"bqy" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"brz" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/main_hall)
+"brR" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"bsa" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	name = "\improper Cargo Shutters";
+	id = "somcargodoor"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor,
+/area/mainship/patrol_base/som)
+"bse" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"bsm" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"bsG" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/med_data/laptop,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"bsJ" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 30
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/donkpocket{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/donkpocket{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/obj/item/reagent_containers/food/snacks/donkpocket,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"bsM" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"bsY" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"bts" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"bui" = (
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"buk" = (
+/obj/structure/table/wood,
+/obj/machinery/atm{
+	pixel_y = 30
+	},
+/obj/item/reagent_containers/food/drinks/flask/vacuumflask,
+/obj/item/storage/box/cups,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"buK" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"buX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille/smoothing,
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"buZ" = (
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"bvK" = (
+/obj/docking_port/stationary/marine_dropship/lz1,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"bwf" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"bwg" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/canteen)
+"bwx" = (
+/obj/structure/table/wood,
+/obj/item/clothing/head/boonie,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle{
+	pixel_x = -10
+	},
+/obj/item/binoculars,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"bwC" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"bwL" = (
+/turf/closed/wall,
+/area/lv624/lazarus/quart)
+"bwR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"bwX" = (
+/obj/structure/cargo_container/gorg{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"bxg" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille/smoothing,
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/river3)
+"byh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/corporate_affairs)
+"byM" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"byT" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"byZ" = (
+/obj/item/tool/analyzer,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"bza" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"bzy" = (
+/obj/structure/foamedmetal,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"bzD" = (
+/turf/closed/wall,
+/area/lv624/lazarus/hydroponics)
+"bzN" = (
+/turf/open/floor/mainship/silver/corner,
+/area/mainship/patrol_base/som)
+"bAh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"bAk" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/extinguisher/regularweighted,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"bAE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"bAG" = (
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/ground/caves/central1/garbledradio)
+"bAO" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"bBm" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"bBp" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"bBy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/quartstorage)
+"bBH" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"bBL" = (
+/obj/structure/rack,
+/obj/item/clothing/under/colonist,
+/obj/item/clothing/under/colonist,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"bCl" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 4
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"bCp" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/misc/table_lighting,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"bCv" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"bCV" = (
+/obj/structure/table,
+/obj/item/mmi/radio_enabled,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"bCZ" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"bDh" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/ground/filtration)
+"bDk" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"bDK" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/caves/rock)
+"bDM" = (
+/obj/item/tool/mop,
+/obj/structure/rack,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"bDN" = (
+/obj/structure/table,
+/obj/item/tool/weldingtool,
+/obj/item/tool/wrench,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"bDR" = (
+/obj/machinery/optable,
+/obj/item/tank/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"bDV" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"bDW" = (
+/obj/structure/table,
+/obj/item/clothing/suit/storage/apron/overalls,
+/obj/item/clothing/under/colonist,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"bEf" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"bEx" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor,
+/area/lv624/ground/caves/central3/garbledradio)
+"bEH" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"bFq" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle9)
+"bGm" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/clothing/suit/storage/apron,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"bHm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"bHG" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"bHU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"bIf" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop2/lz2)
+"bIp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"bIP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"bJb" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"bJP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"bJW" = (
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"bKn" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
+	},
+/area/lv624/lazarus/main_hall)
+"bKt" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"bKu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/robotics)
+"bKE" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/caves/central3/garbledradio)
+"bKI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"bKX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"bLd" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"bLv" = (
+/obj/effect/landmark/patrol_point/tgmc_11,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"bLX" = (
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"bMg" = (
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
+	dir = 1;
+	name = "\improper Research Dome"
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"bMi" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/n)
+"bMq" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"bMz" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor/tile/neutral,
+/area/lv624/lazarus/spaceport)
+"bNm" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"bNn" = (
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport)
+"bNO" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6/garbledradio)
+"bNU" = (
+/turf/closed/wall/brick,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"bOc" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"bOu" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"bOC" = (
+/obj/machinery/light/small,
+/obj/structure/table,
+/obj/machinery/recharger,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"bOP" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle2)
+"bOR" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"bPi" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"bPn" = (
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"bPD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"bPT" = (
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"bPX" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"bPY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"bQh" = (
+/obj/structure/rack,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"bQn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"bQA" = (
+/obj/machinery/power/smes/buildable/empty{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/engineering)
+"bQI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"bQO" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
+	},
+/area/lv624/lazarus/main_hall)
+"bQQ" = (
+/obj/item/stack/sheet/wood,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"bRh" = (
+/obj/machinery/door/airlock/mainship/generic{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	name = "Strange Temple"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"bRT" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"bRY" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"bSg" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"bSk" = (
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"bSz" = (
+/obj/machinery/colony_floodlight_switch{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"bTE" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 5
+	},
+/area/lv624/lazarus/fitness)
+"bTQ" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"bTR" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"bUe" = (
+/obj/structure/foamedmetal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"bUj" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"bVf" = (
+/obj/structure/cryofeed/right,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"bVp" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/lv624/lazarus/atmos)
+"bVT" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 10
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"bWd" = (
+/obj/machinery/conveyor/inverted{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"bWw" = (
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
+	name = "\improper Research Dome"
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"bWE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"bWZ" = (
+/obj/item/clothing/mask/facehugger/dead,
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"bXa" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle1)
+"bXm" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"bXq" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"bXr" = (
+/obj/structure/flora/grass/green,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"bYl" = (
+/turf/closed/mineral/smooth,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"bYm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"bYy" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"bYU" = (
+/obj/structure/noticeboard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
+"bYX" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Atmospherics Condenser"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"bZb" = (
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"bZi" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"bZD" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/platform,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple)
+"cau" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"caB" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"caG" = (
+/obj/structure/table,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"caW" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/ground/jungle9)
+"cbc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"cbN" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"cbW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"ccm" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"ccu" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"ccU" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 1
+	},
+/area/lv624/ground/sand2)
+"cdf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/corporate_affairs)
+"cdJ" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"cdU" = (
+/obj/structure/girder,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"ceo" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"ceB" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"ceL" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"cfF" = (
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"cfY" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"cga" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"cgl" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
+"cgn" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"cgr" = (
+/obj/item/clothing/glasses/regular,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"cgt" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"chU" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"cim" = (
+/obj/effect/ai_node,
+/obj/machinery/landinglight/lz1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"cis" = (
+/obj/structure/largecrate/supply/supplies/coifs,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"cix" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
+"ciz" = (
+/obj/structure/flora/pottedplant/thirteen,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"ciT" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"cjl" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"cjv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"cjD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"cjW" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"ckJ" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"clh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"cll" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"clw" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"clP" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"clS" = (
+/obj/structure/bed/stool,
+/obj/item/storage/backpack,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"cmp" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"cmL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/patrol_base/som{
+	ceiling = 6
+	})
+"cnc" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
+"coi" = (
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"coj" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple)
+"cox" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"coA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"coK" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"cpd" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"cpe" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"cpO" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"cqA" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"cqT" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/structure/sign/safety/hazard,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/quartstorage/outdoors)
+"crc" = (
+/obj/structure/rack,
+/obj/item/stack/cable_coil,
+/obj/item/weapon/combat_knife,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"crq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"csp" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"css" = (
+/obj/structure/cargo_container/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"csu" = (
+/turf/open/floor/tile/red/redtaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/security)
+"csx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/atmos)
+"csH" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"csO" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window,
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"csQ" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor/wood/broken,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"ctl" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/captain)
+"ctE" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"ctH" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"ctO" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/lazarus/spaceport2)
+"ctR" = (
+/obj/structure/closet/open,
+/obj/item/flashlight,
+/obj/item/clothing/under/colonist,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"ctS" = (
+/obj/effect/spawner/random/medical/heal_pack/bruteweighted,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"ctX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/closed/wall/r_wall/chigusa,
+/area/mainship/patrol_base/som)
+"cua" = (
+/obj/structure/cargo_container/nt{
+	dir = 1
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"cuo" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"cuE" = (
+/obj/structure/bed/chair/sofa,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"cuV" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"cvl" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"cvo" = (
+/obj/machinery/hydroponics,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"cwp" = (
+/obj/item/clothing/shoes/jackboots,
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"cwF" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 6
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"cwJ" = (
+/obj/item/clothing/head/warning_cone,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"cwM" = (
+/obj/effect/spawner/random/engineering/shovel,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"cwW" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"cxn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"cyd" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"cye" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"cyj" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"cyq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"czg" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"czV" = (
+/obj/machinery/computer/atmos_alert,
+/obj/structure/table,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"cAg" = (
+/obj/structure/table/wood,
+/obj/item/megaphone,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"cBr" = (
+/obj/effect/spawner/random/misc/trash,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"cCd" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"cCk" = (
+/obj/structure/closet,
+/obj/item/weapon/baseballbat,
+/obj/item/clothing/head/beret/jan,
+/obj/item/stack/medical/splint,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"cDe" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"cDZ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand9)
+"cEb" = (
+/obj/structure/bed,
+/obj/item/bedsheet/mime,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"cEr" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"cEs" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/kitchen)
+"cED" = (
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/item/trash/cheesie,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"cEN" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"cFc" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/sleep_female)
+"cFg" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"cFG" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"cFI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/trash/cheesie,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"cFT" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 10
+	},
+/area/lv624/lazarus/security)
+"cFU" = (
+/obj/effect/landmark/sensor_tower,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"cGk" = (
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	dir = 1;
+	name = "\improper Research Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"cGC" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"cGE" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"cGM" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"cGR" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/obj/structure/flora/jungle/vines,
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/fourteen,
+/area/lv624/lazarus/sandtemple)
+"cHd" = (
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"cIb" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"cIh" = (
+/obj/structure/window_frame/colony,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating,
+/area/lv624/ground/jungle9)
+"cJs" = (
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/ripley_build_and_repair,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"cJS" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"cKe" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"cKn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"cKp" = (
+/obj/structure/closet/gmcloset,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"cKt" = (
+/obj/effect/decal/remains/xeno{
+	pixel_x = 31
+	},
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"cKz" = (
+/obj/item/weapon/gun/pistol/rt3,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"cKE" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central2)
+"cKU" = (
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/fitness)
+"cKZ" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/crashed_ship)
+"cLh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"cMa" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"cMs" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"cMt" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"cMz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"cME" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"cNc" = (
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/tablefort)
+"cNy" = (
+/obj/structure/table,
+/obj/item/radio/survivor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"cNG" = (
+/obj/structure/closet,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"cNJ" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"cNQ" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"cOq" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Robotics Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/robotics)
+"cOQ" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/lazarus/sandtemple/garbledradio)
+"cPh" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/sign/botany{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"cPx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/security/glass/free_access,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"cPQ" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"cQG" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor,
+/area/lv624/ground/river1)
+"cRA" = (
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 1
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"cSI" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"cSN" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"cSZ" = (
+/obj/item/ammo_casing,
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
+"cTb" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/canteen)
+"cTd" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"cTy" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"cTI" = (
+/obj/structure/stairs/seamless{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"cTL" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"cTP" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"cTR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle5)
+"cTT" = (
+/obj/structure/table/reinforced,
+/obj/item/tool/lighter,
+/obj/item/tool/analyzer,
+/obj/item/tool/multitool,
+/obj/item/assembly/prox_sensor,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"cUn" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"cUA" = (
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal/edge,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"cUZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"cVn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"cVq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"cVC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"cVE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/ne)
+"cVI" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"cVM" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"cVX" = (
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"cWj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"cWy" = (
+/obj/effect/decal/remains/human,
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"cWU" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/largecrate/supply/supplies/water,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"cXc" = (
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"cXk" = (
+/obj/structure/bed/alien,
+/obj/item/bedsheet/blue,
+/obj/effect/landmark/start/job/clf/standard,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 9
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"cXK" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"cXR" = (
+/obj/structure/catwalk,
+/turf/open/ground/grass/beach{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"cXT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"cYs" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"cYD" = (
+/obj/effect/spawner/random/misc/structure/closet/electrical,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"cZb" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/lazarus/spaceport)
+"cZz" = (
+/obj/structure/table,
+/obj/item/stack/rods{
+	amount = 40
+	},
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"cZA" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
+"cZH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"cZS" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 8
+	},
+/obj/structure/closet/wardrobe/medic_white,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/obj/item/tweezers,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"cZT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"daa" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"dad" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"dav" = (
+/obj/item/spacecash/c200{
+	pixel_y = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"dcq" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"dcw" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"dde" = (
+/turf/open/floor/tile/chapel{
+	dir = 1
+	},
+/area/lv624/lazarus/chapel)
+"ddx" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"ddy" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"ddS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"deS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"dfd" = (
+/obj/structure/table/wood,
+/obj/item/tool/candle,
+/obj/item/storage/box/matches,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"dfg" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"dfl" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river,
+/area/lv624/ground/jungle9)
+"dfn" = (
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"dfp" = (
+/obj/structure/hoop{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/tile/white/warningstripe,
+/area/lv624/lazarus/fitness)
+"dfL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"dgh" = (
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
+"dgq" = (
+/obj/structure/prop/mainship/hangar_stencil/two,
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"dgA" = (
+/obj/effect/landmark/start/latejoinclf,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"dgF" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"dhy" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"dhG" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
+"dik" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/turf/open/floor,
+/area/lv624/lazarus/chapel)
+"dil" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"diz" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/storage/box/disks{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"djz" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"djK" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"dkn" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"dkB" = (
+/obj/structure/inflatable/wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"dkO" = (
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport2)
+"dlh" = (
+/obj/machinery/landinglight/lz2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"dlr" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"dlv" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/caves/rock)
+"dlz" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
+"dlV" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"dmo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"dmu" = (
+/obj/machinery/power/geothermal/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"dmA" = (
+/obj/structure/showcase/six,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"dnD" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"dnK" = (
+/obj/structure/cable,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 1
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"dnM" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dom" = (
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/ground/caves/east1/garbledradio)
+"doH" = (
+/obj/item/shard,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"dqk" = (
+/obj/item/bananapeel,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
+"dqw" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"dqN" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"dre" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"drx" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"dsc" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"dsi" = (
+/obj/structure/table,
+/obj/item/storage/box/donkpockets,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"dsm" = (
+/obj/item/frame/table,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dsv" = (
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"dsN" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	id = "science_blast";
+	name = "\improper Science Wing Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/research)
+"dsQ" = (
+/obj/effect/landmark/start/job/som/squadengineer,
+/obj/effect/landmark/start/job/som,
+/turf/open/floor/mainship/purple{
+	dir = 7
+	},
+/area/mainship/patrol_base/som)
+"dsX" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"dtn" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"dts" = (
+/obj/machinery/floodlight/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
+"dtD" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"duI" = (
+/obj/machinery/computer/telecomms/monitor,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"duT" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"dvS" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"dwl" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"dwx" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"dwB" = (
+/obj/effect/decal/remains/xeno{
+	pixel_x = -1;
+	pixel_y = -31
+	},
+/obj/structure/showcase,
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"dxe" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"dxf" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"dxL" = (
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"dym" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/beach/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"dyR" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/n)
+"dyZ" = (
+/obj/machinery/vending/sovietsoda,
+/turf/open/floor/mainship/orange{
+	dir = 10
+	},
+/area/mainship/patrol_base/som)
+"dze" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"dzp" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"dzE" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dzQ" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dAl" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dBx" = (
+/obj/item/stack/sheet/wood,
+/obj/item/shard,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"dBF" = (
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/lv624/lazarus/security)
+"dCE" = (
+/obj/machinery/door/airlock/colony/engineering/nexusstorage/open,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"dCK" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Storage Dome"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quart)
+"dDa" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"dDo" = (
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/east1/garbledradio)
+"dDq" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/computerframe,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"dDv" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"dDF" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/glass,
+/obj/item/toy/deck,
+/obj/item/mecha_parts/part/gygax_head,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"dDM" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dDV" = (
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"dDW" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"dEm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"dEB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/internal_affairs)
+"dEM" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 8
+	},
+/turf/closed/wall/brick,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"dFt" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 50
+	},
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 50
+	},
+/turf/open/floor/plating/catwalk,
+/area/mainship/patrol_base/som)
+"dFU" = (
+/obj/structure/cable,
+/obj/machinery/computer/arcade,
+/turf/open/floor/mainship/orange{
+	dir = 9
+	},
+/area/mainship/patrol_base/som)
+"dGl" = (
+/obj/structure/closet/crate/secure/hydrosec,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"dGo" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"dHe" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Nexus Cargo Storage"
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"dHg" = (
+/obj/structure/bed/chair/wood/normal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"dHv" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/main_hall)
+"dHw" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"dIf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dIl" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"dIs" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"dIy" = (
+/obj/structure/cable,
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"dJj" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"dJE" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"dJI" = (
+/turf/open/floor/marking/warning/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport2)
+"dJZ" = (
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"dKd" = (
+/obj/effect/spawner/random/engineering/shovel,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"dKh" = (
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"dKN" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"dLf" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"dLA" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dLD" = (
+/turf/open/floor/mech_bay_recharge_floor/asteroid,
+/area/lv624/ground/sand2)
+"dMj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"dMl" = (
+/turf/closed/mineral/smooth/indestructible,
+/area/space)
+"dMP" = (
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"dNf" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"dND" = (
+/obj/structure/cable,
+/turf/closed/wall/brick,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"dOj" = (
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/hydroponics/aux)
+"dPb" = (
+/obj/structure/bed/stool,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"dPd" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"dPf" = (
+/turf/closed/wall,
+/area/lv624/ground/compound/sw)
+"dPi" = (
+/obj/item/clothing/head/warning_cone,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"dPk" = (
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"dPl" = (
+/obj/structure/closet/crate/hydroponics/prespawned,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"dPs" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dPB" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle1)
+"dPD" = (
+/obj/structure/fence,
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/ground/sand2)
+"dPE" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 1
+	},
+/area/lv624/lazarus/quartstorage)
+"dPW" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"dQg" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"dQk" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
+"dQz" = (
+/obj/structure/bed/chair/wood/wings,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"dQT" = (
+/obj/structure/table/reinforced/prison,
+/obj/item/book/manual/engineering_construction,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"dRc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"dRG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"dRN" = (
+/obj/machinery/vending/SyndiMed,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"dSg" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"dSk" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"dTw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"dTG" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/lazarus/sandtemple/garbledradio)
+"dUl" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"dUv" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"dUC" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"dVe" = (
+/obj/structure/bed/chair/sofa/corsat,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"dVg" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/caves/east1/garbledradio)
+"dVl" = (
+/obj/structure/largecrate/supply/weapons/standard_smg,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"dVx" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"dVQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"dWR" = (
+/obj/machinery/floodlight/colony,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"dXv" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"dXZ" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"dYe" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"dYl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/computer3/server/rack,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"dYs" = (
+/obj/effect/decal/cleanable/blood/gibs/robot/limb,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"dZp" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"dZs" = (
+/obj/item/lightstick/red,
+/obj/item/lightstick/red,
+/obj/structure/inflatable/popped,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 6
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"dZt" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/platform,
+/turf/closed/gm/dense,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"eaa" = (
+/obj/effect/spawner/modularmap/lv624/medicaldome,
+/turf/open/space/basic,
+/area/space)
+"ean" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"eav" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"eaA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"eaM" = (
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/obj/item/weapon/gun/smg/uzi,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"eaP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/sand9)
+"ebf" = (
+/obj/machinery/iv_drip,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/turf/open/floor/mainship/sterile/side{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"ebN" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"eco" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"edc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"edl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/forensic_scanning,
+/turf/open/floor/tile/red/redtaupe,
+/area/lv624/lazarus/security)
+"edv" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"eeF" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"eeQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"eeR" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"efu" = (
+/obj/effect/decal/cleanable/blood/gibs/robot/limb,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"efS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"egc" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"egd" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"egF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"ehH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"ehT" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"eig" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/c)
+"eij" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
+"eiv" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"eiN" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"eiZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"ejc" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"eje" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"ejn" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/quartstorage/outdoors)
+"ejs" = (
+/obj/item/trash/mre,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"ejt" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"ejE" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river1)
+"ekc" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"eke" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"ekp" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"ekx" = (
+/obj/structure/table/wood,
+/obj/item/megaphone,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"ekB" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/saltshaker,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"elm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"elp" = (
+/obj/item/reagent_containers/food/snacks/worm,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"emE" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow,
+/area/lv624/lazarus/main_hall)
+"emU" = (
+/obj/structure/table/wood,
+/obj/item/weapon/gun/shotgun/double,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"ena" = (
+/obj/item/spacecash/c500{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"ens" = (
+/obj/structure/cable,
+/obj/structure/cargo_container{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"enC" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle4)
+"enO" = (
+/turf/open/floor/mainship/silver/corner{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"enP" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/misc/earmuffs,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/security)
+"enZ" = (
+/obj/structure/largecrate/random/barrel/blue,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"eoa" = (
+/obj/structure/barricade/plasteel,
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"eow" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
+"eoG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"eoR" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"epk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"eps" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"epG" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"epN" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"eqv" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/obj/structure/cable,
+/obj/machinery/power/apc,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"eqK" = (
+/obj/structure/platform,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple)
+"eqL" = (
+/obj/structure/largecrate/supply/supplies/water,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"erc" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"erm" = (
+/obj/item/reagent_containers/food/drinks/flask/barflask,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"ern" = (
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"erE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"esE" = (
+/obj/item/tool/surgery/surgicaldrill,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"esN" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"esV" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"eta" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"etc" = (
+/obj/machinery/door_control{
+	dir = 8;
+	id = "secure_blast";
+	name = "Vault Access";
+	pixel_x = 25
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"etp" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"ets" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 8
+	},
+/area/lv624/ground/sand5)
+"etD" = (
+/obj/effect/turf_decal/tracks/wheels/bloody,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"euc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"euh" = (
+/obj/structure/cargo_container/green{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"eut" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"euw" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"euy" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"euM" = (
+/turf/open/floor/plating/platebotc,
+/area/lv624/ground/caves/central1/garbledradio)
+"evu" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"ewi" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"ewC" = (
+/obj/item/clothing/under/colonist,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ewD" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"ewP" = (
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"exh" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"exU" = (
+/obj/structure/bed/stool,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"exZ" = (
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/chapel)
+"eyj" = (
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"eyl" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
+"eyv" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"eyw" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"eyG" = (
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"eyJ" = (
+/obj/structure/table,
+/obj/item/trash/snack_bowl{
+	pixel_y = 9
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"eyO" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"eze" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank{
+	pixel_y = 23;
+	pixel_x = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"ezO" = (
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"ezW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"eAe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"eAo" = (
+/obj/structure/bed/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"eBm" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"eBn" = (
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"eBx" = (
+/obj/item/shard,
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"eCj" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"eCE" = (
+/obj/structure/table,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"eCN" = (
+/turf/closed/wall,
+/area/lv624/lazarus/overgrown)
+"eCP" = (
+/obj/structure/showcase/six,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"eCS" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
+	},
+/area/lv624/lazarus/main_hall)
+"eDa" = (
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"eDc" = (
+/obj/structure/largecrate/supply/explosives/grenades,
+/obj/machinery/light,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"eDi" = (
+/obj/structure/table,
+/obj/item/weapon/twohanded/fireaxe,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"eES" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"eFr" = (
+/obj/item/spacecash/c100{
+	pixel_x = -12
+	},
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"eFG" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"eFV" = (
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"eGb" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"eGs" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 10
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"eHQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"eHX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/bar)
+"eIb" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"eIB" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle3)
+"eIN" = (
+/obj/machinery/computer/area_atmos/area,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"eIT" = (
+/obj/item/ammo_casing,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"eJD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"eJG" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/misc/folder/nooffset,
+/obj/item/assembly/signaler,
+/obj/item/radio/survivor,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"eJI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"eJS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"eJU" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"eKv" = (
+/obj/item/trash/popcorn,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"eKM" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"eLx" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"eML" = (
+/obj/structure/coatrack,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"eMM" = (
+/obj/item/trash/cigbutt/cigarbutt,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"eNZ" = (
+/obj/structure/catwalk,
+/obj/structure/flora/jungle/vines,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"eOS" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"ePp" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"ePu" = (
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"ePD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"ePY" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"eQf" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"eQo" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"eQp" = (
+/turf/open/floor/mainship/silver{
+	dir = 5
+	},
+/area/mainship/patrol_base/som)
+"eQF" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"eQG" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"eQN" = (
+/obj/item/contraband/poster,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"eRu" = (
+/obj/structure/showcase/yaut,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"eRz" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/engitool,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"eRW" = (
+/obj/machinery/vending/boozeomat,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"eRZ" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"eSE" = (
+/obj/structure/catwalk,
+/obj/structure/flora/jungle/vines,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river1)
+"eSJ" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"eTg" = (
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/latejoinsom,
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"eTj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/chapel{
+	dir = 8
+	},
+/area/lv624/lazarus/chapel)
+"eTl" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"eTL" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"eTN" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"eUt" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"eUy" = (
+/obj/structure/sink,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"eUS" = (
+/turf/closed/wall,
+/area/lv624/lazarus/sleep_female)
+"eVf" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 4
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"eVG" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/ground/jungle5)
+"eWj" = (
+/turf/open/floor/tile/dark,
+/area/lv624/ground/sand6)
+"eWH" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand9)
+"eXe" = (
+/obj/item/storage/firstaid/adv,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"eXf" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"eXo" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"eXS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"eYi" = (
+/turf/closed/wall/brick,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"eYN" = (
+/obj/structure/closet/crate/mortar_ammo/mortar_kit,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"eZd" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"eZg" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"eZC" = (
+/obj/effect/ai_node,
+/obj/item/armor_module/module/fire_proof/som,
+/obj/item/armor_module/module/fire_proof/som,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"eZJ" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
+"eZL" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"eZM" = (
+/obj/structure/cargo_container/horizontal,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"eZN" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"faf" = (
+/obj/structure/closet/secure_closet/atmos_personal,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"faq" = (
+/obj/effect/spawner/random/food_or_drink/drink_alcohol_bottle,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"faC" = (
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"faE" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"fbk" = (
+/obj/structure/cargo_container/horizontal,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"fbv" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"fbR" = (
+/obj/structure/cargo_container/green{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"fbU" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"fbX" = (
+/obj/item/spacecash/c200{
+	pixel_y = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"fcg" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"fcv" = (
+/turf/closed/wall,
+/area/lv624/ground/caves/rock)
+"fcK" = (
+/obj/structure/table/wood,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"fcM" = (
+/obj/machinery/processor,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"fcR" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand7)
+"fcS" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
+"fds" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"fdt" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"fdU" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"fey" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"feI" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"ffv" = (
+/obj/effect/landmark/start/job/xenomorph,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"ffS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"fgd" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"fgl" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"fgq" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"fgs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"fgU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"fhD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"fhU" = (
+/obj/structure/reagent_dispensers/fueltank/barrel,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"fhY" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"fib" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"fil" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/sw)
+"fip" = (
+/obj/structure/hoop,
+/turf/open/floor/tile/white/warningstripe{
+	dir = 1
+	},
+/area/lv624/lazarus/fitness)
+"fiS" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fiV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"fjy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fkg" = (
+/obj/structure/table/wood,
+/obj/item/taperecorder,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"fkB" = (
+/obj/machinery/computer/general_air_control,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"fkG" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"flO" = (
+/obj/structure/rack,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"flT" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"fmb" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fmm" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop2/lz2)
+"fnA" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"fnD" = (
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/central3/garbledradio)
+"fnT" = (
+/obj/structure/closet/lawcloset,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/security)
+"fog" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"foD" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 5
+	},
+/area/mainship/patrol_base/som)
+"foU" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage)
+"foW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"foY" = (
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/main_hall)
+"fpj" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle5)
+"fpk" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/obj/machinery/door/window,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"fpl" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/largecrate/random/barrel,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"fpV" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"fpW" = (
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"fqh" = (
+/obj/effect/landmark/nuke_spawn,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"fqo" = (
+/obj/structure/sign/redcross{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"fqI" = (
+/obj/structure/cargo_container/nt{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"fqM" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/fitness)
+"fqR" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"fqV" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Robotics Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/robotics)
+"fqX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/cult,
+/area/lv624/lazarus/bar)
+"frf" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"frt" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"frz" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"frA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"frO" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quart)
+"fse" = (
+/obj/effect/landmark/patrol_point/tgmc_21,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"fsg" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"ftw" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/medical/firstaid,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"ftz" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"ftF" = (
+/obj/structure/closet/open,
+/obj/item/clothing/under/colonist,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"fuh" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/se)
+"fux" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"fuQ" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"fuR" = (
+/obj/structure/closet/lasertag/blue,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"fvy" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/trash/plate,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fvG" = (
+/turf/open/floor/plating/warning,
+/area/lv624/ground/caves/central1/garbledradio)
+"fvM" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle1)
+"fwc" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7/garbledradio)
+"fwm" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"fwL" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"fwY" = (
+/obj/structure/table/reinforced/flipped,
+/obj/structure/table/reinforced/flipped,
+/obj/item/reagent_containers/food/snacks/sandwiches/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/sandwiches/toastedsandwich,
+/obj/item/reagent_containers/food/snacks/sausage,
+/obj/item/reagent_containers/food/snacks/sausage,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"fxs" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/ground/ruin)
+"fxP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"fxV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"fya" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"fyp" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/platform,
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"fyw" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"fyW" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Storage Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"fzv" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"fzD" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"fAc" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating/catwalk,
+/area/mainship/patrol_base/som)
+"fAi" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"fAz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"fAI" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"fBi" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"fBt" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"fBE" = (
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fBH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"fCj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"fCk" = (
+/obj/structure/glowshroom,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"fCn" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/remains/human,
+/turf/open/floor/tile/dark/brown2,
+/area/lv624/lazarus/atmos)
+"fCN" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"fCZ" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/sleep_female)
+"fDc" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"fDh" = (
+/obj/item/mecha_parts/chassis/gygax,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"fDH" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"fDR" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"fEk" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"fEw" = (
+/obj/machinery/door_control{
+	dir = 4;
+	id = "secure_blast";
+	name = "Vault Access"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"fEU" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"fEV" = (
+/obj/structure/rack,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"fEW" = (
+/obj/structure/rack,
+/obj/item/clothing/head/helmet/gimmick,
+/obj/item/clothing/head/helmet/gimmick,
+/obj/item/clothing/head/helmet/gimmick,
+/obj/item/clothing/head/helmet/marine,
+/obj/item/clothing/head/helmet/marine,
+/obj/item/clothing/head/helmet/marine,
+/obj/item/clothing/head/helmet/marine,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/facepaint/green,
+/obj/item/facepaint/brown,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"fFe" = (
+/obj/structure/cargo_container/nt{
+	dir = 8
+	},
+/obj/structure/cargo_container/nt{
+	dir = 8
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"fFm" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 6
+	},
+/area/lv624/lazarus/fitness)
+"fFn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"fFp" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"fFv" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"fFC" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"fGe" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"fGQ" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window,
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"fHG" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"fHN" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"fIl" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/sand7)
+"fIn" = (
+/obj/item/reagent_containers/food/snacks/worm,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"fIz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"fJl" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"fJU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"fKa" = (
+/obj/item/tank/nitrogen{
+	pixel_x = 5
+	},
+/obj/item/tank/nitrogen,
+/obj/structure/rack,
+/obj/effect/turf_decal/sandytile,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"fKV" = (
+/obj/effect/decal/cleanable/blood,
+/turf/closed/wall,
+/area/lv624/lazarus/research)
+"fMb" = (
+/turf/open/floor/mainship/orange,
+/area/mainship/patrol_base/som)
+"fMe" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"fMf" = (
+/obj/effect/spawner/random/misc/structure/closet/tool,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"fMo" = (
+/obj/structure/closet/gmcloset,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"fMP" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 2
+	},
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"fMQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"fMZ" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"fNo" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/computer/sleep_console,
+/turf/open/floor/mainship/sterile/white,
+/area/mainship/patrol_base/som)
+"fNu" = (
+/obj/structure/table,
+/obj/item/clothing/suit/storage/apron,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"fNz" = (
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"fNB" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"fNL" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"fNQ" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Atmospherics Condenser"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"fNR" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"fNS" = (
+/obj/effect/landmark/weed_node,
+/obj/item/ammo_casing,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"fNT" = (
+/obj/effect/landmark/start/job/clf/specialist,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"fOd" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"fOu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/ground/filtration)
+"fOJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"fOQ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"fOV" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/stairs/corner_seamless,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"fPW" = (
+/obj/structure/flora/ausbushes,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"fRs" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"fSg" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"fSh" = (
+/obj/structure/rack,
+/obj/effect/landmark/itemspawner/butler,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"fSn" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_x = -28
+	},
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"fTz" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/caves/central3)
+"fTD" = (
+/obj/item/flashlight,
+/obj/item/ammo_magazine/smg/m25,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"fTO" = (
+/obj/effect/decal/remains/xeno,
+/obj/structure/stairs/seamless{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"fTR" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/misc/table_lighting,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 8
+	},
+/area/lv624/lazarus/security)
+"fUm" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"fUy" = (
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/river3)
+"fVU" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"fVY" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"fWa" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fWj" = (
+/obj/effect/spawner/random/decal/blood,
+/obj/structure/bed/roller,
+/obj/effect/turf_decal/tile/transparent/dark_green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"fWB" = (
+/turf/closed/wall/brick,
+/area/lv624/ground/caves/central1)
+"fXP" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"fXT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"fYn" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"fYr" = (
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "\improper Water Filtration Plant"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/ground/filtration)
+"fYI" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fYM" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"fYS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"fZH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"fZP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"gaA" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"gaP" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"gbs" = (
+/obj/structure/sign/botany{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"gbz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"gbD" = (
+/obj/item/weapon/baseballbat/metal,
+/obj/item/weapon/baseballbat/metal{
+	pixel_x = 5
+	},
+/obj/structure/rack,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"gbH" = (
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
+"gbT" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"gcU" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"gdo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"gdp" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/internal_affairs)
+"gdJ" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/caves/central3/garbledradio)
+"geh" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"gem" = (
+/obj/effect/spawner/random/engineering/structure/powergenerator/superweighted,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"gfy" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"gfS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"gge" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"ggq" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"ggx" = (
+/obj/structure/computerframe,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"ggQ" = (
+/obj/structure/table,
+/obj/item/ammo_casing,
+/obj/item/attachable/suppressor,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"ghe" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5)
+"ghs" = (
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/caves/east1)
+"ghA" = (
+/obj/structure/paper_bin,
+/obj/structure/table/reinforced/prison,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside{
+	dir = 4
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"ghB" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/ne)
+"ghD" = (
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/river2)
+"ghM" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/tablefort)
+"ghP" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"ghT" = (
+/obj/structure/catwalk,
+/obj/effect/landmark/weed_node,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"ghY" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"gil" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"giV" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand6)
+"gjq" = (
+/obj/item/reagent_containers/food/snacks/sliceable/pizzapasta/donkpocket/raw,
+/obj/item/reagent_containers/food/snacks/sliceable/pizzapasta/donkpocket/raw,
+/obj/item/reagent_containers/food/snacks/sliceable/pizzapasta/dank/raw,
+/obj/item/reagent_containers/food/snacks/raw_lizard_sausage,
+/obj/item/reagent_containers/food/snacks/raw_lizard_sausage,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawcutlet,
+/obj/item/reagent_containers/food/snacks/rawmeatball,
+/obj/item/reagent_containers/food/snacks/rawmeatball,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/item/reagent_containers/food/snacks/meat/monkey,
+/obj/structure/closet/secure_closet/freezer,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"gjs" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"gjC" = (
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"gjO" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"gkk" = (
+/obj/structure/flora/jungle/plantbot1,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"gkr" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"gky" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"gld" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"gmb" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/wall,
+/area/lv624/ground/river2)
+"gmc" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"gmi" = (
+/obj/machinery/vending/robotics,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"gmn" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"gmY" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"gnf" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"gnt" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/misc/earmuffs,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"gnT" = (
+/turf/closed/wall,
+/area/lv624/lazarus/internal_affairs)
+"goP" = (
+/obj/structure/table,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"goR" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"gpb" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"gpv" = (
+/obj/structure/cargo_container/nt{
+	dir = 1
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"gqf" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"gqm" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"gqu" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"gqw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
+"gqI" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"grH" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"grK" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"grV" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
+"gsc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"gsi" = (
+/obj/structure/cargo_container{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"gso" = (
+/obj/machinery/sleeper,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"gsp" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
+"gth" = (
+/obj/structure/cable,
+/obj/structure/bookcase,
+/obj/item/book/manual/engineering_singularity_safety,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"gtC" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/melee,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"gtL" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"gtM" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	pixel_y = 6;
+	pixel_x = 10
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"gtO" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 1
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"gtP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"gtW" = (
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/structure/cable,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"guf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"guK" = (
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/kitchen,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"guS" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"gvf" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"gvC" = (
+/obj/structure/bookcase,
+/obj/item/book/manual/engineering_construction,
+/obj/item/book/manual/engineering_guide,
+/obj/item/book/manual/engineering_hacking,
+/obj/item/book/manual/atmospipes,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"gvN" = (
+/obj/effect/turf_decal/siding/wideplating_new/light,
+/obj/machinery/washing_machine,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"gvO" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"gwd" = (
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/lv624/lazarus/security)
+"gxa" = (
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"gxg" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"gxi" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"gxq" = (
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 6
+	},
+/area/lv624/lazarus/main_hall)
+"gxZ" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"gyc" = (
+/obj/machinery/hydroponics,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"gzD" = (
+/turf/open/floor/scorched/two,
+/area/lv624/ground/sand2)
+"gzQ" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/caves/central3)
+"gzS" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"gAc" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/platform{
+	dir = 10
+	},
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"gAq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"gAv" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"gAW" = (
+/obj/structure/table/wood,
+/obj/machinery/light/small,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"gBq" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/sand9)
+"gCP" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"gDe" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
+/obj/item/clothing/glasses/sunglasses/big{
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"gDr" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"gDs" = (
+/obj/machinery/door_control{
+	id = "science_blast";
+	name = "Science Wing Lockdown";
+	pixel_x = -25
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"gDC" = (
+/obj/structure/table/mainship,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"gDG" = (
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"gDH" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"gDZ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"gEr" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle6)
+"gEM" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"gFz" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"gFI" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"gGa" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"gGn" = (
+/turf/closed/wall/brick,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"gGQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"gGT" = (
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"gHI" = (
+/obj/structure/inflatable/wall,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"gHS" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"gIc" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"gIC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"gIL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"gIN" = (
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/lv624/lazarus/bar)
+"gIT" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/shuttle/drop1/lz1)
+"gJz" = (
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"gJG" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"gJS" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river1)
+"gJU" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome Male Dormitories"
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"gKc" = (
+/turf/open/ground/grass,
+/area/lv624/lazarus/research)
+"gKw" = (
+/turf/closed/wall,
+/area/lv624/lazarus/toilet)
+"gKz" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/captain)
+"gKD" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"gLa" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"gLU" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"gNC" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"gNK" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"gNP" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"gOc" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle2)
+"gOq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"gOs" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome Freezer"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/lazarus/kitchen)
+"gOt" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/sand5)
+"gOA" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/jungle2)
+"gOE" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river1)
+"gOQ" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"gPh" = (
+/obj/structure/bed/roller,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"gPi" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/tomato,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"gPm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/mainship/orange{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"gPt" = (
+/obj/structure/cable,
+/obj/machinery/power/geothermal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"gPy" = (
+/obj/effect/spawner/random/misc/structure/random_piano,
+/turf/open/floor/carpet/side{
+	dir = 9
+	},
+/area/lv624/lazarus/bar)
+"gPI" = (
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/caves/east1/garbledradio)
+"gPO" = (
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
+"gPQ" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"gQb" = (
+/turf/open/floor/tile/dark/brown2,
+/area/lv624/lazarus/atmos)
+"gQn" = (
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
+"gQx" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/smooth,
+/area/lv624/ground/caves/rock)
+"gQz" = (
+/turf/closed/wall,
+/area/lv624/lazarus/comms)
+"gQD" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"gQG" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"gQS" = (
+/obj/effect/spawner/random/engineering/shovel,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"gRf" = (
+/obj/machinery/power/smes/preset,
+/obj/structure/cable,
+/turf/open/floor/plating/catwalk,
+/area/mainship/patrol_base/som)
+"gRw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"gRS" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"gSc" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"gSu" = (
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"gSH" = (
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/fitness)
+"gTo" = (
+/obj/machinery/light/small,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"gTp" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"gTL" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"gTM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"gTN" = (
+/obj/item/clothing/glasses/regular,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"gUc" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"gUe" = (
+/obj/structure/table,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"gUl" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 8
+	},
+/turf/closed/wall/brick,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"gUy" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atm{
+	pixel_y = 29
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"gVh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"gVl" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"gVI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"gVX" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"gWE" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle4)
+"gWR" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Nexus Dome Canteen"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/canteen)
+"gXL" = (
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"gXY" = (
+/obj/structure/flora/grass/both,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"gYf" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"gYx" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river1)
+"gYZ" = (
+/obj/machinery/gibber,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"gZc" = (
+/obj/structure/table/mainship,
+/obj/item/restraints/handcuffs/cyborg,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"gZe" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"gZx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"gZy" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder2/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle7)
+"hac" = (
+/obj/structure/cable,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"hag" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"hav" = (
+/turf/open/floor/scorched,
+/area/lv624/ground/sand2)
+"haO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"hba" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"hbc" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"hbn" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"hby" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/power/apc/hyper,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"hbz" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"hbA" = (
+/obj/structure/flora/jungle/vines{
+	pixel_y = 1
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"hbF" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/shuttle/dropship/fourteen,
+/area/lv624/lazarus/sandtemple)
+"hbY" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 1
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"hcg" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"hcw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"hcF" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"hcQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/misc/trash,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"hdk" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"hdq" = (
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/som/squadveteran,
+/turf/open/floor/mainship/purple{
+	dir = 9
+	},
+/area/mainship/patrol_base/som)
+"hdG" = (
+/obj/item/clothing/mask/facehugger/dead,
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"hdN" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"heg" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/wood,
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"hex" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"heA" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"heN" = (
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"heS" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"hfd" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"hff" = (
+/obj/item/ammo_casing,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"hfG" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"hfJ" = (
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport)
+"hfN" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"hfU" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"hgp" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"hgP" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"hgQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"hgT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"hgU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2{
+	dir = 6
+	},
+/area/lv624/lazarus/atmos)
+"hhg" = (
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"hhq" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Storage Dome"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/quartstorage)
+"hhz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"hhP" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"hhU" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/tile/whiteyellow{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"hif" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"hja" = (
+/obj/structure/cargo_container/horizontal,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"hje" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"hjO" = (
+/obj/item/weapon/butterfly/switchblade,
+/obj/item/weapon/butterfly/switchblade,
+/obj/item/weapon/butterfly/switchblade,
+/obj/structure/closet/secure_closet/guncabinet,
+/obj/item/weapon/gun/rifle/type71,
+/obj/item/weapon/gun/rifle/type71,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/item/ammo_magazine/rifle/type71,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"hjS" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/tile/dark/brown2/corner,
+/area/lv624/lazarus/atmos)
+"hke" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"hku" = (
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"hkC" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"hlh" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
+"hlj" = (
+/obj/structure/lamarr/destroyed,
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"hlm" = (
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"hlK" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"hlL" = (
+/obj/effect/landmark/patrol_point/som/som_21,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"hlS" = (
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"hmq" = (
+/obj/machinery/newscaster{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/captain)
+"hmr" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"hmN" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Blast Door"
+	},
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/overgrown)
+"hng" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"hnG" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"hnV" = (
+/obj/machinery/gibber,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"hnX" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/dome)
+"hod" = (
+/obj/machinery/vending/engineering,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"hou" = (
+/turf/open/space/basic,
+/area/space)
+"hoP" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"hpd" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/main_hall)
+"hpk" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"hps" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/decal/remains/xeno,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"hpw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle10)
+"hpy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"hpE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/ground/filtration)
+"hpO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"hqa" = (
+/turf/closed/gm/dense,
+/area/lv624/lazarus/spaceport)
+"hqs" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"hqu" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle1)
+"hqG" = (
+/obj/structure/flora/pottedplant/three,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"hqJ" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"hqO" = (
+/obj/structure/table/reinforced,
+/obj/item/restraints/handcuffs,
+/obj/item/storage/firstaid/adv,
+/obj/machinery/light/small,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 1
+	},
+/area/lv624/lazarus/security)
+"hrd" = (
+/obj/item/stack/sheet/wood,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"hrh" = (
+/obj/structure/table/reinforced/flipped,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"hrw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/spawner/random/misc/trash,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"hrH" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle5)
+"hrT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"hsf" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"hsw" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"hsF" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"htz" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"htU" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"huk" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/sw)
+"hvb" = (
+/obj/structure/safe{
+	spawnkey = 0
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"hvF" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes,
+/obj/machinery/landinglight/lz2{
+	dir = 4
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop2/lz2)
+"hvJ" = (
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/sand5)
+"hvZ" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/wall,
+/area/lv624/ground/jungle9)
+"hwc" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/security)
+"hwv" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"hwC" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"hwS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"hwX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"hwY" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"hxa" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"hxd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"hxA" = (
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/robotics)
+"hxE" = (
+/obj/structure/cryofeed,
+/obj/effect/turf_decal/warning_stripes/linethick{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"hxM" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"hxP" = (
+/obj/item/clothing/under/shorts/black{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"hxW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/loadingarea{
+	dir = 4
+	},
+/area/lv624/lazarus/quartstorage)
+"hyh" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/lv624/lazarus/canteen)
+"hyN" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"hyO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"hza" = (
+/obj/effect/landmark/start/job/som/squadleader,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"hzc" = (
+/obj/structure/closet/athletic_mixed,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"hzf" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"hzi" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"hzj" = (
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"hzl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"hzw" = (
+/obj/structure/bed/stool,
+/obj/item/trash/cigbutt/cigarbutt,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"hzS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"hzT" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"hzZ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/structure/glowshroom,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"hAc" = (
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"hAk" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"hAu" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/anticorner/contrasted{
+	dir = 8
+	},
+/turf/closed/wall/brick,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"hAI" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"hAO" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/stairs/corner_seamless{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"hBc" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"hBm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"hBp" = (
+/obj/structure/rack,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"hCu" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/structure/platform_decoration,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"hDY" = (
+/obj/item/stack/sheet/animalhide/xeno{
+	color = "#524e4e";
+	desc = "An old hide from a fearsome creature.";
+	name = "hunter hide"
+	},
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"hEF" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"hEJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"hET" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"hFz" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"hFJ" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"hFT" = (
+/obj/effect/ai_node,
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"hGl" = (
+/obj/structure/computerframe,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"hGm" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"hGO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"hGQ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"hGR" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/plating,
+/area/lv624/lazarus/research)
+"hIC" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/armory)
+"hIK" = (
+/obj/structure/fence,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"hJn" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"hJr" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"hJs" = (
+/obj/machinery/vending,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"hJN" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"hJX" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/glass,
+/obj/effect/spawner/random/engineering/glass,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"hKq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"hKv" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"hKE" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"hKZ" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"hLd" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"hLg" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"hLn" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"hLK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"hMr" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"hMH" = (
+/turf/open/floor/wood/broken,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"hNf" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"hNI" = (
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"hNP" = (
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5/garbledradio)
+"hOe" = (
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central3/garbledradio)
+"hOm" = (
+/obj/effect/decal/remains/xeno{
+	pixel_y = 31
+	},
+/obj/structure/table/mainship,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"hOu" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"hOR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"hPs" = (
+/obj/effect/spawner/random/misc/plushie/nospawnninetyfive,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"hQy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/floodlight/colony,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"hQH" = (
+/obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/spawner/random/misc/plushie,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"hQI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/quartstorage)
+"hQS" = (
+/obj/effect/landmark/sensor_tower,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"hQT" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/grown/banana,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"hRm" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"hRr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"hRC" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"hSe" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"hSi" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"hSn" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"hSD" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"hSH" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/transparent/dark_green/anticorner/contrasted,
+/obj/structure/closet/secure_closet/medical3/colony,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"hTt" = (
+/turf/closed/mineral/smooth,
+/area/lv624/ground/caves/rock)
+"hTw" = (
+/obj/machinery/status_display{
+	pixel_y = -1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/quart)
+"hTz" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"hTA" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"hTG" = (
+/obj/structure/barricade/wooden,
+/obj/effect/ai_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"hTS" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"hTV" = (
+/obj/structure/fence,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 8
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"hTZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"hUb" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"hUv" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "science_blast";
+	name = "\improper Science Wing Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/research)
+"hUE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"hUG" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"hUS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/lazarus/fitness)
+"hUX" = (
+/obj/structure/closet/open,
+/obj/structure/window/reinforced/tinted,
+/obj/item/clothing/under/colonist,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"hVV" = (
+/obj/structure/largecrate/supply,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/beret,
+/obj/item/clothing/head/soft/sec,
+/obj/item/clothing/head/hardhat,
+/obj/item/clothing/head/hardhat,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"hXa" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"hXd" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"hXs" = (
+/obj/machinery/recharger,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"hXR" = (
+/obj/alien/weeds/node/resting,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"hYq" = (
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
+"hYR" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"hZJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/cic_maptable/som_maptable,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"hZY" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"iaE" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"iaO" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "science_blast";
+	name = "\improper Science Wing Blast Door"
+	},
+/obj/machinery/door/airlock/colony/research/dome{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"iaX" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"ibb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"ibE" = (
+/obj/effect/ai_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/west1)
+"ibF" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"icC" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle4)
+"icW" = (
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"ide" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"ieb" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/stairs/corner_seamless,
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"iec" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"iel" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"ieB" = (
+/obj/effect/spawner/random/misc/folder,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"ieD" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"ieM" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"ieT" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"ife" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"ify" = (
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"igi" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"igo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"igA" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"igO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"igU" = (
+/obj/structure/cable,
+/obj/item/storage/box/monkeycubes,
+/obj/item/storage/box/monkeycubes,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"igV" = (
+/obj/structure/rack,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/random/weaponry/explosive/plastiqueexplosive,
+/obj/effect/spawner/random/weaponry/explosive/plastiqueexplosive,
+/obj/effect/spawner/random/weaponry/explosive/plastiqueexplosive,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"ihx" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/sign/botany{
+	dir = 8
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"ihC" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"ihD" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/sleep_male)
+"ihW" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"iih" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"iiz" = (
+/turf/open/floor/marking/warning,
+/area/lv624/lazarus/spaceport2)
+"iiA" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"iiI" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/spawner/random/weaponry/gun/rifles,
+/obj/effect/spawner/random/weaponry/gun/rifles,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"ijw" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"ijB" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"iki" = (
+/obj/effect/landmark/corpsespawner/chef,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"ikj" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport2)
+"iku" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"ikw" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_x = -28
+	},
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"ikx" = (
+/obj/machinery/vending/som/armor_supply,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"ikH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/machinery/air_alarm{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"ikX" = (
+/obj/structure/table/reinforced/flipped,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/tablefort)
+"ily" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/silver/corner{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"imr" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"imz" = (
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"imE" = (
+/obj/structure/cargo_container/green{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"imH" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle10)
+"inb" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"ind" = (
+/obj/machinery/door/window,
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"inm" = (
+/obj/item/shard,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/caves/central1/garbledradio)
+"inn" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"int" = (
+/obj/structure/table,
+/obj/item/tool/hatchet{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"inC" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"ioe" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/ruin)
+"ioJ" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"ipq" = (
+/obj/structure/grille/broken,
+/obj/item/shard,
+/obj/structure/window_frame/colony/reinforced,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/main_hall)
+"ipw" = (
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
+"ipI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"ipY" = (
+/obj/structure/closet/lasertag/red,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"iqc" = (
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"iqq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"iqQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"iqY" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"irb" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"irf" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/tablefort)
+"irj" = (
+/obj/structure/closet/radiation,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"irz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"irD" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"irS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"isb" = (
+/obj/structure/table,
+/obj/item/clothing/suit/storage/chef/classic,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"isN" = (
+/obj/structure/cable,
+/obj/effect/landmark/corpsespawner/scientist,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
+"itf" = (
+/obj/effect/spawner/random/engineering/structure/powergenerator/superweighted,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"itA" = (
+/obj/structure/rack,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"itI" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"iuu" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/bed,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"iuV" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"ivh" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ivi" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Hydroponics Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"ivl" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"ivu" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop1/lz1)
+"iwc" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"iwe" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"iwp" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
+"iwt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"iwG" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"iwO" = (
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"iwP" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"iwU" = (
+/turf/open/ground/grass,
+/area/lv624/ground/compound/sw)
+"ixm" = (
+/obj/effect/spawner/modularmap/lv624/hydrobridge,
+/turf/open/space/basic,
+/area/space)
+"ixn" = (
+/obj/structure/safe{
+	spawnkey = 0
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"ixp" = (
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 1
+	},
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"ixu" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/dark_blue,
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"iya" = (
+/obj/structure/table,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"iyg" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"iyK" = (
+/turf/open/floor/tile/red/redtaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/security)
+"iyM" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"iAn" = (
+/obj/structure/stairs/seamless{
+	dir = 1
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"iAF" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"iBd" = (
+/obj/item/clothing/glasses/regular,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"iBD" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"iBH" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"iCe" = (
+/obj/effect/ai_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/east1/garbledradio)
+"iCw" = (
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"iCG" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"iCL" = (
+/obj/structure/closet/cabinet,
+/obj/item/reagent_containers/food/snacks/syndicake,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"iCQ" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"iCT" = (
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 10
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"iDi" = (
+/obj/structure/largecrate/supply/supplies/mre,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"iDO" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/obj/effect/spawner/random/weaponry/ammo/shotgun,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"iDX" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"iEw" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle7)
+"iEz" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/bomb_supply,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"iEP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"iET" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"iFo" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"iFv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"iFG" = (
+/obj/structure/sign/atmosplaque{
+	dir = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"iFM" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"iFV" = (
+/obj/structure/table/mainship,
+/obj/item/stack/medical/heal_pack/gauze,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"iGf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"iGq" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"iGA" = (
+/obj/structure/flora/pottedplant,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"iGD" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/structure/table/reinforced/prison,
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/snacks/sandwiches/jelliedtoast/cherry{
+	pixel_y = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"iGM" = (
+/obj/structure/table/wood,
+/obj/item/trash/chips,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"iGQ" = (
+/turf/open/ground/grass/beach{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"iHC" = (
+/obj/structure/bed,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"iHJ" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"iIU" = (
+/obj/structure/largecrate/supply/medicine,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"iJQ" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"iKc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central2)
+"iKl" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"iKn" = (
+/obj/structure/sign/science{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"iKv" = (
+/turf/closed/wall,
+/area/lv624/ground/filtration)
+"iKH" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/start/latejoinclf,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"iKJ" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"iLg" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"iLu" = (
+/obj/structure/dispenser/oxygen,
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"iLz" = (
+/obj/structure/flora/pottedplant/twenty,
+/turf/open/floor/mainship/sterile/side{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"iLA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"iLJ" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"iMg" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"iMn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"iMx" = (
+/obj/machinery/light/small,
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"iMD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"iMG" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"iMU" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river1)
+"iNi" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"iNK" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"iNP" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/gm/dense,
+/area/lv624/ground/river3)
+"iNZ" = (
+/turf/open/liquid/water/river,
+/area/lv624/lazarus/fitness)
+"iOa" = (
+/obj/structure/rack,
+/obj/item/clothing/glasses/regular,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"iOt" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"iOF" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"iPf" = (
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"iPr" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"iPx" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
+"iQm" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"iRi" = (
+/obj/effect/landmark/corpsespawner/prisoner,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"iRC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"iRL" = (
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"iRM" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"iRS" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics)
+"iSn" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"iSw" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"iSB" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/compound/n)
+"iSY" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"iTp" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"iTC" = (
+/turf/open/ground/grass/beach/corner{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"iTX" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"iUl" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"iUp" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river2)
+"iUs" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"iUL" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"iUT" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"iUV" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"iUX" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/mainship/orange{
+	dir = 9
+	},
+/area/mainship/patrol_base/som)
+"iVT" = (
+/obj/item/clothing/suit/redtag,
+/obj/structure/closet/athletic_mixed,
+/obj/machinery/atm{
+	pixel_y = 30
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"iWl" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"iWp" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"iWM" = (
+/obj/machinery/conveyor{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"iWQ" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/security/glass/free_access,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"iWT" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/security)
+"iXc" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"iXS" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"iYi" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"iZm" = (
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"iZo" = (
+/obj/item/bedsheet/rd,
+/obj/item/toy/bikehorn/rubberducky,
+/obj/structure/bed/fancy,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"iZu" = (
+/obj/machinery/vending/engineering,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"iZF" = (
+/mob/living/simple_animal/corgi/puppy/mrwiggles,
+/obj/effect/ai_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"iZW" = (
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"jag" = (
+/obj/structure/device/broken_piano,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"jaw" = (
+/obj/structure/cargo_container/nt{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"jbf" = (
+/turf/open/floor/marking/warning{
+	dir = 5
+	},
+/area/lv624/lazarus/spaceport)
+"jcl" = (
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"jcs" = (
+/turf/open/liquid/water/river,
+/area/lv624/ground/river1)
+"jcu" = (
+/obj/item/reagent_containers/food/snacks/worm,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"jcw" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"jcN" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"jcQ" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"jcT" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/c)
+"jcV" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"jdl" = (
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"jds" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/research)
+"jdt" = (
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"jdu" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"jdR" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"jdZ" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"jfc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/ground/jungle9)
+"jfg" = (
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/tablefort)
+"jfO" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"jgc" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle3)
+"jgs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"jgG" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"jgI" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop2/lz2)
+"jgK" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"jhe" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"jhk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"jhq" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/item/weapon/sword/machete,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"jhB" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"jhI" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"jhU" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"jib" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"jie" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor,
+/area/mainship/patrol_base/som)
+"jih" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"jii" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/sand5)
+"jik" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"jin" = (
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"jip" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"jiq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"jiA" = (
+/obj/structure/flora/pottedplant,
+/obj/machinery/light/spot,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"jiD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"jiS" = (
+/obj/structure/bed,
+/mob/living/simple_animal/corgi/lisa,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"jiV" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"jiZ" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"jjs" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"jjz" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"jjG" = (
+/obj/structure/cargo_container/green{
+	dir = 1
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"jkg" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"jkt" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"jlo" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"jlL" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/structure/glowshroom,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"jlU" = (
+/obj/item/stack/cable_coil,
+/obj/item/clothing/mask/breath,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"jlX" = (
+/turf/open/floor/marking/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/spaceport)
+"jmj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"jml" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"jmN" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/east1/garbledradio)
+"jnp" = (
+/obj/structure/table,
+/obj/item/tool/hatchet{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"jnO" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
+"joe" = (
+/obj/effect/landmark/corpsespawner/security,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"jox" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"joB" = (
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"joJ" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"jpE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"jpS" = (
+/obj/effect/turf_decal/tracks/human1/wet{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 5
+	},
+/area/lv624/ground/jungle5)
+"jpW" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"jqe" = (
+/obj/structure/rack,
+/obj/item/storage/box/m94,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"jqt" = (
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"jqV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"jrc" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"jrk" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"jrz" = (
+/turf/closed/wall,
+/area/lv624/lazarus/atmos)
+"jrI" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"jrN" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"jrX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"jsf" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"jsT" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"jsY" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"jtS" = (
+/obj/structure/table/mainship,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"juF" = (
+/obj/structure/table,
+/obj/docking_port/stationary/crashmode,
+/obj/structure/cable,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"juO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"jvx" = (
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"jvJ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/metal{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/spawner/random/engineering/metal{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"jwz" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"jxq" = (
+/obj/machinery/power/geothermal/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"jxI" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
+"jyv" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/rock)
+"jyA" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/grass,
+/area/lv624/lazarus/internal_affairs)
+"jyC" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"jyK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"jzn" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"jzF" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"jzU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/red/redtaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/security)
+"jzZ" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"jBe" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"jBm" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"jCe" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Atmospherics Condenser"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"jCp" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"jCs" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/fourcorners,
+/obj/structure/cable,
+/obj/structure/sign/safety/medical,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"jCP" = (
+/obj/machinery/hydroponics,
+/obj/structure/sink{
+	dir = 4
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"jCT" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"jDk" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"jDn" = (
+/obj/structure/table,
+/obj/item/clothing/shoes/sandal,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"jDy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/lazarus/quartstorage/outdoors)
+"jDH" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"jEr" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"jEy" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"jEN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"jFe" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"jFU" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"jGO" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"jHh" = (
+/turf/open/ground/grass/beach/corner,
+/area/lv624/ground/jungle9)
+"jHk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"jHs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"jHu" = (
+/obj/structure/sign/safety/hazard,
+/turf/open/floor/marking/warning,
+/area/lv624/lazarus/spaceport)
+"jHz" = (
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"jHV" = (
+/obj/structure/dispenser/oxygen,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"jIz" = (
+/obj/item/tool/crowbar,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"jID" = (
+/obj/item/frame/table,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"jIT" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"jJc" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"jJk" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"jJp" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"jJH" = (
+/obj/structure/sign/safety/hazard,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport2)
+"jKz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"jKK" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"jKM" = (
+/obj/structure/bed/chair/comfy{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"jLr" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Storage Dome"
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/vault,
+/area/lv624/lazarus/quartstorage)
+"jLz" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/rock)
+"jLS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"jME" = (
+/obj/item/clothing/mask/facehugger/dead,
+/obj/machinery/door/poddoor/mainship/open{
+	name = "\improper Forced Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	name = "\improper Research Dome"
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"jML" = (
+/obj/structure/cargo_container/nt{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"jMS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"jNk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"jNA" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/security)
+"jOd" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"jOC" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"jOT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/carpet/side{
+	dir = 5
+	},
+/area/lv624/lazarus/bar)
+"jOU" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"jPo" = (
+/obj/machinery/status_display{
+	pixel_y = 30
+	},
+/obj/item/folder/white,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/internal_affairs)
+"jPE" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river2)
+"jPG" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"jQj" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"jQz" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/ammo/rifle,
+/obj/effect/spawner/random/weaponry/ammo/rifle,
+/obj/effect/spawner/random/weaponry/ammo/rifle,
+/obj/effect/spawner/random/weaponry/ammo/rifle,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"jQY" = (
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"jRc" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"jRs" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/obj/effect/turf_decal/riverdecal/edge,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"jTg" = (
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport2)
+"jTp" = (
+/obj/structure/bed/bunkbed,
+/obj/effect/landmark/start/job/som/staff_officer,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/purple{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"jTy" = (
+/obj/structure/rack,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"jUb" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"jUf" = (
+/turf/open/floor/marking/warning,
+/area/lv624/ground/sand2)
+"jUF" = (
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/beer{
+	pixel_y = 26
+	},
+/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"jUN" = (
+/obj/structure/sign/electricshock,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/engineering)
+"jVj" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"jVp" = (
+/obj/docking_port/stationary/crashmode,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"jVv" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"jWc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"jWk" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"jWZ" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/toilet)
+"jXg" = (
+/obj/structure/bed/alien{
+	color = "#aba9a9"
+	},
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"jXn" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/dmg1,
+/area/lv624/ground/river1)
+"jXr" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"jYc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/captain)
+"jYf" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"jYE" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/cable,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/fitness)
+"jYT" = (
+/obj/machinery/door/airlock/mainship/generic{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	name = "Strange Temple"
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"jYU" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics)
+"jZM" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"kaw" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"kaL" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"kaR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"kbc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"kbA" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"kbQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/item/book/manual/atmospipes,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"kcp" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"kcC" = (
+/obj/structure/closet/coffin/open,
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/chapel{
+	dir = 1
+	},
+/area/lv624/lazarus/chapel)
+"kcY" = (
+/obj/machinery/seed_extractor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"kdk" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"kdS" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle2)
+"keg" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"kei" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"keq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"kev" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
+"keI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"kfB" = (
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"kgd" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/marking/warning/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport)
+"kgw" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"kgS" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"kgX" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"khp" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/river2)
+"khH" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central2)
+"khL" = (
+/turf/closed/gm/dense,
+/area/mainship/patrol_base/som)
+"kib" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage/outdoors)
+"kiw" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"kjh" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"kju" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"kjx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/chair/wood/wings{
+	dir = 8
+	},
+/turf/open/floor/carpet/side{
+	dir = 1
+	},
+/area/lv624/lazarus/bar)
+"kjM" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport2)
+"kjZ" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"kkg" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"kko" = (
+/turf/closed/wall/mainship/research/containment/wall/connect_s1{
+	name = "white wall"
+	},
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"kkq" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"kks" = (
+/obj/effect/ai_node,
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"kkR" = (
+/obj/structure/morgue/sarcophagus,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"klc" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"kld" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport)
+"klw" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/lv624/ground/jungle5)
+"klE" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"kmc" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"kmg" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"kmy" = (
+/obj/structure/table/reinforced,
+/obj/item/flashlight,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"kmK" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"knh" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"knw" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"knx" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"knL" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"knN" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"kpb" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"kpn" = (
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/east1/garbledradio)
+"kpN" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"kpR" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"kqn" = (
+/obj/structure/window/framed/colony,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage)
+"kqo" = (
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/ground/river2)
+"kqu" = (
+/obj/item/shard,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"kqD" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 24
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"kqV" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"krd" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/robotics)
+"kre" = (
+/obj/structure/flora/grass/green,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/sw)
+"krh" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"krm" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"kru" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"ksA" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/patrol_point/som/som_11,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"ksB" = (
+/obj/item/ammo_casing,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"ksY" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle2)
+"kte" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"ktl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"kto" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted/colony,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 9
+	},
+/area/lv624/lazarus/main_hall)
+"ktz" = (
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"ktY" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"kuc" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Hydroponics Dome"
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"kux" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"kuL" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/machinery/door/airlock/hatch{
+	dir = 2
+	},
+/turf/open/floor,
+/area/mainship/patrol_base/som)
+"kuN" = (
+/obj/structure/table,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"kuX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"kvH" = (
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"kvU" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/glass,
+/obj/item/toy/deck,
+/obj/item/mecha_parts/part/gygax_head,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"kwF" = (
+/turf/open/ground/coast/corner{
+	dir = 1
+	},
+/area/lv624/ground/sand8)
+"kwM" = (
+/obj/effect/spawner/modularmap/lv624/southsandtemple,
+/turf/open/space/basic,
+/area/space)
+"kxi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"kxk" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 8
+	},
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"kxm" = (
+/obj/structure/flora/jungle/plantbot1,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"kya" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
+"kyb" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
+"kyi" = (
+/obj/machinery/light,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"kyw" = (
+/obj/machinery/door/airlock/mainship/security/locked/free_access{
+	name = "\improper Nexus Dome Marshal Office"
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/lazarus/security)
+"kzk" = (
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"kzq" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"kzs" = (
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"kzB" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"kzP" = (
+/obj/structure/table,
+/obj/item/clothing/head/chefhat,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/item/tool/kitchen/rollingpin,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"kAi" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport2)
+"kAp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"kAx" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"kAC" = (
+/obj/structure/fence,
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/ground/sand5)
+"kAG" = (
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"kBp" = (
+/obj/structure/table,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
+"kBs" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/ai_node,
+/turf/open/floor/tile/neutral,
+/area/lv624/lazarus/spaceport)
+"kBQ" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"kCi" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"kCC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"kCD" = (
+/obj/structure/table,
+/obj/item/tool/analyzer/plant_analyzer{
+	pixel_x = 2;
+	pixel_y = 1
+	},
+/obj/item/tool/analyzer/plant_analyzer,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"kCG" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"kDJ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand7)
+"kDM" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"kDR" = (
+/obj/structure/cable,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"kEk" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"kEl" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"kEm" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"kEp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"kEx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/mainship/sterile/side{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"kEC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/river2)
+"kED" = (
+/obj/effect/spawner/random/medical/bloodpack,
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline,
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"kFd" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"kFf" = (
+/turf/open/floor/mainship/sterile/side{
+	dir = 6
+	},
+/area/mainship/patrol_base/som)
+"kFy" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"kFz" = (
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/river1)
+"kGb" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/security)
+"kGs" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"kGB" = (
+/obj/effect/landmark/start/job/som/squadstandard,
+/turf/open/floor/mainship/purple{
+	dir = 6
+	},
+/area/mainship/patrol_base/som)
+"kGD" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"kGH" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"kGO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"kGR" = (
+/obj/structure/bed/stool,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"kHa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/bar)
+"kHI" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"kHS" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"kIg" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"kIl" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"kIx" = (
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"kIX" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"kJj" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"kJY" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"kKi" = (
+/obj/item/stack/sheet/wood{
+	amount = 50
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"kKC" = (
+/obj/structure/bed/chair/east{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"kKD" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/siding/wideplating_new/light,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"kKK" = (
+/obj/structure/largecrate/supply/generator,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/asteroid/box,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"kLq" = (
+/obj/item/stack/sheet/wood,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"kLr" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/stairs/seamless{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"kLu" = (
+/obj/structure/window_frame/wood,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"kLZ" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/machinery/random_broken_computer/crewmonitor,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"kMx" = (
+/turf/closed/mineral/smooth,
+/area/space)
+"kMP" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"kNl" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"kNm" = (
+/turf/closed/wall/r_wall,
+/area/lv624/ground/caves/rock)
+"kNB" = (
+/obj/item/stack/sheet/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"kNJ" = (
+/obj/effect/landmark/corpsespawner/scientist{
+	corpseback = null;
+	corpseshoes = /obj/item/clothing/shoes/black;
+	corpseuniform = /obj/item/clothing/under/colonist;
+	name = "Colonist Tevin Marks"
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"kOn" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/ground/jungle9)
+"kOv" = (
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/structure/largecrate/random/barrel/green,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"kPb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"kPF" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/structure/handheld_lighting,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"kPG" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"kPQ" = (
+/obj/structure/barricade/wooden,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"kQj" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"kQv" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"kQw" = (
+/turf/closed/wall,
+/area/lv624/ground/sand8)
+"kQB" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"kQD" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"kQK" = (
+/obj/structure/table/reinforced/prison,
+/obj/item/reagent_containers/food/snacks/sliceable/sandwiches/tofubread,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"kQN" = (
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"kQX" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/riverdecal/edge,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"kRe" = (
+/obj/item/weapon/gun/smg/uzi,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"kRi" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport2)
+"kRn" = (
+/obj/structure/cargo_container/green{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"kRG" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"kTj" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"kTt" = (
+/obj/structure/bed/chair/sofa/corner,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"kTD" = (
+/turf/closed/wall/sulaco,
+/area/lv624/ground/sand6)
+"kTE" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/quartstorage/outdoors)
+"kTH" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/random/misc/table_lighting,
+/obj/structure/table,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"kTT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/ground/grass/beach{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"kUn" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/gm/dense,
+/area/lv624/lazarus/spaceport2)
+"kUp" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"kUG" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"kUT" = (
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"kUV" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/ammo_casing,
+/obj/item/ammo_magazine/smg/m25,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"kUX" = (
+/obj/machinery/floodlight/colony,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"kVB" = (
+/obj/structure/catwalk,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"kVT" = (
+/obj/structure/table,
+/obj/item/trash/cheesie,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"kWa" = (
+/turf/closed/wall,
+/area/lv624/lazarus/hydroponics/aux)
+"kWt" = (
+/obj/structure/flora/grass/green,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"kWG" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"kWQ" = (
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"kXc" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/vending/som/lasgun,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"kXe" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"kXw" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"kXC" = (
+/obj/item/reagent_containers/food/snacks/grown/banana{
+	pixel_x = -8
+	},
+/obj/structure/rack,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"kXM" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/stack/sheet/plasteel/large_stack,
+/obj/item/stack/sheet/metal/large_stack,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/obj/item/storage/box/crate/minisentry,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"kYa" = (
+/obj/structure/closet/secure_closet/bar,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"kYp" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"kYS" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"kYY" = (
+/obj/item/stack/sheet/animalhide/xeno{
+	name = "Lurker Hide"
+	},
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"lad" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"lau" = (
+/obj/structure/girder/displaced,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"lby" = (
+/obj/item/ammo_casing,
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"lch" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport2)
+"lcA" = (
+/obj/structure/curtain/temple{
+	dir = 4
+	},
+/turf/open/floor/prison/redfloor,
+/area/lv624/lazarus/sandtemple)
+"lcF" = (
+/turf/open/floor/plating,
+/area/lv624/ground/sand2)
+"ldb" = (
+/obj/machinery/air_alarm,
+/turf/open/floor/tile/dark/brown2,
+/area/lv624/lazarus/atmos)
+"ldj" = (
+/obj/docking_port/stationary/marine_dropship/lz2,
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
+"ldD" = (
+/obj/effect/decal/remains/human,
+/obj/item/weapon/gun/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"lev" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"leI" = (
+/obj/item/flashlight,
+/obj/item/ammo_magazine/smg/mp7,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"leO" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"leQ" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/river3)
+"lfT" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"lgj" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"lgl" = (
+/obj/effect/ai_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5)
+"lgA" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"lgF" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"lhd" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"lhJ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"lhO" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"lie" = (
+/obj/structure/table/wood/gambling,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"liE" = (
+/obj/item/armor_module/storage/uniform/brown_vest,
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"liL" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"ljY" = (
+/turf/open/ground/grass/beach/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"lka" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"lkm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"lko" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle1)
+"lkp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"lkt" = (
+/turf/open/ground/coast/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"lky" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cryofeed/right,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"lkV" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"lli" = (
+/obj/structure/bed/fancy,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"lll" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"llN" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"llT" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/compound/n)
+"lma" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"lmd" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"lmg" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"lmR" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"lnd" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/chapel{
+	dir = 1
+	},
+/area/lv624/lazarus/chapel)
+"lnj" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"lnB" = (
+/obj/structure/table,
+/obj/structure/mirror/broken{
+	dir = 8
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"lnH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
+"lnI" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/turf/open/floor/mainship/silver/corner,
+/area/mainship/patrol_base/som)
+"lnJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/sign/redcross{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"lok" = (
+/obj/item/trash/cigbutt/cigarbutt,
+/turf/open/floor/carpet/side,
+/area/lv624/lazarus/bar)
+"loN" = (
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"lpa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/internal_affairs)
+"lpg" = (
+/obj/machinery/firealarm,
+/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted/colony,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"lpu" = (
+/obj/structure/cargo_container{
+	dir = 8
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"lpP" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/security)
+"lpX" = (
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/ground/jungle7)
+"lpY" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/closed/mineral/smooth/indestructible,
+/area/lv624/ground/caves/rock)
+"lqp" = (
+/obj/structure/bed/chair/sofa/left,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"lqJ" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"lqL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"lqT" = (
+/obj/effect/landmark/start/job/som/fieldcommander,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"lqV" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"lrf" = (
+/obj/structure/cargo_container{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"lrl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/obj/effect/spawner/random/weaponry/ammo/sidearm,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/security)
+"lrn" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"lrp" = (
+/obj/structure/table,
+/obj/effect/spawner/random/medical/firstaid/alwaysspawns{
+	pixel_x = 4;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/medical/firstaid/alwaysspawns{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/effect/spawner/random/medical/firstaid/alwaysspawns,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"lrq" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"lsi" = (
+/obj/effect/spawner/random/misc/structure/closet/welding,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"lsv" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/engineering)
+"lsO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"ltx" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"lty" = (
+/obj/structure/table,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"ltM" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/obj/structure/rack,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"lud" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"luk" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"luA" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/main_hall)
+"luS" = (
+/obj/structure/inflatable/door,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"lvz" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
+"lvL" = (
+/turf/open/floor/marking/warning/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport)
+"lvV" = (
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"lwd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"lwi" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"lwn" = (
+/turf/closed/wall,
+/area/lv624/lazarus/sleep_male)
+"lwq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"lwB" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
+"lwC" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"lxb" = (
+/obj/machinery/door/airlock/mainship/command/locked/free_access{
+	dir = 1;
+	name = "\improper Nexus Dome Director's Quarter"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"lxv" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"lxE" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"lxG" = (
+/turf/open/ground/coast{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"lxO" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"lxW" = (
+/obj/structure/barricade/wooden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"lyi" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"lyq" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"lys" = (
+/obj/machinery/power/apc/drained{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"lyu" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
+"lyJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/robotics)
+"lzx" = (
+/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"lzz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"lzV" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/river2)
+"lAw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"lAK" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"lBe" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"lBj" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"lBI" = (
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"lCu" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
+	},
+/area/lv624/lazarus/main_hall)
+"lCy" = (
+/obj/effect/landmark/weed_node,
+/turf/closed/wall/brick,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"lCz" = (
+/obj/item/tool/mop,
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 9
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"lCQ" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/ground/sand2)
+"lCX" = (
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"lDn" = (
+/obj/docking_port/stationary/crashmode,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"lDt" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"lEu" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 8
+	},
+/area/lv624/ground/jungle1)
+"lEw" = (
+/turf/closed/wall/brick,
+/area/ice_colony/underground/medical/treatment)
+"lEx" = (
+/obj/item/lightstick/red/anchored,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 5
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"lEM" = (
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"lEN" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"lES" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"lFa" = (
+/turf/open/ground/grass,
+/area/lv624/ground/compound/n)
+"lFn" = (
+/obj/structure/table,
+/obj/item/tool/pen,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"lFT" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"lGh" = (
+/turf/open/ground/grass/beach,
+/area/lv624/ground/jungle9)
+"lGp" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"lHk" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 1
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"lHr" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/clothing/sunglasses,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"lHx" = (
+/obj/item/ammo_casing{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"lHA" = (
+/obj/structure/largecrate/cow,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"lHD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/ground/river1)
+"lHW" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/overgrown)
+"lIx" = (
+/obj/structure/inflatable/popped/door,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 10
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"lJh" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"lJp" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic/prep{
+	dir = 2
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"lJB" = (
+/obj/structure/curtain/shower,
+/obj/structure/cable,
+/obj/machinery/power/apc/hyper,
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"lJD" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"lJN" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"lKq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"lKu" = (
+/obj/machinery/door/airlock/multi_tile/secure{
+	dir = 2
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/ground/jungle5)
+"lKG" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/spaceport)
+"lLd" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"lLe" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/matches,
+/obj/item/tool/candle,
+/turf/open/floor/tile/chapel{
+	dir = 1
+	},
+/area/lv624/lazarus/chapel)
+"lLh" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"lLj" = (
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"lLx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"lLz" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"lLN" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/tablefort)
+"lLU" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"lMn" = (
+/turf/closed/wall,
+/area/lv624/ground/jungle4)
+"lMu" = (
+/turf/open/floor/marking/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/spaceport2)
+"lMy" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6/garbledradio)
+"lMG" = (
+/obj/structure/sign/redcross,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"lMW" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"lOe" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"lOl" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"lOy" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes,
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop2/lz2)
+"lOC" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"lOZ" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"lPi" = (
+/obj/item/stack/sheet/wood{
+	amount = 50
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"lPJ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"lQp" = (
+/obj/machinery/door/airlock/colony/engineering/smes{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"lQG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/tank/oxygen,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"lQS" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"lRT" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"lRU" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"lSi" = (
+/obj/structure/table,
+/obj/item/radio/headset/survivor{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/radio/headset/survivor,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"lSn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"lSs" = (
+/obj/structure/cable,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"lTd" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"lTu" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"lUf" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"lUn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"lUy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"lUL" = (
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"lVj" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/internal_affairs)
+"lVM" = (
+/obj/structure/mopbucket,
+/obj/item/tool/mop,
+/obj/item/tool/mop,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"lVO" = (
+/obj/machinery/floodlight/colony,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"lVU" = (
+/obj/item/tank/oxygen/yellow,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"lWz" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/loadingarea{
+	dir = 4
+	},
+/area/lv624/ground/sand2)
+"lXR" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"lXV" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"lYi" = (
+/obj/structure/cable,
+/obj/structure/catwalk,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"lYr" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"lYH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"lYL" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"lYM" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/turf/open/floor/mainship/silver{
+	dir = 6
+	},
+/area/mainship/patrol_base/som)
+"lYS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"lZy" = (
+/obj/machinery/newscaster,
+/turf/closed/wall,
+/area/lv624/lazarus/quart)
+"lZA" = (
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/ground/sand2)
+"lZO" = (
+/obj/item/attachable/reddot,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"mam" = (
+/obj/machinery/vending/nanomed{
+	dir = 8
+	},
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"maZ" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"mcj" = (
+/obj/structure/window/framed/wood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/bar)
+"mco" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/engineering/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"mcq" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 8
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"mcP" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"mdi" = (
+/obj/structure/bed/stool,
+/obj/structure/cable,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/kitchen)
+"mdn" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"mdp" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"mef" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"mel" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"meU" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"mfu" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"mfT" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"mfZ" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/compound/c)
+"mgz" = (
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"mgF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"mhb" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"mhj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"mho" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/power/apc/drained{
+	crash_break_probability = 100
+	},
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"mhz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/cult,
+/area/lv624/lazarus/bar)
+"mhS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
+"mhX" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/effect/landmark/corpsespawner/russian/ranged,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"mif" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"miv" = (
+/turf/open/floor,
+/area/lv624/lazarus/quartstorage)
+"miP" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 5
+	},
+/area/shuttle/drop1/lz1)
+"miT" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage)
+"mjn" = (
+/turf/closed/gm/dense,
+/area/lv624/lazarus/spaceport2)
+"mjD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"mjJ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"mjK" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/west1)
+"mke" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"mkx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"mkz" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"mkJ" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"mkL" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"mkP" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"mkX" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"mli" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"mlz" = (
+/obj/effect/decal/cleanable/blood/xtracks,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"mlF" = (
+/obj/item/toy/beach_ball,
+/turf/open/liquid/water/river,
+/area/lv624/lazarus/fitness)
+"mmj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"mnb" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"mnp" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle3)
+"mnv" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"mnS" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/lazarus/fitness)
+"mnW" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"mob" = (
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
+"mod" = (
+/obj/structure/table,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/effect/spawner/random/misc/paperbin,
+/obj/item/tool/pen,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"moC" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"moD" = (
+/obj/vehicle/train/cargo/trolley,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"moW" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics/aux)
+"mpn" = (
+/obj/structure/cargo_container/red{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"mps" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"mpu" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"mqh" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
+"mqL" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"mrb" = (
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/ground/sand7)
+"mrw" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"mrA" = (
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0
+	})
+"mrG" = (
+/obj/structure/table/reinforced,
+/obj/item/ashtray/bronze,
+/obj/item/storage/donut_box,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 8
+	},
+/area/lv624/lazarus/security)
+"msf" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"mso" = (
+/obj/machinery/floodlight,
+/obj/item/ammo_casing,
+/obj/effect/landmark/dropship_start_location,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"mst" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"msA" = (
+/obj/item/tool/minihoe,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"msM" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"msX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/ai_node,
+/turf/open/floor/carpet/side,
+/area/lv624/lazarus/bar)
+"mum" = (
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"muo" = (
+/obj/structure/cargo_container/horizontal,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"muW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"mvh" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"mvi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"mvN" = (
+/obj/structure/bed,
+/obj/item/bedsheet/purple,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"mwc" = (
+/obj/structure/bed/stool,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"mwi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2,
+/area/lv624/lazarus/atmos)
+"mwp" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport2)
+"mwt" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"mwW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"mxn" = (
+/obj/structure/table,
+/obj/item/megaphone,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"mxq" = (
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"mxt" = (
+/obj/structure/computerframe,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"mxA" = (
+/obj/structure/table,
+/obj/machinery/chem_dispenser/soda{
+	pixel_y = 22
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"mym" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 6
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"myJ" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"myM" = (
+/obj/structure/closet/coffin,
+/turf/open/floor/tile/chapel{
+	dir = 8
+	},
+/area/lv624/lazarus/chapel)
+"myQ" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 10
+	},
+/area/lv624/lazarus/atmos)
+"mzs" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"mzH" = (
+/obj/structure/largecrate/random/barrel/green,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"mzQ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"mAe" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"mBh" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/cult,
+/area/lv624/lazarus/bar)
+"mBz" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/corpsespawner/PMC,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"mBA" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/chapel,
+/area/lv624/lazarus/chapel)
+"mBC" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"mCd" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/caves/central3/garbledradio)
+"mCt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cryofeed,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"mCB" = (
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"mDe" = (
+/obj/effect/turf_decal/tracks/human1/wet,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"mDt" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"mDu" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 1
+	},
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"mEY" = (
+/obj/structure/table/wood,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"mEZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"mFl" = (
+/obj/machinery/light,
+/obj/item/shard,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"mFE" = (
+/obj/machinery/landinglight/lz1,
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"mFT" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"mGf" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"mGj" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"mGl" = (
+/obj/structure/flora/jungle/vines{
+	pixel_y = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"mHD" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand9)
+"mHL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"mIm" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle3)
+"mIV" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"mJb" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"mJe" = (
+/turf/closed/mineral/smooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"mJj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"mKF" = (
+/obj/structure/flora/jungle/plantbot1,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"mKG" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"mLd" = (
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/ground/sand5)
+"mLn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/item/xeno_iff_tag/som,
+/obj/item/xeno_iff_tag/som,
+/obj/item/xeno_iff_tag/som,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"mMp" = (
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"mMr" = (
+/obj/item/trash/cheesie,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"mMB" = (
+/obj/effect/landmark/sensor_tower,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"mMJ" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"mMX" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/showcase/mulebot{
+	pixel_x = -2
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"mNt" = (
+/obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"mNw" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"mNJ" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"mOn" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"mOz" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop2/lz2)
+"mOA" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"mOH" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"mOU" = (
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/compound/se)
+"mPt" = (
+/turf/closed/wall,
+/area/lv624/lazarus/corporate_affairs)
+"mPD" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"mPI" = (
+/obj/machinery/newscaster,
+/turf/closed/wall,
+/area/lv624/lazarus/internal_affairs)
+"mQi" = (
+/obj/structure/stairs/corner_seamless,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"mQG" = (
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"mQV" = (
+/obj/structure/flora/grass/brown,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"mQX" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "science_blast";
+	name = "\improper Science Wing Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
+	name = "\improper Research Dome"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"mRe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"mRm" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/item/weapon/gun/smg/m25,
+/obj/item/weapon/gun/smg/m25,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"mRv" = (
+/turf/open/ground/grass,
+/area/lv624/lazarus/sleep_female)
+"mRF" = (
+/obj/item/contraband/poster,
+/obj/item/clothing/glasses/regular/hipster,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"mRR" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"mSX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"mTB" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"mTD" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"mTR" = (
+/obj/structure/sign/safety/storage,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"mUP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/corner,
+/area/lv624/lazarus/main_hall)
+"mUZ" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/sleep_female)
+"mVb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/sign/redcross{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"mWC" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"mWU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"mXC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white/warningstripe{
+	dir = 8
+	},
+/area/lv624/lazarus/fitness)
+"mYa" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/caves/rock)
+"mYq" = (
+/obj/structure/fence,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/sw)
+"mYT" = (
+/obj/machinery/vending/phoronresearch,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"mZa" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"mZj" = (
+/obj/structure/table,
+/obj/item/radio/survivor,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"mZk" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"mZp" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"mZq" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"mZw" = (
+/obj/structure/catwalk,
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river1)
+"mZF" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 1
+	},
+/area/shuttle/drop1/lz1)
+"mZZ" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"naz" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"naG" = (
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/item/clothing/mask/muzzle,
+/obj/structure/rack,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"nbG" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"ncs" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"ncP" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/flask/vacuumflask,
+/obj/machinery/light,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"ndm" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/security)
+"ndB" = (
+/obj/structure/cable,
+/obj/structure/stairs/seamless{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"ndF" = (
+/obj/item/book/manual/security_space_law,
+/obj/item/book/manual/ripley_build_and_repair,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"ndG" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder2/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle7)
+"ndT" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/overgrown)
+"neU" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"nfi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"nfn" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Atmospherics Condenser"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"ngo" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/caves/central1/garbledradio)
+"ngu" = (
+/turf/open/floor/marking/warning/corner,
+/area/lv624/lazarus/spaceport)
+"ngK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"nhh" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"nhp" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"nhy" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"nhD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"nim" = (
+/obj/item/flash,
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "nexus_blast";
+	name = "Nexus Lockdown"
+	},
+/turf/open/floor/tile/red/redtaupecorner,
+/area/lv624/lazarus/security)
+"niW" = (
+/obj/structure/bed/chair,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"njg" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"njE" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"njG" = (
+/obj/effect/turf_decal/tile/transparent/dark_green,
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"njS" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"njZ" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"nkp" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
+"nkC" = (
+/turf/closed/wall,
+/area/lv624/lazarus/robotics)
+"nkP" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"nlq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/silver{
+	dir = 3
+	},
+/area/mainship/patrol_base/som)
+"nls" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor,
+/area/mainship/patrol_base/som)
+"nlz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"nlC" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/ai_node,
+/obj/structure/stairs/corner_seamless{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"nlS" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"nmN" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"nmQ" = (
+/obj/structure/flora/grass/green,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"nmV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/hydroponics/aux)
+"nnd" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/stairs/corner_seamless{
+	dir = 1
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"nnu" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"nnD" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"nnU" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"noj" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"nox" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"noE" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/river1)
+"nqs" = (
+/obj/effect/landmark/start/job/clf/standard,
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 8
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"nqt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"nqF" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/canteen)
+"nqG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"nrd" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"nrh" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"nrG" = (
+/turf/open/floor/scorched,
+/area/lv624/ground/sand6)
+"nrL" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"nrT" = (
+/obj/structure/rack,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"nrV" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"nsp" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport)
+"nsu" = (
+/obj/effect/turf_decal/trimline/dark_blue,
+/obj/structure/sign/safety/medical,
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"nsK" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/structure/largecrate/supply/supplies/mre,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"nsT" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 6
+	},
+/area/lv624/lazarus/spaceport)
+"nsY" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle10)
+"nte" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"ntg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"nth" = (
+/obj/structure/window_frame/colony/reinforced,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"ntl" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/clothing/suit/storage/apron,
+/obj/item/clothing/under/colonist,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"ntS" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"nud" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"nun" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"nut" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"nvx" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"nvD" = (
+/obj/effect/ai_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5/garbledradio)
+"nvN" = (
+/obj/structure/inflatable/popped,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"nwn" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"nwu" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"nwv" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle6)
+"nwO" = (
+/obj/structure/fence,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/ground/sand2)
+"nwT" = (
+/obj/structure/sink,
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"nxj" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome"
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"nya" = (
+/obj/structure/window_frame/colony,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"nyk" = (
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 9
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1;
+	pixel_y = 7
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"nyl" = (
+/obj/item/bedsheet/rd,
+/obj/item/toy/bikehorn/rubberducky,
+/obj/structure/bed/fancy,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"nys" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"nyD" = (
+/obj/item/ammo_casing{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"nyE" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"nyR" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"nzb" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"nzJ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"nAh" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"nAB" = (
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"nBq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"nBx" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"nEG" = (
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"nEU" = (
+/obj/machinery/cryopod/right,
+/turf/open/floor/mainship/purple{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"nFb" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille/smoothing,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/river2)
+"nFd" = (
+/obj/structure/table,
+/obj/item/trash/chips,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"nGy" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"nGO" = (
+/obj/machinery/bot/roomba{
+	name = "A roomba"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "somcargodoor"
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"nGY" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor,
+/area/lv624/ground/river1)
+"nGZ" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle6)
+"nHi" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"nHr" = (
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"nHy" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/c)
+"nHC" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/ai_node,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/quartstorage)
+"nHH" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/ruin)
+"nHJ" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"nIe" = (
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river1)
+"nIp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"nIC" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"nJq" = (
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	dir = 1;
+	name = "\improper Research Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"nJt" = (
+/obj/structure/rack,
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"nJG" = (
+/obj/item/clothing/glasses/regular/hipster,
+/obj/item/bedsheet/captain,
+/obj/structure/bed/fancy,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"nJR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"nKj" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"nKr" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"nKJ" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 8
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/river2)
+"nKP" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
+"nLf" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"nLu" = (
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand6)
+"nLA" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"nLE" = (
+/obj/effect/spawner/random/misc/trash,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"nMb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"nMT" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"nNt" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"nNG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/tank/oxygen,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"nNO" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tool,
+/obj/effect/spawner/random/engineering/tool{
+	pixel_x = -4;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"nOw" = (
+/obj/item/contraband/poster,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"nOy" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"nOG" = (
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 8
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"nOK" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"nOT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"nPa" = (
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/obj/item/ammo_magazine/smg/uzi/extended,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"nPe" = (
+/obj/effect/decal/cleanable/cobweb2,
+/obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
+/obj/structure/rack,
+/obj/item/reagent_containers/hypospray/autoinjector/dexalinplus{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/hypospray/autoinjector/quickclot{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/hypospray/autoinjector/tricordrazine,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"nPm" = (
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/ground/caves/central1/garbledradio)
+"nPo" = (
+/obj/effect/turf_decal/tracks/wheels/bloody{
+	dir = 4
+	},
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/tablefort)
+"nPp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"nPX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/broken_bottle,
+/turf/open/floor/cult,
+/area/lv624/lazarus/bar)
+"nPZ" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/bed,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"nQj" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"nQs" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"nQI" = (
+/obj/effect/landmark/corpsespawner/scientist,
+/obj/item/weapon/gun/pistol/holdout,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"nQP" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/se)
+"nRd" = (
+/obj/item/stack/sheet/metal,
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 25;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/mineral/phoron{
+	amount = 25;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"nRj" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 8
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"nRm" = (
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"nRA" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"nRY" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"nSR" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"nSV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"nTJ" = (
+/obj/item/toy/inflatable_duck,
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/liquid/water/river,
+/area/lv624/lazarus/fitness)
+"nTT" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"nUs" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Communications Dome"
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"nUt" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"nUD" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"nUX" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"nVM" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tech_supply,
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"nWi" = (
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/obj/structure/window/reinforced,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"nWJ" = (
+/obj/effect/spawner/random/misc/trash,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"nWK" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle10)
+"nXe" = (
+/obj/machinery/light/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"nXy" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/tracks/human1/wet{
+	dir = 8
+	},
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"nXL" = (
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"nYf" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"nYh" = (
+/obj/structure/barricade/plasteel,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"nYN" = (
+/obj/structure/platform_decoration{
+	dir = 1
+	},
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"nYP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"nYW" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"nZa" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"nZi" = (
+/obj/item/trash/chips,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"nZt" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"nZL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"nZS" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
+	},
+/area/lv624/lazarus/main_hall)
+"oac" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/research)
+"oaq" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"oay" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river3)
+"oaK" = (
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"oaO" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"obD" = (
+/turf/closed/wall,
+/area/lv624/ground/jungle10)
+"ocH" = (
+/obj/structure/cargo_container,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"ocT" = (
+/obj/structure/rack,
+/obj/item/shard,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"ocY" = (
+/turf/open/floor/mainship/silver{
+	dir = 3
+	},
+/area/mainship/patrol_base/som)
+"odn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"odx" = (
+/obj/structure/cryofeed,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"odA" = (
+/obj/structure/flora/jungle/plantbot1,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"odW" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"oet" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"oeL" = (
+/obj/item/stack/sheet/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"oeW" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"oeY" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"ofq" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted/colony,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"ofw" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"ofE" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/shuttle/drop1/lz1)
+"ofS" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"ogd" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"ogN" = (
+/turf/open/ground/grass/beach{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"ogS" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"oho" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/ground/jungle9)
+"ohD" = (
+/obj/item/shard,
+/obj/structure/window_frame/colony/reinforced,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/main_hall)
+"ohE" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"ohG" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/closed/mineral/smooth,
+/area/lv624/ground/caves/rock)
+"ohP" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"ohS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"ohZ" = (
+/turf/open/floor,
+/area/lv624/ground/sand6)
+"oii" = (
+/obj/structure/stairs/seamless{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"oiq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"oiz" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 5
+	},
+/area/lv624/lazarus/atmos)
+"oiN" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"ojo" = (
+/obj/effect/spawner/random/misc/structure/broken_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/overgrown)
+"ojs" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/gm/dense,
+/area/lv624/lazarus/spaceport2)
+"ojt" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"okb" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 10
+	},
+/area/lv624/lazarus/main_hall)
+"okC" = (
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"okS" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/caves/central1/garbledradio)
+"okV" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/comms)
+"ola" = (
+/obj/structure/rack,
+/obj/item/attachable/flashlight,
+/obj/item/attachable/flashlight,
+/obj/item/attachable/flashlight,
+/obj/item/attachable/flashlight,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"olS" = (
+/obj/effect/decal/remains/human,
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"olZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"omm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"omo" = (
+/obj/effect/landmark/start/job/clf/leader,
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"omB" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"omS" = (
+/obj/effect/decal/remains/human,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"omU" = (
+/obj/machinery/light/small,
+/obj/effect/landmark/corpsespawner/doctor{
+	corpseback = null;
+	corpsegloves = /obj/item/clothing/gloves/latex;
+	name = "Colonist Redo Koster"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"omV" = (
+/turf/open/floor/marking/warning/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"one" = (
+/turf/closed/wall,
+/area/lv624/ground/compound/se)
+"onp" = (
+/obj/item/clothing/glasses/regular,
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"onv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"ood" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"ooe" = (
+/obj/structure/sign/science{
+	dir = 1
+	},
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/c)
+"oof" = (
+/obj/item/trash/chips,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"oon" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/power/apc/hyper,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"oot" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"ooB" = (
+/obj/structure/largecrate/random/barrel/yellow,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"ooJ" = (
+/obj/effect/spawner/modularmap/lv624/hydroroad,
+/turf/open/space/basic,
+/area/space)
+"ooO" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"ooV" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"opc" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"opw" = (
+/obj/structure/reagent_dispensers/fueltank/barrel,
+/turf/open/floor/marking/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/spaceport)
+"opE" = (
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"opU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"oqg" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/secure_storage)
+"oqn" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"oqA" = (
+/obj/structure/bed,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"oqB" = (
+/obj/structure/cable,
+/obj/machinery/autodoc{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/transparent/dark_green/anticorner/contrasted{
+	dir = 1
+	},
+/obj/machinery/power/apc/hyper,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"oqC" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/misc/cigarettes,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"oqF" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"oqR" = (
+/obj/structure/table/wood,
+/obj/item/pinpointer,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"orf" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
+"oru" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"orJ" = (
+/turf/closed/wall/indestructible/bulkhead{
+	name = ""Youfuckedup" monument.";
+	desc = "To make a mistake is human, to blame it on someone else is even more human."
+	},
+/area/mainship/patrol_base/som)
+"osr" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"osF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"osO" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0
+	},
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"osP" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 9
+	},
+/area/shuttle/drop2/lz2)
+"osY" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/ground/filtration)
+"otb" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river1)
+"oto" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"otB" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall,
+/area/lv624/lazarus/canteen)
+"otZ" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"ouV" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"ovf" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"ovs" = (
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"ovx" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"owb" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"owh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"owi" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"owr" = (
+/obj/item/weapon/gun/smg/mp7,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"owt" = (
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"owK" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"owP" = (
+/turf/open/ground/jungle,
+/area/lv624/ground/jungle7)
+"owT" = (
+/obj/structure/sign/botany{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"owY" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"oxd" = (
+/obj/machinery/floodlight/landing,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"oxl" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"oxw" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"oxC" = (
+/obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"oxT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/docking_port/stationary/crashmode,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"oxW" = (
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"oyu" = (
+/obj/structure/noticeboard{
+	pixel_y = 30
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"oyx" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"ozn" = (
+/obj/structure/table/reinforced/flipped,
+/obj/machinery/microwave,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"ozv" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0
+	},
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"ozZ" = (
+/obj/item/shard,
+/obj/structure/window_frame/colony/reinforced,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating,
+/area/lv624/lazarus/sleep_male)
+"oAf" = (
+/obj/machinery/computer/telecomms/server,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"oAo" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"oAL" = (
+/obj/effect/spawner/random/machinery/machine_frame,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"oAZ" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"oBv" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/obj/effect/spawner/random/medical/health_analyzer,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"oBC" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"oBN" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/ground/ruin)
+"oBQ" = (
+/obj/effect/spawner/random/machinery/machine_frame,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"oCi" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"oCC" = (
+/obj/structure/cargo_container{
+	dir = 1
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"oCL" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"oCS" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"oCW" = (
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"oCY" = (
+/obj/structure/table,
+/obj/item/clothing/head/soft/blue,
+/obj/machinery/light,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"oDb" = (
+/obj/item/ashtray/plastic,
+/obj/item/stack/flag/red,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"oDe" = (
+/obj/machinery/conveyor{
+	id = "lower_garbage"
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"oDk" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"oDm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"oDp" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"oEa" = (
+/turf/closed/wall,
+/area/lv624/ground/compound/n)
+"oEB" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
+/obj/item/toy/dice/d20,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"oFb" = (
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"oFC" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/internal_affairs)
+"oGf" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"oGr" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"oGE" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome"
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"oGG" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"oGQ" = (
+/obj/machinery/vending/security,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/lv624/lazarus/security)
+"oGV" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning,
+/area/lv624/lazarus/spaceport2)
+"oHj" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes,
+/obj/machinery/landinglight/lz1{
+	dir = 8
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop1/lz1)
+"oHp" = (
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"oIc" = (
+/obj/structure/platform{
+	dir = 9
+	},
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"oIn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"oIs" = (
+/obj/item/spacecash/c100{
+	pixel_x = -12
+	},
+/obj/item/reagent_containers/food/drinks/bottle/sake,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"oJB" = (
+/obj/structure/rack,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"oJE" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand2)
+"oJT" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
+"oKe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/misc/trash,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"oKj" = (
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"oKs" = (
+/obj/item/tool/crowbar,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"oKI" = (
+/obj/machinery/button/door/open_only/landing_zone/lz2,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport2)
+"oKM" = (
+/obj/machinery/mineral/stacking_machine,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"oLa" = (
+/obj/effect/ai_node,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"oLh" = (
+/obj/item/folder/blue,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/corporate_affairs)
+"oLi" = (
+/obj/structure/catwalk,
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"oLl" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"oLw" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"oLx" = (
+/obj/machinery/door_control{
+	dir = 8;
+	id = "science_blast";
+	name = "Science Wing Lockdown"
+	},
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"oLJ" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5)
+"oMe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"oMv" = (
+/obj/effect/decal/cleanable/blood/oil/armorblood,
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
+"oMI" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"oMS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"oMY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 10
+	},
+/area/lv624/lazarus/atmos)
+"oNG" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"oOp" = (
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"oOI" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"oPl" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"oPu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"oPC" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"oPQ" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"oQb" = (
+/obj/structure/table,
+/obj/item/tool/shovel/spade,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"oQc" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"oQt" = (
+/obj/machinery/door_control{
+	id = "corporate_blast";
+	name = "Dome Lockdown";
+	pixel_y = 25
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"oQz" = (
+/obj/item/tool/shovel,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"oQD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth,
+/area/lv624/ground/caves/rock)
+"oRo" = (
+/obj/effect/landmark/start/job/clf/standard,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"oRB" = (
+/turf/closed/wall/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"oRK" = (
+/turf/closed/wall,
+/area/lv624/ground/sand5)
+"oRL" = (
+/obj/structure/rack,
+/obj/item/clothing/under/overalls,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"oRM" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/ground/jungle3)
+"oRY" = (
+/obj/item/shard,
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"oSb" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"oTz" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"oTA" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"oTC" = (
+/obj/effect/landmark/corpsespawner/chef,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/spawner/random/food_or_drink/kitchenknife/butcherweighted,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"oTG" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport)
+"oTK" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river1)
+"oUl" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"oVs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"oWI" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast,
+/area/lv624/ground/jungle9)
+"oXl" = (
+/obj/structure/closet,
+/obj/item/healthanalyzer,
+/obj/item/clothing/shoes/centcom,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"oXw" = (
+/obj/effect/spawner/random/engineering/structure/tank/waterweighted,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"oXZ" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/machinery/light/small,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 6
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"oYf" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"oYE" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 8
+	},
+/area/lv624/lazarus/security)
+"oYH" = (
+/obj/machinery/door/airlock/mainship/command/free_access{
+	name = "\improper Nexus Dome Command Quarter"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"oYO" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/hydroponics)
+"oYT" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5/garbledradio)
+"oZt" = (
+/obj/item/folder/blue,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/internal_affairs)
+"paa" = (
+/obj/item/clothing/mask/gas,
+/obj/structure/rack,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"pbe" = (
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"pbm" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"pbC" = (
+/obj/structure/cargo_container/red{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"pce" = (
+/obj/machinery/light/small,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"pcV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"pdA" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"pdE" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/mining/brace,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/caves/central1/garbledradio)
+"pdJ" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"pex" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"peD" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"peV" = (
+/obj/item/shard,
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/sleep_male)
+"pfe" = (
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "\improper Nexus Dome Armory"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/armory)
+"pff" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"pfV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"pgl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"pgm" = (
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"pgu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"pgL" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/hyper{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"pha" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"phB" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"phD" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/stairs/seamless{
+	dir = 1
+	},
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"phY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"pif" = (
+/obj/effect/landmark/corpsespawner/bridgeofficer{
+	corpseidjob = "Bridge Officer";
+	corpseuniform = /obj/item/clothing/under/waiter;
+	name = "Mr. Johnson Telovin"
+	},
+/obj/item/tool/crowbar,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"pit" = (
+/obj/structure/flora/jungle/plantbot1,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"piF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"pjb" = (
+/obj/machinery/computer3/server,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"pjl" = (
+/obj/machinery/floodlight/colony{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"pjo" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"pjB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/power/apc/drained,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"pkm" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"pkt" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"pkz" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"pkG" = (
+/obj/item/shard,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"pkJ" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"pli" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
+"ply" = (
+/obj/structure/bed/chair/comfy/black,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple)
+"pmg" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"pmF" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"pmT" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"pne" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"pnf" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"pnj" = (
+/obj/effect/ai_node,
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"pnI" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"pnL" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
+"pnR" = (
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"pnS" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport)
+"pnZ" = (
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"poM" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"ppH" = (
+/obj/machinery/prop/autolathe,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"pqc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"pqh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"pqk" = (
+/obj/structure/table/wood,
+/obj/item/storage/bible,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/chapel)
+"pqV" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1
+	},
+/turf/open/floor/marking/warning{
+	dir = 6
+	},
+/area/lv624/lazarus/spaceport2)
+"prk" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"prP" = (
+/obj/structure/bed/chair/office/light,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"prY" = (
+/obj/structure/fence,
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/sand8)
+"psi" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"psr" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
+"pss" = (
+/obj/effect/landmark/start/job/clf/specialist,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"ptg" = (
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"ptv" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"ptK" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"ptU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"pum" = (
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"pvq" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"pvI" = (
+/obj/structure/bed/chair,
+/obj/effect/turf_decal/trimline/dark_blue,
+/obj/structure/mirror,
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"pvU" = (
+/obj/machinery/door/airlock/medical{
+	dir = 2
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"pvX" = (
+/obj/item/shard,
+/obj/structure/displaycase/destroyed,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"pwN" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"pxU" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"pyI" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand1)
+"pyQ" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"pyY" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"pzd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5)
+"pze" = (
+/obj/structure/bed/bunkbed,
+/turf/open/floor/mainship/purple{
+	dir = 5
+	},
+/area/mainship/patrol_base/som)
+"pzf" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/hyper,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"pAh" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"pAG" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"pAU" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/wood{
+	amount = 50
+	},
+/obj/item/stack/sheet/wood{
+	amount = 50
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"pAW" = (
+/obj/structure/fence,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"pBj" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"pBt" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"pBK" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"pBS" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/quartstorage)
+"pCn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"pCt" = (
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"pCK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"pDo" = (
+/obj/item/tool/analyzer,
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"pDt" = (
+/turf/open/ground/coast/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"pDx" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"pDy" = (
+/obj/machinery/chem_dispenser/soda{
+	pixel_y = 32
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"pEg" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"pEj" = (
+/obj/item/clothing/head/warning_cone,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"pEO" = (
+/obj/machinery/door/airlock/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome Bathroom"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"pEU" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/floor/elevatorshaft,
+/area/lv624/lazarus/bar)
+"pFz" = (
+/obj/structure/stairs/corner_seamless{
+	dir = 4
+	},
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"pFH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"pFT" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"pGd" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/clothing/mask/facehugger/dead,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"pGe" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle5)
+"pGi" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"pGD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"pGK" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 8
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"pGQ" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes,
+/obj/machinery/landinglight/lz1{
+	dir = 4
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop1/lz1)
+"pGZ" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"pHj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"pHI" = (
+/obj/effect/landmark/start/job/clf/medic,
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"pIa" = (
+/obj/structure/cargo_container/horizontal{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"pIz" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central2)
+"pIJ" = (
+/obj/structure/rack,
+/obj/item/armor_module/storage/uniform/black_vest,
+/obj/item/armor_module/storage/uniform/black_vest,
+/obj/item/armor_module/storage/uniform/black_vest,
+/obj/item/armor_module/storage/uniform/black_vest,
+/obj/item/armor_module/storage/uniform/brown_vest,
+/obj/item/armor_module/storage/uniform/brown_vest,
+/obj/item/armor_module/storage/uniform/brown_vest,
+/obj/item/armor_module/storage/uniform/white_vest,
+/obj/item/armor_module/storage/uniform/white_vest,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"pIU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"pIY" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/weapon/gun/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"pJF" = (
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple)
+"pKj" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"pKG" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"pKP" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"pKQ" = (
+/obj/structure/largecrate/supply/medicine/blood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"pKS" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 1
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"pLB" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand9)
+"pMe" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
+"pMu" = (
+/obj/effect/spawner/random/engineering/technology_scanner,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"pMY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"pNq" = (
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"pOI" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"pPo" = (
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/sand7)
+"pPX" = (
+/turf/open/floor/marking/warning{
+	dir = 5
+	},
+/area/lv624/lazarus/spaceport2)
+"pQb" = (
+/obj/item/clothing/glasses/regular/hipster,
+/obj/item/bedsheet/captain,
+/obj/structure/bed/fancy,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"pQf" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"pQj" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"pQw" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/ground/sand7)
+"pQD" = (
+/obj/structure/mecha_wreckage/ripley/lv624,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"pQI" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
+"pQR" = (
+/obj/machinery/recharge_station,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"pQY" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"pRx" = (
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/main_hall)
+"pRy" = (
+/obj/machinery/computer/intel_computer,
+/obj/machinery/door_control{
+	dir = 4;
+	id = "science_blast";
+	name = "Science Wing Lockdown"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"pSl" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand6)
+"pSr" = (
+/obj/structure/lazarus_sign,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"pSF" = (
+/obj/structure/cryofeed/right,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"pSU" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"pSX" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/quartstorage/outdoors)
+"pTc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"pTj" = (
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"pTw" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"pTO" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/ne)
+"pTR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"pUb" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 1
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"pUm" = (
+/obj/structure/window/reinforced,
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/obj/effect/spawner/random/weaponry/gun/shotgun,
+/obj/structure/window/reinforced/windowstake{
+	dir = 8
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"pUq" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"pVc" = (
+/obj/machinery/light/red{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 5
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"pVD" = (
+/obj/machinery/mining/drill,
+/obj/item/shard,
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/caves/central1/garbledradio)
+"pWq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"pWs" = (
+/obj/machinery/computer/camera_advanced/overwatch/som,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"pWt" = (
+/obj/machinery/door/airlock/colony/medical/hydroponics{
+	dir = 1
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"pXp" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"pXJ" = (
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river1)
+"pXO" = (
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"pXV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/misc/trash,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"pYm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"pYp" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"pYw" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2/garbledradio)
+"pZb" = (
+/obj/structure/bed/chair/sofa/right,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"pZm" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"pZq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"pZB" = (
+/obj/structure/disposalpipe/segment{
+	name = "water pipe"
+	},
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"pZV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"qan" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"qar" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"qaw" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"qbW" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"qcx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river1)
+"qcW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"qdq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"qdt" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/robotics)
+"qdW" = (
+/turf/closed/wall/r_wall/chigusa,
+/area/mainship/patrol_base/som)
+"qea" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"qeT" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/closed/wall,
+/area/lv624/ground/jungle9)
+"qfa" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"qfC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"qfE" = (
+/obj/machinery/status_display{
+	pixel_y = -1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/kitchen)
+"qfF" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"qgr" = (
+/obj/vehicle/train/cargo/engine,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"qgR" = (
+/turf/open/floor/mainship/sterile/corner{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"qhc" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"qhd" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"qhk" = (
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"qhz" = (
+/obj/structure/rack,
+/obj/item/storage/box/MRE,
+/obj/item/storage/box/MRE,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"qhC" = (
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/lv624/ground/sand8)
+"qhF" = (
+/obj/structure/table/reinforced/prison,
+/obj/structure/table/reinforced/prison,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside{
+	dir = 4
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"qhS" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"qiF" = (
+/obj/structure/largecrate/guns/russian,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"qiS" = (
+/obj/structure/bookcase,
+/obj/item/book/manual/chef_recipes,
+/obj/item/book/manual/nuclear,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"qiW" = (
+/obj/structure/stairs/corner_seamless{
+	dir = 8
+	},
+/obj/structure/platform_decoration{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"qjf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"qjh" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"qkt" = (
+/obj/structure/table,
+/obj/item/clipboard,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"qkJ" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"qkX" = (
+/obj/machinery/landinglight/lz2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"qmW" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"qng" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"qnm" = (
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"qno" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"qnL" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2,
+/area/lv624/lazarus/atmos)
+"qob" = (
+/obj/item/toy/inflatable_duck,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle1)
+"qop" = (
+/obj/effect/spawner/random/weaponry/gun/machineguns,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"qos" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"qox" = (
+/obj/item/weapon/sword/machete,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"qpc" = (
+/obj/structure/table,
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"qpp" = (
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"qpP" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"qqf" = (
+/obj/machinery/quick_vendor/som,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"qqC" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/ground/grass/grass2,
+/area/lv624/lazarus/overgrown)
+"qqU" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/obj/effect/spawner/random/engineering/technology_scanner,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"qrp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport2)
+"qrw" = (
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"qsn" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"qsy" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 6
+	},
+/area/shuttle/drop1/lz1)
+"qsz" = (
+/obj/structure/window_frame/wood,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/mainship/patrol_base/som)
+"qsB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/patrol_base/som)
+"qsT" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Communications Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"qsZ" = (
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5)
+"qta" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"qti" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand8)
+"qtq" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"quW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	dir = 4
+	},
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"qwi" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"qwt" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"qwQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"qwT" = (
+/obj/structure/table,
+/obj/item/tool/analyzer/plant_analyzer,
+/obj/item/tool/analyzer/plant_analyzer,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"qxf" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"qyd" = (
+/turf/open/ground/grass,
+/area/lv624/lazarus/spaceport)
+"qye" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 6
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"qyn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"qyu" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/airlock/mainship/generic{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	name = "Strange Temple"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"qyx" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"qyy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"qyC" = (
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"qyD" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"qyG" = (
+/obj/structure/largecrate/random/secure,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"qyP" = (
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"qzd" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"qzK" = (
+/obj/structure/stairs/corner_seamless{
+	dir = 1
+	},
+/obj/structure/platform_decoration,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"qAq" = (
+/obj/structure/table/wood,
+/obj/item/trash/cigbutt/cigarbutt,
+/obj/machinery/cell_charger,
+/obj/effect/spawner/random/misc/cigarettes,
+/obj/effect/spawner/random/clothing/sunglasses,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"qBj" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"qBr" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"qBs" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/sleep_male)
+"qBF" = (
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/river2)
+"qBU" = (
+/turf/closed/mineral/smooth/indestructible,
+/area/storage/testroom)
+"qBW" = (
+/obj/effect/landmark/start/job/som/commander,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/turf/open/floor/mainship/purple{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"qBY" = (
+/obj/effect/decal/remains/human,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
+"qCb" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/east1/garbledradio)
+"qCc" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/wood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"qCk" = (
+/obj/item/tool/multitool,
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/obj/structure/rack,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"qCv" = (
+/obj/structure/prop/mainship/hangar_stencil,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"qCy" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"qCI" = (
+/obj/item/ammo_casing,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"qDh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/main_hall)
+"qDm" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/kitchen)
+"qDB" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"qDI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"qEf" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"qEh" = (
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/robotics)
+"qEm" = (
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"qEw" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"qEW" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/closed/wall,
+/area/lv624/lazarus/fitness)
+"qEY" = (
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/river3)
+"qFl" = (
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"qFs" = (
+/obj/structure/window_frame/wood,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"qFx" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"qGg" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"qGj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"qHl" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/tablefort)
+"qHn" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
+"qHD" = (
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand6)
+"qIM" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"qJo" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"qJC" = (
+/obj/machinery/light,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"qJV" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/turf_decal/sandytile,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple)
+"qJY" = (
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"qKa" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/fitness)
+"qKi" = (
+/obj/structure/flora/jungle/vines{
+	pixel_y = 1
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"qKm" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"qKp" = (
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle2)
+"qKv" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"qKE" = (
+/obj/machinery/firealarm,
+/obj/machinery/vending/cigarette/colony,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/internal_affairs)
+"qLo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"qLS" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
+"qLU" = (
+/obj/effect/landmark/weed_node,
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"qMb" = (
+/obj/structure/table/reinforced,
+/obj/item/trash/pistachios,
+/obj/item/t_scanner,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"qMo" = (
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"qMC" = (
+/obj/effect/spawner/random/decal/blood,
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"qME" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"qMG" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"qMI" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"qMN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/floor/elevatorshaft,
+/area/lv624/lazarus/bar)
+"qMS" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/obj/item/ammo_magazine/smg/uzi/extended,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
+	},
+/area/lv624/lazarus/main_hall)
+"qNc" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"qNm" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"qNF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"qNN" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/structure/table/reinforced/prison,
+/obj/machinery/light/small,
+/obj/item/reagent_containers/food/snacks/sliceable/pastries/plaincake,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"qNW" = (
+/obj/structure/fence,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/compound/c)
+"qOe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"qOh" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6/garbledradio)
+"qOq" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"qOC" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Communications Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"qOW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"qPI" = (
+/obj/item/explosive/grenade/flare/civilian,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"qQe" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"qQq" = (
+/obj/machinery/optable,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"qQZ" = (
+/obj/item/stack/sheet/wood,
+/obj/item/stack/sheet/wood,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"qRw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"qRI" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/chapel)
+"qRK" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"qRR" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/canteen)
+"qSs" = (
+/obj/effect/decal/cleanable/vomit,
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/canteen)
+"qSN" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"qTw" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 10
+	},
+/area/lv624/lazarus/fitness)
+"qTz" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/turf/open/floor,
+/area/lv624/lazarus/corporate_affairs)
+"qTB" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand2)
+"qTK" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"qTS" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/fitness)
+"qUq" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"qUu" = (
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"qUD" = (
+/obj/structure/table/reinforced,
+/obj/item/tweezers,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/cell/high,
+/obj/machinery/cell_charger,
+/obj/item/storage/firstaid/adv,
+/obj/item/storage/surgical_tray,
+/turf/open/floor/mainship/sterile/side,
+/area/mainship/patrol_base/som)
+"qUF" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"qUJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table/reinforced/flipped,
+/obj/structure/table/reinforced/flipped,
+/obj/structure/closet/crate/freezer/rations{
+	pixel_y = 7
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"qVa" = (
+/obj/effect/spawner/random/misc/trash,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"qVg" = (
+/obj/structure/bed/alien,
+/obj/item/bedsheet/blue,
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"qVG" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/river3)
+"qVI" = (
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"qWd" = (
+/obj/effect/spawner/random/engineering/structure/handheld_lighting,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"qWR" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"qXg" = (
+/obj/machinery/computer3,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"qXw" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"qXB" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"qYk" = (
+/turf/closed/wall/brick,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"qYE" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"qYH" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"qZc" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle4)
+"qZd" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/shuttle/drop2/lz2)
+"qZe" = (
+/obj/item/shard,
+/obj/structure/displaycase/destroyed,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"rad" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"rai" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"ran" = (
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"raD" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"rbs" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/chapel)
+"rbz" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"rbD" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"rck" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"rcm" = (
+/obj/structure/rack,
+/obj/item/ammo_magazine/rifle/mpi_km/black,
+/obj/item/ammo_magazine/rifle/mpi_km/black,
+/obj/item/ammo_magazine/rifle/mpi_km/black,
+/obj/item/ammo_magazine/rifle/mpi_km/black,
+/obj/item/ammo_magazine/rifle/mpi_km/black,
+/obj/item/ammo_magazine/rifle/mpi_km/extended,
+/obj/item/ammo_magazine/rifle/mpi_km/extended,
+/obj/item/ammo_magazine/rifle/mpi_km/extended,
+/obj/item/weapon/gun/rifle/mpi_km/black/magharness,
+/obj/item/weapon/gun/rifle/mpi_km/black/magharness,
+/obj/item/weapon/gun/rifle/mpi_km/black/magharness,
+/obj/item/weapon/gun/rifle/mpi_km/black/magharness,
+/obj/item/weapon/gun/rifle/mpi_km/black/magharness,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"rcv" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central3/garbledradio)
+"rcB" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"rcE" = (
+/obj/structure/showcase/six,
+/obj/structure/platform{
+	dir = 15
+	},
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"rcJ" = (
+/turf/open/ground/coast/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"rcT" = (
+/obj/structure/stairs/corner_seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"rcU" = (
+/obj/structure/largecrate,
+/obj/item/mecha_parts/mecha_equipment/repair_droid{
+	pixel_y = -10
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"rcV" = (
+/obj/effect/spawner/random/misc/structure/barrel,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"rdT" = (
+/obj/structure/table,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"rdY" = (
+/obj/item/stack/sheet/metal{
+	amount = 3
+	},
+/obj/item/stack/sheet/metal{
+	amount = 3
+	},
+/obj/item/clothing/suit/armor/vest,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"reb" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"reO" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/main_hall)
+"reR" = (
+/obj/structure/largecrate,
+/obj/item/explosive/grenade/stick,
+/obj/item/explosive/grenade/stick,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"rft" = (
+/obj/machinery/vending/medical{
+	name = "Stolen Medicament Vendor";
+	req_access = list(206)
+	},
+/turf/open/floor/mainship/sterile/corner,
+/area/mainship/patrol_base/som)
+"rgc" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"rgi" = (
+/obj/effect/landmark/start/job/som/squadcorpsman,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"rgj" = (
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"rgw" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle5)
+"rhf" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
+"rhr" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2/garbledradio)
+"rhF" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"rhQ" = (
+/obj/structure/window/reinforced/tinted,
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"ric" = (
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"rim" = (
+/obj/item/stack/sheet/wood,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"riz" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"riJ" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2/garbledradio)
+"rjc" = (
+/obj/machinery/power/monitor{
+	name = "Main Power Grid Monitoring"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"rji" = (
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"rjJ" = (
+/turf/open/ground/coast,
+/area/lv624/ground/jungle9)
+"rkg" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"rkk" = (
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"rkl" = (
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"rkr" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"rkw" = (
+/obj/effect/turf_decal/trimline/dark_blue,
+/obj/structure/mirror,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"rma" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"rmg" = (
+/obj/structure/cargo_container{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"rmq" = (
+/obj/item/tool/multitool,
+/obj/structure/rack,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"rmB" = (
+/turf/open/floor,
+/area/lv624/ground/river1)
+"rmS" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/windowstake{
+	dir = 8
+	},
+/obj/structure/window/reinforced/windowstake{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/lv624/lazarus/corporate_affairs)
+"rnn" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"rnz" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/autoinjector/quickclot,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"rnA" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle7)
+"rof" = (
+/obj/effect/turf_decal/riverdecal/edge,
+/turf/open/floor/plating,
+/area/lv624/ground/river2)
+"roO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/quartstorage)
+"rpr" = (
+/obj/structure/closet/secure_closet/engineering_personal{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"rpv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/sign/botany{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"rpO" = (
+/obj/machinery/hydroponics,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"rqw" = (
+/obj/item/attachable/quickfire,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"rrl" = (
+/obj/item/ammo_magazine/pistol,
+/obj/machinery/light,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"rrv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"rrx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/orange/corner{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"rrB" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "science_blast";
+	name = "\improper Science Wing Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/research)
+"rrC" = (
+/obj/item/clothing/mask/breath,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"rrZ" = (
+/obj/effect/landmark/weed_node,
+/obj/item/trash/candy,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"rsc" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle10)
+"rsG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"rsP" = (
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"rte" = (
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"rtE" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"rtH" = (
+/obj/structure/table/wood,
+/obj/item/ashtray/bronze,
+/obj/item/clothing/mask/cigarette/tram,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"rtU" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"rut" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"ruz" = (
+/obj/structure/bed/chair/office/light,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"ruC" = (
+/obj/structure/table,
+/obj/item/flashlight,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"ruP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"rvb" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/secure_storage)
+"rve" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"rvj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"rwc" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_tunnel_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"rwg" = (
+/obj/effect/ai_node,
+/turf/open/floor/prison/redfloor,
+/area/lv624/lazarus/sandtemple)
+"rwx" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/drained{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"rwA" = (
+/obj/structure/closet,
+/obj/item/clothing/under/rank/scientist,
+/obj/structure/window/reinforced/tinted,
+/obj/effect/spawner/random/medical/heal_pack/bruteweighted,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"rwP" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"rwV" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"rxh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"rxu" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/floodlight/colony,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"rxG" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"rxN" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
+"rxX" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/plating,
+/area/lv624/ground/sand5)
+"ryp" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"ryI" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"ryZ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"rzb" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 1
+	},
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/river2)
+"rzp" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"rzx" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"rAe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/obj/machinery/air_alarm{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"rAw" = (
+/obj/effect/spawner/random/engineering/powercell,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"rAH" = (
+/obj/machinery/griddle,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"rAM" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"rAW" = (
+/obj/effect/spawner/random/weaponry/gun/machineguns,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/corporate_affairs)
+"rBl" = (
+/obj/structure/closet/crate/hydroponics/prespawned,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"rCm" = (
+/obj/structure/flora/pottedplant,
+/obj/item/trash/cheesie,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"rCv" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"rCx" = (
+/turf/open/floor/mech_bay_recharge_floor/asteroid,
+/area/lv624/ground/caves/central5/garbledradio)
+"rCz" = (
+/obj/structure/table/wood,
+/obj/item/tool/candle,
+/turf/open/floor/tile/chapel{
+	dir = 8
+	},
+/area/lv624/lazarus/chapel)
+"rCB" = (
+/obj/structure/rack,
+/obj/item/clothing/under/color/black,
+/obj/item/clothing/under/color/blackf,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"rCX" = (
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river1)
+"rDg" = (
+/obj/structure/bed/alien,
+/obj/item/bedsheet/blue,
+/obj/effect/landmark/start/job/clf/standard,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 10
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"rDi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/sensor_tower,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"rDq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"rEk" = (
+/obj/structure/table/wood,
+/obj/item/storage/box/donkpockets,
+/obj/effect/spawner/random/clothing/sunglasses,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"rEP" = (
+/obj/structure/prop/mainship/research/mechafab,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"rEY" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/attachable/suppressor,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"rEZ" = (
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/sand7)
+"rFa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"rFd" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"rFj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"rFo" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 9
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"rFu" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"rGG" = (
+/obj/item/bedsheet/rd,
+/obj/item/weapon/cane,
+/obj/structure/bed/fancy,
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"rGI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/engineering)
+"rHo" = (
+/obj/structure/bed,
+/obj/machinery/light,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"rHr" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"rHz" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 8;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"rIa" = (
+/obj/machinery/floodlight,
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/lazarus/tablefort)
+"rIm" = (
+/obj/effect/turf_decal/sandytile,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"rIz" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/structure/handheld_lighting,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"rIX" = (
+/obj/machinery/door/airlock/mainship/secure/free_access{
+	name = "\improper Water Filtration Plant"
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/ground/filtration)
+"rJr" = (
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"rJB" = (
+/obj/item/clothing/under/shorts/blue,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"rJD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/cult,
+/area/lv624/lazarus/bar)
+"rJY" = (
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"rKg" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"rKs" = (
+/obj/structure/showcase/six,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"rLm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/side{
+	dir = 6
+	},
+/area/lv624/lazarus/bar)
+"rLu" = (
+/obj/item/target/syndicate,
+/obj/structure/target_stake,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/security)
+"rLx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/hydroponics/aux)
+"rLV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/lazarus/spaceport)
+"rMh" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"rMC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"rMU" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"rMW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"rNE" = (
+/turf/closed/wall/r_wall,
+/area/lv624/ground/caves/central1/garbledradio)
+"rOc" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
+"rOi" = (
+/obj/structure/closet,
+/obj/item/clothing/under/overalls,
+/obj/effect/spawner/random/medical/heal_pack/bruteweighted,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"rOz" = (
+/obj/item/shard,
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"rPf" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop2/lz2)
+"rPl" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/n)
+"rQw" = (
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"rQB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"rQH" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"rQY" = (
+/obj/structure/cargo_container/nt{
+	dir = 8
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"rRr" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 24
+	},
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"rRA" = (
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"rRT" = (
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/rock)
+"rRU" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Storage Dome"
+	},
+/turf/open/floor/vault,
+/area/lv624/lazarus/quartstorage)
+"rRZ" = (
+/obj/structure/closet,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"rSg" = (
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"rSh" = (
+/obj/machinery/landinglight/lz1{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"rSw" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"rSV" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"rTn" = (
+/obj/structure/sign/atmosplaque{
+	dir = 1
+	},
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"rTr" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"rTA" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"rTI" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"rTV" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"rTY" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle3)
+"rUd" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"rVi" = (
+/obj/effect/spawner/modularmap/lv624/largecentralcave,
+/turf/open/space/basic,
+/area/space)
+"rVG" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"rVL" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 1
+	},
+/obj/machinery/computer/autodoc_console,
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"rVW" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"rVX" = (
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/tile/dark/brown2/corner,
+/area/lv624/lazarus/atmos)
+"rWE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"rWM" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"rXK" = (
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"rXT" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport)
+"rXW" = (
+/obj/machinery/light/small,
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"rYf" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2{
+	dir = 4
+	},
+/area/lv624/lazarus/sandtemple/garbledradio)
+"rZd" = (
+/obj/structure/cargo_container,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"rZy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/bar)
+"rZE" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"rZI" = (
+/obj/structure/plasticflaps,
+/obj/machinery/conveyor{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"sad" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle1)
+"saf" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/corporate_affairs)
+"saq" = (
+/obj/structure/catwalk,
+/turf/open/ground/grass/beach{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"sat" = (
+/turf/closed/wall,
+/area/lv624/ground/sand7)
+"saz" = (
+/obj/machinery/floodlight/colony,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"sbo" = (
+/obj/machinery/light,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"sbF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"sbW" = (
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"sco" = (
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/prison/redfloor,
+/area/lv624/lazarus/sandtemple)
+"sct" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"sdj" = (
+/obj/structure/rack,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"sdm" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle5)
+"sdF" = (
+/obj/structure/safe/floor/lvcolony,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"ser" = (
+/obj/machinery/door_control{
+	id = "secure_blast";
+	name = "Vault Access";
+	pixel_x = -25
+	},
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"sez" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/compound/se)
+"seC" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
+	},
+/area/lv624/lazarus/main_hall)
+"seE" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3)
+"seJ" = (
+/obj/structure/table/wood,
+/obj/machinery/photocopier{
+	pixel_y = 12
+	},
+/obj/item/tool/wrench,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"seK" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"seQ" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"sfb" = (
+/obj/structure/bed/stool,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"sfe" = (
+/obj/item/shard,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"sfg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"sfs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"sfL" = (
+/obj/structure/barricade/metal{
+	dir = 1
+	},
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"sfQ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"sgb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"sgT" = (
+/obj/structure/disposalpipe/segment/corner,
+/turf/open/floor/plating/catwalk,
+/area/lv624/ground/sand9)
+"sha" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"shc" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"shd" = (
+/obj/item/clothing/under/shorts/red,
+/obj/structure/rack,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"shQ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"siz" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"siD" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/beach{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"siE" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/ground/jungle2)
+"siR" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"sjf" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/caves/rock)
+"sjE" = (
+/obj/structure/barricade/metal{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"sjS" = (
+/obj/structure/rack,
+/obj/item/storage/box/handcuffs,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"skB" = (
+/obj/structure/fence,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"skP" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"sli" = (
+/turf/closed/wall,
+/area/lv624/lazarus/research)
+"slO" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"smF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/machinery/computer3/server/rack,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"snc" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"snx" = (
+/obj/structure/platform_decoration{
+	dir = 4
+	},
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"snU" = (
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/ground/river1)
+"snX" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"spi" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"sqQ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"sqZ" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/corporate_affairs)
+"srn" = (
+/turf/closed/wall,
+/area/lv624/ground/compound/c)
+"srN" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/structure/cable,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"srV" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass/grass2,
+/area/lv624/lazarus/overgrown)
+"ssf" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Storage Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/quartstorage)
+"ssj" = (
+/turf/open/floor/marking/bot,
+/area/lv624/ground/caves/central1/garbledradio)
+"sss" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"ssG" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"ssX" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"stb" = (
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"stz" = (
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"stJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"suc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/main_hall)
+"suh" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"sur" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/quartstorage/outdoors)
+"sus" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"suE" = (
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"suO" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"svF" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"svT" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"swa" = (
+/obj/item/frame/table/wood,
+/obj/structure/nuke_disk_candidate,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"swj" = (
+/obj/structure/barricade/wooden{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"swn" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"swU" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"swX" = (
+/obj/effect/landmark/patrol_point/tgmc_11,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 4
+	},
+/area/lv624/ground/jungle1)
+"sxe" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"sxj" = (
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/quartstorage)
+"sxB" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"sxP" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"syl" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river1)
+"syy" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/central5/garbledradio)
+"syT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"szz" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"szB" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"szS" = (
+/obj/structure/table/reinforced/prison,
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/item/reagent_containers/food/snacks/soup/beetsoup{
+	pixel_y = 11;
+	pixel_x = 3
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"sAa" = (
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/lazarus/engineering)
+"sAe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"sAh" = (
+/obj/structure/bed/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"sBf" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"sBr" = (
+/obj/machinery/door_control{
+	id = "corporate_blast";
+	name = "Dome Lockdown";
+	pixel_y = -25
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"sBS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"sBZ" = (
+/obj/structure/stairs/corner_seamless{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"sCq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"sDq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"sDu" = (
+/obj/item/tank/oxygen/yellow,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"sDE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"sDG" = (
+/obj/structure/bed,
+/obj/item/bedsheet/brown,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"sDR" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"sDU" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"sDX" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"sDZ" = (
+/turf/open/liquid/water/river,
+/area/lv624/ground/sand8)
+"sEq" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"sEU" = (
+/obj/structure/table,
+/obj/item/stack/medical/heal_pack/ointment,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/ground/filtration)
+"sFq" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"sFv" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"sFx" = (
+/obj/structure/rack,
+/obj/item/storage/holster/flarepouch/full,
+/obj/item/storage/holster/flarepouch/full,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"sFN" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport)
+"sGc" = (
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"sGg" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/item/ammo_casing,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"sGp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"sGt" = (
+/obj/item/stack/sheet/animalhide/xeno{
+	name = "Warrior hide"
+	},
+/obj/structure/table/mainship,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"sGJ" = (
+/obj/machinery/landinglight/lz2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"sGT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"sHg" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"sHh" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/armory)
+"sHr" = (
+/turf/closed/wall,
+/area/lv624/ground/jungle9)
+"sHG" = (
+/obj/structure/bed/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"sHK" = (
+/obj/structure/table/reinforced/prison,
+/obj/structure/table/reinforced/prison,
+/obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/item/reagent_containers/food/snacks/soup/bisque{
+	pixel_x = -2;
+	pixel_y = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 4
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"sIg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"sIp" = (
+/obj/structure/rack,
+/obj/item/tool/multitool,
+/obj/item/tool/multitool,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"sIx" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"sJm" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/patrol_point/tgmc_11,
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/jungle5)
+"sJq" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/chapel{
+	dir = 4
+	},
+/area/lv624/lazarus/chapel)
+"sJV" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"sKK" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"sKM" = (
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"sLi" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"sLq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"sLs" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle4)
+"sLz" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/medical/heal_pack/bruteweighted,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"sLG" = (
+/obj/machinery/door/poddoor/mainship{
+	dir = 2;
+	id = "science_blast";
+	name = "\improper Science Wing Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/research/locked/free_access{
+	dir = 1;
+	name = "\improper Research Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"sLQ" = (
+/obj/structure/bed/chair/sofa/corsat/right,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"sMe" = (
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"sMt" = (
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"sMB" = (
+/turf/closed/wall,
+/area/lv624/ground/jungle3)
+"sMI" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"sMY" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "\improper Nexus Dome"
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"sNd" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage)
+"sNu" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 8
+	},
+/area/shuttle/drop1/lz1)
+"sNP" = (
+/obj/item/stack/sheet/wood{
+	amount = 50
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"sOf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/burger,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"sOz" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/table,
+/obj/item/toy/deck,
+/obj/effect/spawner/random/misc/cigarettes,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"sOB" = (
+/turf/closed/mineral/smooth,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"sOP" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"sPe" = (
+/obj/structure/table/mainship,
+/obj/item/weapon/twohanded/spear,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"sPn" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 16
+	},
+/obj/structure/largecrate/supply/medicine/medkits,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"sPp" = (
+/obj/item/tool/weldpack,
+/obj/item/tool/weldingtool/largetank,
+/obj/structure/table,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 5
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"sPU" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/security)
+"sPZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/machinery/floodlight/landing,
+/obj/machinery/power/apc/hyper{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"sQl" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/fitness)
+"sQD" = (
+/turf/open/floor/engine/cult,
+/area/lv624/lazarus/bar)
+"sRg" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"sRp" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"sRZ" = (
+/turf/open/ground/coast/corner2,
+/area/lv624/ground/jungle9)
+"sSe" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/corporate_affairs)
+"sTa" = (
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
+"sTe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"sTg" = (
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"sTo" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Storage Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/vault,
+/area/lv624/lazarus/quartstorage)
+"sTy" = (
+/obj/effect/spawner/random/engineering/shovel,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"sTE" = (
+/obj/structure/catwalk,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"sTH" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"sTX" = (
+/obj/structure/foamedmetal,
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"sUx" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"sUA" = (
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"sUC" = (
+/obj/structure/girder/displaced,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"sUI" = (
+/obj/structure/largecrate/supply/ammo/standard_smg,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"sUR" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"sVf" = (
+/obj/effect/spawner/random/misc/structure/closet/welding,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"sVB" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport)
+"sVF" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"sVW" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"sWf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"sWE" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
+"sWN" = (
+/obj/machinery/floodlight,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"sXh" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"sXi" = (
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"sXv" = (
+/obj/item/weapon/sword/machete,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"sXD" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"sXL" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall/chigusa,
+/area/mainship/patrol_base/som)
+"sYv" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"sYH" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"sYL" = (
+/obj/structure/table,
+/obj/item/radio/survivor,
+/obj/item/tool/crowbar,
+/obj/machinery/light,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"sYY" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"sZk" = (
+/obj/item/bananapeel,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"sZr" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"sZw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"sZL" = (
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 4
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"sZP" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"tai" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"taz" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"taJ" = (
+/obj/machinery/door/airlock/mainship/generic{
+	desc = "This strange temple is covered in runes. It looks extremely ancient.";
+	dir = 2;
+	name = "Strange Temple"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"tbg" = (
+/turf/open/floor/marking/warning/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport)
+"tbm" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"tbz" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/liquid/water/river,
+/area/lv624/ground/jungle9)
+"tbD" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"tbN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"tbO" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/canteen)
+"tcf" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"tcr" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/river2)
+"tcG" = (
+/obj/structure/table/mainship,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"tcK" = (
+/obj/structure/fence,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"tcX" = (
+/obj/structure/cable,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"tdi" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome Female Dormitories"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"tdl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/main_hall)
+"tdu" = (
+/obj/machinery/vending/som/uniform_supply,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"tdE" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"tdF" = (
+/obj/docking_port/stationary/crashmode,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"teC" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple)
+"teN" = (
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"teS" = (
+/obj/structure/benchpress,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"tfo" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand9)
+"tfv" = (
+/obj/structure/table/wood/gambling,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"tfy" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"tgB" = (
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"tgF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"tgQ" = (
+/obj/machinery/shower{
+	pixel_y = 16
+	},
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 5
+	},
+/turf/open/floor/plating/plating_catwalk,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"thd" = (
+/obj/structure/cargo_container/gorg{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand5)
+"tig" = (
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"tir" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"tiV" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"tjH" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"tjJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport2)
+"tjN" = (
+/obj/item/spacecash/c100,
+/obj/item/spacecash/c200{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"tjS" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"tku" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"tlb" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"tly" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"tlK" = (
+/obj/structure/table/wood,
+/obj/item/instrument/accordion,
+/obj/item/instrument/saxophone,
+/obj/item/clothing/mask/cigarette/pipe/cobpipe,
+/turf/open/floor/carpet/side{
+	dir = 10
+	},
+/area/lv624/lazarus/bar)
+"tma" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"tmi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mainship/silver{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"tmr" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"tmw" = (
+/obj/structure/closet/wardrobe,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"tmx" = (
+/obj/structure/flora/jungle/plantbot1/alien{
+	pixel_y = 18
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"tmX" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"tne" = (
+/obj/structure/closet/secure_closet/atmos_personal,
+/turf/open/floor/tile/dark/brown2{
+	dir = 4
+	},
+/area/lv624/lazarus/atmos)
+"tnJ" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/obj/item/weapon/gun/energy/lasgun/lasrifle/volkite/cope/predeployed,
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"tnM" = (
+/obj/structure/table,
+/obj/item/storage/belt/marine,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"tnP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"tou" = (
+/obj/structure/foamedmetal,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"tov" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle7)
+"toJ" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"toS" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/marking/warning{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport2)
+"toT" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 1
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"tpv" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"tpC" = (
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 8
+	},
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"tpH" = (
+/obj/structure/platform{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/secure_storage)
+"tpL" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"tpR" = (
+/obj/effect/spawner/random/misc/table_lighting,
+/obj/structure/table,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"tpU" = (
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/corporate_affairs)
+"tqi" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"tqk" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"tqA" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"trE" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"trL" = (
+/obj/structure/table,
+/obj/item/reagent_containers/spray/plantbgone{
+	pixel_x = 12
+	},
+/obj/item/reagent_containers/spray/plantbgone,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"tsa" = (
+/obj/structure/cable,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"tsn" = (
+/obj/item/ammo_casing,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"tsp" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"tss" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"tsK" = (
+/obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline,
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"tsM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"ttl" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage/dome)
+"tts" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
+"ttx" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"ttz" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"tuv" = (
+/obj/item/shard,
+/turf/closed/wall/sulaco,
+/area/lv624/ground/caves/central1/garbledradio)
+"tuU" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/item/stool,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"tuY" = (
+/obj/structure/powerloader_wreckage,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"tuZ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"tvl" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"tvH" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	name = "\improper Nexus Dome Canteen"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/canteen)
+"tvW" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle3)
+"twc" = (
+/obj/structure/stairs/seamless{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"twn" = (
+/turf/open/floor/prison/redfloor,
+/area/lv624/lazarus/sandtemple)
+"twt" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"twu" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"twQ" = (
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage/dome)
+"txY" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/engivend,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"tyC" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/patrol_point/som/som_11,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"tzH" = (
+/obj/structure/bed,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"tAh" = (
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport2)
+"tBm" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor,
+/area/lv624/ground/sand6)
+"tBu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/fence,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"tBZ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"tCg" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/obj/structure/sign/safety/hazard,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"tCn" = (
+/obj/structure/cargo_container/green{
+	dir = 4
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"tCs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mainship/generic,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"tCw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/internal_affairs)
+"tCx" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 9
+	},
+/area/lv624/lazarus/fitness)
+"tCQ" = (
+/obj/item/stack/sheet/wood,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"tCT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"tDj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"tDu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroidfloor,
+/area/shuttle/drop1/lz1)
+"tDA" = (
+/turf/open/floor/tile/white/warningstripe{
+	dir = 8
+	},
+/area/lv624/lazarus/fitness)
+"tDP" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"tEk" = (
+/obj/structure/sink{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/item/clothing/mask/facehugger/dead,
+/obj/effect/landmark/corpsespawner/scientist{
+	corpseshoes = /obj/item/clothing/shoes/black;
+	corpseuniform = /obj/item/clothing/under/colonist;
+	name = "Colonist Jan Horris"
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/research)
+"tEl" = (
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"tFe" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"tFR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"tGf" = (
+/obj/machinery/floodlight/landing,
+/obj/effect/turf_decal/warning_stripes,
+/obj/machinery/landinglight/lz2{
+	dir = 8
+	},
+/turf/open/floor/mech_bay_recharge_floor,
+/area/shuttle/drop2/lz2)
+"tGE" = (
+/obj/effect/decal/remains/xeno,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"tGG" = (
+/obj/effect/landmark/corpsespawner/doctor{
+	corpseback = null;
+	corpsegloves = /obj/item/clothing/gloves/latex;
+	name = "Colonist Mio Linno"
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"tGU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"tGW" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"tHc" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood/broken,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"tHm" = (
+/turf/closed/wall,
+/area/lv624/lazarus/main_hall)
+"tHG" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 26
+	},
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"tHS" = (
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
+"tIu" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"tIx" = (
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"tIH" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"tIL" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"tJt" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle5)
+"tJK" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/sw)
+"tKd" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"tKI" = (
+/obj/machinery/light/small,
+/turf/open/floor/marking/warning,
+/area/lv624/lazarus/spaceport)
+"tLc" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"tMp" = (
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/tile/dark/brown2{
+	dir = 9
+	},
+/area/lv624/lazarus/atmos)
+"tMr" = (
+/turf/open/floor/marking/warning/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/spaceport2)
+"tMQ" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/hydroponics/aux)
+"tMS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"tMU" = (
+/turf/open/floor/mainship/silver/corner{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"tMY" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"tNj" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/compound/n)
+"tNw" = (
+/obj/machinery/computer/intel_computer,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"tNJ" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"tOF" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"tOG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"tOY" = (
+/obj/structure/cable,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som)
+"tPa" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river3)
+"tPi" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Storage Dome"
+	},
+/turf/open/floor/vault,
+/area/lv624/lazarus/quartstorage)
+"tPj" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop2/lz2)
+"tPk" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"tPx" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/research)
+"tPy" = (
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow/corner,
+/area/lv624/lazarus/main_hall)
+"tQb" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"tQA" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"tQO" = (
+/obj/machinery/power/apc/drained{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"tQY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"tRe" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river3)
+"tRR" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/weapon/gun/launcher/rocket/oneuse,
+/obj/item/storage/holster/backholster/rpg/som,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"tRY" = (
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/corporate_affairs)
+"tSI" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Robotics Dome"
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"tSU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"tTD" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/wood,
+/area/lv624/ground/jungle8)
+"tUn" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"tUo" = (
+/turf/open/floor/tile/dark/brown2{
+	dir = 6
+	},
+/area/lv624/lazarus/atmos)
+"tUq" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"tUs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
+"tUw" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/sleep_male)
+"tUF" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/lazarus/spaceport)
+"tUV" = (
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"tVg" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"tVy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"tWj" = (
+/obj/structure/table,
+/obj/item/storage/backpack/marine,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"tWm" = (
+/turf/open/floor/marking/warning{
+	dir = 6
+	},
+/area/lv624/lazarus/spaceport2)
+"tWH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"tWV" = (
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/west1)
+"tXn" = (
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow,
+/area/lv624/lazarus/main_hall)
+"tXo" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"tXx" = (
+/obj/structure/bookcase,
+/obj/item/bananapeel,
+/obj/item/book/manual/research_and_development,
+/obj/item/book/manual/security_space_law,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"tXV" = (
+/obj/structure/cable,
+/obj/structure/largecrate/supply/generator,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/catwalk,
+/area/mainship/patrol_base/som)
+"tYq" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/atmos)
+"tYs" = (
+/obj/item/clothing/mask/facehugger/dead,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"tYA" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"tYB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"tYF" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"tZc" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/robotics)
+"tZl" = (
+/obj/structure/bed/chair/comfy/lime{
+	dir = 1
+	},
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"tZW" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/weaponry/explosive/plastiqueexplosive{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/effect/spawner/random/weaponry/explosive/plastiqueexplosive,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"uaf" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
+"ubp" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"ubL" = (
+/turf/closed/wall,
+/area/lv624/ground/jungle6)
+"ucq" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 5
+	},
+/area/lv624/lazarus/spaceport)
+"ucz" = (
+/obj/structure/closet/wardrobe/engineering_yellow,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"ucR" = (
+/turf/open/floor/scorched/two,
+/area/lv624/ground/sand6)
+"udq" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/machinery/door/poddoor/shutters/mainship{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"udO" = (
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/jungle4)
+"uef" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"uej" = (
+/obj/effect/decal/cleanable/blood,
+/obj/item/weapon/gun/smg/uzi,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"uem" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"uet" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"uex" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle10)
+"uez" = (
+/obj/effect/decal/cleanable/blood/oil,
+/obj/item/stack/sheet/metal{
+	amount = 30;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/structure/rack,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"ueG" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"ufl" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"ufA" = (
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"ugi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"ugj" = (
+/obj/structure/table,
+/obj/item/weapon/gun/pistol/highpower,
+/obj/item/ammo_magazine/pistol/highpower,
+/obj/item/ammo_magazine/pistol/highpower,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"ugn" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"ugK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"ugS" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"uhf" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"uhQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"uip" = (
+/obj/structure/stairs/seamless,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"uiB" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"uiE" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	name = "Armoury";
+	id = "clfarmoury"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"ujC" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"ujM" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"ujS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/canteen)
+"ukc" = (
+/obj/structure/barricade/plasteel,
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"uke" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport)
+"ukn" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Storage Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"ukv" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/landmark/patrol_point/som/som_11,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"ukC" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"ukS" = (
+/obj/structure/table/wood,
+/obj/item/pinpointer,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"ukV" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport)
+"uld" = (
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"uln" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/mainship/sterile/corner{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"ulw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"ulD" = (
+/turf/closed/wall,
+/area/lv624/ground/river2)
+"ulJ" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/marking/loadingarea{
+	dir = 4
+	},
+/area/lv624/lazarus/quartstorage)
+"ulT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"ums" = (
+/obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"umJ" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"une" = (
+/turf/open/floor/plating/icefloor/warnplate,
+/area/shuttle/drop1/lz1)
+"unj" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"unl" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/comms)
+"unX" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"uox" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"uoF" = (
+/obj/structure/catwalk,
+/turf/open/ground/grass/beach,
+/area/lv624/ground/jungle9)
+"uoN" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"uoU" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle6)
+"uoZ" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/spawner/random/clothing/sunglasses{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"upB" = (
+/turf/open/floor/plating,
+/area/lv624/ground/sand7)
+"upL" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/lv624/ground/sand4)
+"uqG" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 5
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"uqP" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"urw" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/bed/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"urI" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand3)
+"urK" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"urX" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"usq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"usC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"usN" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/mining/brace,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"ute" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"utr" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"uud" = (
+/obj/structure/table/reinforced/flipped,
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"uui" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"uus" = (
+/obj/machinery/mineral/processing_unit,
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"uuT" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"uuX" = (
+/obj/structure/table,
+/obj/item/trash/plate,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"uvC" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder2/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/quartstorage/outdoors)
+"uvD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"uvO" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 8
+	},
+/area/lv624/ground/caves/central1/garbledradio)
+"uwF" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/flora/pottedplant/twelve,
+/turf/open/floor/mainship/silver{
+	dir = 3
+	},
+/area/mainship/patrol_base/som)
+"uwP" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"uxi" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"uyx" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/caves/central1/garbledradio)
+"uyH" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"uzq" = (
+/obj/structure/window/reinforced,
+/obj/structure/largecrate/supply/supplies/flares,
+/obj/machinery/light,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"uzr" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"uzw" = (
+/turf/open/floor/tile/chapel{
+	dir = 4
+	},
+/area/lv624/lazarus/chapel)
+"uzY" = (
+/obj/effect/landmark/patrol_point/som/som_11,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"uAo" = (
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"uAB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8;
+	on = 1
+	},
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"uAM" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/sign/botany,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"uAR" = (
+/obj/structure/bed/alien,
+/obj/item/bedsheet/blue,
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"uBl" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"uBV" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"uBY" = (
+/obj/item/stool,
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"uCa" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor,
+/area/lv624/ground/jungle6)
+"uCM" = (
+/obj/machinery/door/airlock/mainship/research/free_access{
+	name = "\improper Research Dome"
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"uCR" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"uDM" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"uDU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Auxillary Hydroponics Dome"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/hydroponics/aux)
+"uEa" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle2)
+"uEe" = (
+/obj/structure/closet,
+/obj/item/tool/crowbar,
+/obj/item/clothing/gloves/insulated,
+/obj/item/stack/medical/heal_pack/advanced/bruise_pack,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/tool/crowbar,
+/obj/item/clothing/gloves/yellow,
+/obj/effect/spawner/random/medical/heal_pack/bruteweighted,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"uEn" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	dir = 1;
+	name = "\improper Hydroponics Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"uEr" = (
+/obj/effect/decal/remains/human,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"uFd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"uFl" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/obj/effect/ai_node,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"uFu" = (
+/obj/structure/table/reinforced/prison,
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/item/reagent_containers/food/snacks/soup/cheesy_porridge{
+	pixel_y = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 10
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"uFy" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"uFK" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"uFX" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"uGs" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"uGC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille/smoothing,
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/ground/river2)
+"uHg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"uHk" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"uHH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"uHJ" = (
+/obj/machinery/floodlight,
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/tablefort)
+"uHT" = (
+/obj/structure/rack,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"uIf" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/tool/taperoll/engineering,
+/obj/item/tool/taperoll/engineering,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"uIh" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/item/ammo_casing,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"uIj" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"uIl" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"uIo" = (
+/obj/item/stool,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"uIC" = (
+/obj/structure/kitchenspike,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/kitchen)
+"uIM" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"uIN" = (
+/turf/open/floor/plating,
+/area/lv624/ground/caves/central1/garbledradio)
+"uIT" = (
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"uIX" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"uJz" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"uJG" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/structure/barricade/wooden,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"uJK" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor,
+/area/lv624/ground/caves/central1/garbledradio)
+"uJN" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"uJU" = (
+/obj/structure/bed,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"uKm" = (
+/obj/structure/closet,
+/obj/item/clothing/shoes/laceup,
+/obj/effect/spawner/random/medical/heal_pack/bruteweighted,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"uKn" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"uLq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/robotics)
+"uLP" = (
+/obj/item/stool,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"uMw" = (
+/obj/structure/bed/chair/wood/wings,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"uMz" = (
+/obj/item/spacecash/c100,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"uMC" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"uMM" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"uNd" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"uNx" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"uOf" = (
+/obj/structure/flora/grass/brown,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"uOv" = (
+/obj/item/stack/sheet/metal,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"uOR" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/chapel,
+/area/lv624/lazarus/chapel)
+"uOU" = (
+/obj/machinery/vending/marineFood/som,
+/turf/open/floor/mainship/purple{
+	dir = 10
+	},
+/area/mainship/patrol_base/som)
+"uOZ" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle2)
+"uPd" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"uPO" = (
+/obj/effect/landmark/corpsespawner/security{
+	corpsesuit = /obj/item/clothing/suit/storage/CMB;
+	corpseuniform = /obj/item/clothing/under/CM_uniform;
+	name = "Deputy Edgar Nogi"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/crashed_ship)
+"uPS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"uPU" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/compound/c)
+"uQd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/obj/structure/sign/electricshock,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"uQl" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle5)
+"uQx" = (
+/turf/closed/wall/r_wall,
+/area/lv624/ground/jungle3)
+"uQU" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"uRd" = (
+/obj/item/stool,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/robotics)
+"uRe" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"uRo" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/compound/n)
+"uRr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"uRG" = (
+/turf/open/floor/tile/green/whitegreencorner{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"uRH" = (
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport)
+"uSd" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"uSi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"uTf" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/hydroponics/aux)
+"uTD" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"uTK" = (
+/turf/closed/mineral/smooth,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"uUk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"uUu" = (
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"uUV" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
+"uVg" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/jungle5)
+"uVB" = (
+/obj/machinery/floodlight,
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/lazarus/tablefort)
+"uVC" = (
+/obj/structure/table,
+/obj/item/trash/candy,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"uVQ" = (
+/obj/structure/cargo_container/red{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"uWc" = (
+/obj/structure/bed/chair/office/dark,
+/obj/effect/ai_node,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"uWw" = (
+/obj/structure/table/wood/gambling,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"uWE" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"uWY" = (
+/obj/structure/computerframe,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"uXa" = (
+/obj/item/folder/red,
+/obj/effect/ai_node,
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
+"uXo" = (
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"uXx" = (
+/obj/structure/foamedmetal,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"uYg" = (
+/obj/structure/table,
+/obj/structure/mirror{
+	dir = 1;
+	pixel_y = -14
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"uYk" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"uYl" = (
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"uYH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"uYJ" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 9
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"uZi" = (
+/obj/machinery/power/apc,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe,
+/area/lv624/lazarus/security)
+"uZt" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"uZT" = (
+/obj/machinery/door/airlock/mainship/research/free_access{
+	name = "\improper Research Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"vad" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"vbI" = (
+/obj/structure/sign/safety/hazard,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/spaceport)
+"vbL" = (
+/obj/structure/cryofeed,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/lv624/lazarus/atmos)
+"vbN" = (
+/turf/closed/wall/wood,
+/area/lv624/lazarus/bar)
+"vbO" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle1)
+"vbU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/rock)
+"vcu" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"vcL" = (
+/turf/open/floor/mainship/silver{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"vcW" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"vdn" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 2;
+	name = "\improper Cargo Shutters";
+	id = "somcargodoor"
+	},
+/turf/open/floor,
+/area/mainship/patrol_base/som)
+"vdo" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"vdv" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"vdR" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"vdS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle3)
+"veC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"veE" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"vfn" = (
+/obj/structure/flora/bush,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"vfI" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"vfN" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"vfS" = (
+/obj/machinery/button/door/open_only/landing_zone{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport)
+"vfT" = (
+/obj/effect/decal/remains/human,
+/obj/item/ammo_casing,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"vga" = (
+/obj/structure/bed/alien{
+	color = "#aba9a9"
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"vhK" = (
+/turf/open/ground/grass,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"vhN" = (
+/obj/machinery/smartfridge/seeds,
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"vhT" = (
+/obj/effect/landmark/corpsespawner/colonist,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"vhY" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"vic" = (
+/turf/open/floor/plating/dmg3,
+/area/lv624/ground/river1)
+"viw" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/river2)
+"viE" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand2)
+"vjF" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"vjK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"vjO" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"vjX" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"vkh" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"vku" = (
+/turf/open/floor/cult,
+/area/lv624/lazarus/bar)
+"vkI" = (
+/obj/structure/table,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 10
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"vla" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 6
+	},
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"vlD" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"vml" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river2)
+"vmn" = (
+/obj/structure/rack,
+/obj/item/attachable/lasersight,
+/obj/item/attachable/lasersight,
+/obj/item/attachable/lasersight,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/attachable/suppressor,
+/obj/item/attachable/suppressor,
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/secure_storage)
+"vmp" = (
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"vmD" = (
+/obj/machinery/landinglight/lz1{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"vmV" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"vnB" = (
+/obj/item/cell,
+/obj/item/cell,
+/obj/item/cell,
+/obj/structure/closet/crate/construction,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge/regular{
+	dir = 10
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"vnD" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle10)
+"vnI" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/prison/redfloor,
+/area/lv624/lazarus/sandtemple)
+"vnX" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/spaceport)
+"voq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"voL" = (
+/obj/structure/table,
+/obj/item/tool/shovel/spade,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"voY" = (
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 9
+	},
+/area/lv624/lazarus/engineering)
+"vpo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating,
+/area/lv624/ground/river1)
+"vpA" = (
+/obj/effect/spawner/random/engineering/ore_box,
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"vpF" = (
+/obj/structure/cable,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"vpM" = (
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage/outdoors)
+"vpW" = (
+/turf/open/floor/plating/dmg1,
+/area/lv624/ground/river1)
+"vql" = (
+/obj/structure/table,
+/obj/item/book/manual/research_and_development,
+/obj/effect/spawner/random/engineering/powercell,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"vqo" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"vqu" = (
+/obj/structure/window/framed/colony,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/ground/filtration)
+"vqE" = (
+/obj/structure/table,
+/obj/item/ashtray/glass,
+/obj/item/tool/crowbar,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"vqS" = (
+/obj/structure/table/wood,
+/obj/item/megaphone,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"vre" = (
+/obj/structure/bed/chair{
+	dir = 8
+	},
+/turf/open/floor/marking/asteroidwarning{
+	dir = 4
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"vrg" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/window/framed/colony,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/filtration)
+"vrn" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/ruin)
+"vrJ" = (
+/obj/effect/landmark/corpsespawner/bridgeofficer{
+	corpseidjob = "Bridge Officer";
+	corpseuniform = /obj/item/clothing/under/waiter;
+	name = "Mr. Johnson Telovin"
+	},
+/obj/item/tool/crowbar,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"vrU" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating/catwalk,
+/area/mainship/patrol_base/som)
+"vrX" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/corner{
+	dir = 8
+	},
+/area/lv624/ground/jungle5)
+"vsJ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"vsQ" = (
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/quartstorage/outdoors)
+"vtw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"vuc" = (
+/turf/open/floor/marking/warning/corner,
+/area/lv624/lazarus/spaceport2)
+"vui" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass,
+/area/lv624/lazarus/sleep_male)
+"vuP" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/hydroponics/aux)
+"vuT" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"vwz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/marking/loadingarea{
+	dir = 1
+	},
+/area/lv624/lazarus/quartstorage)
+"vwN" = (
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"vwQ" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"vwY" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 4
+	},
+/area/lv624/lazarus/security)
+"vxv" = (
+/obj/machinery/prop/autolathe,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"vxx" = (
+/obj/item/ammo_magazine/smg/uzi/extended,
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"vxN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"vxT" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/closed/mineral/smooth/indestructible,
+/area/storage/testroom)
+"vxU" = (
+/obj/structure/barricade/metal{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"vxV" = (
+/obj/structure/cable,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"vyk" = (
+/obj/structure/rack,
+/obj/item/storage/pill_bottle/tramadol,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"vyx" = (
+/obj/structure/largecrate/supply/supplies/metal,
+/obj/structure/largecrate/supply/supplies/plasteel{
+	pixel_y = 17;
+	pixel_x = -1
+	},
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"vyG" = (
+/obj/machinery/landinglight/lz2,
+/turf/open/floor/plating,
+/area/shuttle/drop2/lz2)
+"vyP" = (
+/turf/open/floor/plating/ground/dirtgrassborder,
+/area/lv624/ground/jungle5)
+"vyT" = (
+/obj/structure/cargo_container/nt{
+	dir = 4
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"vzu" = (
+/obj/effect/decal/remains/xeno{
+	pixel_x = 1;
+	pixel_y = -31
+	},
+/obj/structure/showcase,
+/obj/effect/turf_decal/sandytile,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"vzy" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"vzF" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"vzQ" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"vzU" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"vzV" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"vAh" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river1)
+"vAX" = (
+/obj/item/target,
+/obj/structure/target_stake,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/security)
+"vBo" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"vBC" = (
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/jungle6)
+"vBY" = (
+/obj/effect/turf_decal/siding/wideplating_new/dark/corner,
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 9
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"vCx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"vCY" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"vDH" = (
+/obj/machinery/light/small,
+/obj/structure/cable,
+/turf/open/floor/tile/red/redtaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/security)
+"vDL" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/tablefort)
+"vDV" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"vEl" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_x = -28
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"vEu" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"vEv" = (
+/obj/machinery/door/window{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"vEw" = (
+/obj/item/stack/sheet/mineral/sandstone{
+	amount = 50
+	},
+/obj/structure/table/mainship,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"vEx" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle3)
+"vEA" = (
+/obj/structure/table,
+/obj/item/explosive/grenade/chem_grenade/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/structure/mirror{
+	dir = 8
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"vEC" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"vEF" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"vEO" = (
+/obj/item/clothing/head/hardhat/orange,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"vEV" = (
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 8
+	},
+/area/lv624/ground/jungle1)
+"vEW" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle8)
+"vFe" = (
+/turf/closed/wall,
+/area/lv624/lazarus/chapel)
+"vFn" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 5
+	},
+/area/lv624/lazarus/main_hall)
+"vFH" = (
+/obj/structure/cargo_container/nt,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"vGi" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"vGx" = (
+/obj/effect/landmark/start/latejoinclf,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"vGz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"vGK" = (
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"vHr" = (
+/obj/item/reagent_containers/food/snacks/donkpocket,
+/obj/structure/flora/pottedplant,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"vHv" = (
+/obj/structure/flora/grass/green,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"vIq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"vIM" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"vJd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4;
+	on = 1
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"vJh" = (
+/obj/effect/turf_decal/tile/transparent/dark_green/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/transparent/dark_green,
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"vJs" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/table/reinforced/flipped,
+/obj/item/ammo_casing,
+/obj/effect/spawner/random/weaponry/ammo/machinegun,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"vJw" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/marking/loadingarea{
+	dir = 1
+	},
+/area/lv624/ground/sand2)
+"vJU" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/wood{
+	amount = 50
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"vKE" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/open/ground/coast,
+/area/lv624/ground/river3)
+"vKF" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"vKW" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle9)
+"vLP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"vMy" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	dir = 1;
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"vMH" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"vMK" = (
+/obj/structure/barricade/metal{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle5)
+"vMW" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"vNj" = (
+/turf/open/floor/tile/neutral,
+/area/lv624/lazarus/spaceport)
+"vNt" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"vNw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/bar)
+"vNW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/c)
+"vOd" = (
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 8
+	},
+/obj/structure/largecrate/supply/supplies/mre,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 10
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"vOe" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/internal_affairs)
+"vOr" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/overgrown)
+"vOu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/se)
+"vOx" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"vOG" = (
+/obj/structure/bed/chair/wood/wings{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"vPa" = (
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"vPd" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"vPR" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Robotics Dome"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/robotics)
+"vPV" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"vQi" = (
+/turf/open/floor/grimy,
+/area/lv624/lazarus/captain)
+"vQk" = (
+/obj/structure/cable,
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
+"vQm" = (
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"vQp" = (
+/obj/structure/table,
+/obj/item/tool/minihoe,
+/obj/item/tool/shovel,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 4
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"vQS" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/engineering)
+"vRk" = (
+/turf/open/floor/mainship/sterile/white,
+/area/mainship/patrol_base/som)
+"vRv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"vSq" = (
+/obj/effect/spawner/random/engineering/metal,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"vSs" = (
+/obj/structure/largecrate/supply/supplies/flares,
+/turf/open/floor/mainship/cargo,
+/area/mainship/patrol_base/som)
+"vSG" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"vTc" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/docking_port/stationary/crashmode,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"vTn" = (
+/obj/item/trash/raisins,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"vTo" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
+"vTA" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"vTX" = (
+/turf/closed/wall,
+/area/lv624/lazarus/kitchen)
+"vUk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"vVO" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"vWq" = (
+/obj/structure/catwalk,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river1)
+"vWu" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"vWI" = (
+/obj/structure/largecrate/random/case,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"vXe" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"vXh" = (
+/turf/closed/wall/r_wall,
+/area/lv624/ground/sand5)
+"vXz" = (
+/obj/structure/extinguisher_cabinet,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"vYc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"vYg" = (
+/obj/structure/table,
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"vYj" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"vYo" = (
+/obj/structure/disposalpipe/segment/corner{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"vYt" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner,
+/area/lv624/ground/jungle5)
+"vZW" = (
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"waB" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"waL" = (
+/obj/item/tool/minihoe,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"wbd" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"wbk" = (
+/turf/open/floor/marking/warning,
+/area/lv624/lazarus/spaceport)
+"wbp" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"wbv" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/engine/cult,
+/area/lv624/ground/caves/east1/garbledradio)
+"wbS" = (
+/turf/closed/wall/brick,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"wcw" = (
+/obj/effect/ai_node,
+/turf/open/floor/mainship/plate,
+/area/mainship/patrol_base/som{
+	requires_power = 1
+	})
+"wcR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"wdb" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/drinkingglass{
+	pixel_y = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"wdh" = (
+/obj/item/stack/sheet/wood,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/whitegreen,
+/area/lv624/lazarus/main_hall)
+"wdi" = (
+/obj/structure/cable,
+/obj/structure/table,
+/obj/item/armor_module/module/welding,
+/obj/item/armor_module/module/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
+/obj/machinery/power/apc/hyper,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside/regular{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"wdB" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/shard,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"wdQ" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"wep" = (
+/obj/structure/bed/chair/sofa/corsat/left,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"weO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/cable,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"weT" = (
+/obj/structure/table/mainship,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/sandtemple)
+"wfy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/engineering)
+"wfJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"wfL" = (
+/obj/structure/bed/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"wgm" = (
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1/garbledradio)
+"wgu" = (
+/obj/structure/bed/chair,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wgE" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"wgH" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/hallway/primary/tram{
+	name = "CLF primary hallway";
+	outside = 0;
+	ceiling = 6
+	})
+"wgX" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"whW" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5/garbledradio)
+"wid" = (
+/obj/item/tank/oxygen/yellow,
+/turf/open/floor/plating,
+/area/lv624/lazarus/crashed_ship)
+"wim" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle9)
+"wiy" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"wiR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/internal_affairs)
+"wjm" = (
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	name = "\improper Research Dome"
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/research)
+"wjA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/indestructible,
+/area/lv624/ground/caves/rock)
+"wka" = (
+/obj/machinery/light/small,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"wkd" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"wkx" = (
+/obj/item/spacecash/c100,
+/obj/item/spacecash/c200{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"wkF" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/grille/smoothing,
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning{
+	dir = 5
+	},
+/area/lv624/ground/river2)
+"wkI" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"wlq" = (
+/obj/structure/fence,
+/turf/open/floor/marking/warning{
+	dir = 8
+	},
+/area/lv624/ground/sand5)
+"wls" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/table/wood/gambling,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"wlV" = (
+/obj/effect/landmark/weed_node,
+/obj/item/stack/sheet/wood,
+/turf/open/floor/marking/bot,
+/area/lv624/ground/sand5)
+"wmc" = (
+/obj/structure/table,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"wme" = (
+/obj/machinery/landinglight/lz1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/drop1/lz1)
+"wmm" = (
+/turf/closed/mineral/smooth/indestructible,
+/area/lv624/ground/caves/rock)
+"wmr" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"wmP" = (
+/turf/open/floor/plating,
+/area/lv624/ground/sand5)
+"wmQ" = (
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"wmW" = (
+/obj/structure/largecrate/supply/supplies/tables_racks,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"wno" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"wnB" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"wnI" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/filtration)
+"wol" = (
+/obj/effect/ai_node,
+/turf/open/floor/wood,
+/area/lv624/ground/jungle8{
+	outside = 0
+	})
+"woy" = (
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/twoside/regular{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"wpu" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"wpv" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_x = -28
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"wpD" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"wpF" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"wpT" = (
+/obj/structure/curtain/temple{
+	dir = 4
+	},
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"wqm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/deep,
+/area/lv624/ground/river2)
+"wqz" = (
+/obj/structure/sign/redcross{
+	dir = 4
+	},
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"wqC" = (
+/turf/closed/wall,
+/area/lv624/lazarus/quartstorage)
+"wrb" = (
+/obj/structure/cargo_container/green{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand2)
+"wri" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/machinery/random_broken_computer/crewmonitor,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"wrx" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/botanic_leather,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"wrO" = (
+/obj/effect/spawner/random/misc/structure/supplycrate,
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"wrP" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"wrY" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"wsk" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"wsK" = (
+/obj/structure/flora/ausbushes/fernybush,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"wsT" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/colaweighted,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wsY" = (
+/obj/machinery/camera/autoname/lz_camera,
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 4
+	},
+/area/shuttle/drop1/lz1)
+"wsZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"wtg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 6
+	},
+/area/lv624/ground/jungle5)
+"wtk" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"wtF" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle1)
+"wtX" = (
+/obj/effect/spawner/random/weaponry/melee,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"wuo" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	dir = 2;
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/canteen)
+"wuT" = (
+/obj/effect/spawner/random/engineering/tool,
+/turf/open/floor/marking/warning/corner{
+	dir = 8
+	},
+/area/lv624/lazarus/spaceport)
+"wvb" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"wvf" = (
+/obj/structure/rack,
+/obj/item/clothing/under/colonist/webbing,
+/obj/item/clothing/under/colonist/webbing,
+/obj/item/clothing/under/colonist/webbing,
+/obj/item/clothing/under/colonist/webbing,
+/turf/open/floor/plating/asteroidfloor,
+/area/outpost/brig/gear_room{
+	name = "CLF armoury"
+	})
+"wvo" = (
+/obj/structure/table,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"wvT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"wvV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"wwo" = (
+/obj/structure/window/framed/colony/reinforced,
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/internal_affairs)
+"wwN" = (
+/turf/closed/gm/dense,
+/area/lv624/ground/jungle10)
+"wxb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"wxf" = (
+/obj/structure/catwalk,
+/obj/effect/landmark/weed_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"wxw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/internal_affairs)
+"wxA" = (
+/obj/structure/table,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"wxD" = (
+/obj/effect/landmark/xeno_resin_wall,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"wxL" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/ground/river2)
+"wxM" = (
+/obj/effect/landmark/patrol_point/tgmc_11,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 4
+	},
+/area/lv624/ground/jungle1)
+"wyh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"wyo" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"wyW" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"wzM" = (
+/obj/structure/cable,
+/turf/open/floor/tile/chapel{
+	dir = 8
+	},
+/area/lv624/lazarus/chapel)
+"wAb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"wAp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/warning_stripes/thick,
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 1
+	},
+/obj/machinery/hydroponics,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"wBo" = (
+/obj/structure/catwalk,
+/turf/open/liquid/water/river,
+/area/lv624/ground/river2)
+"wBp" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/lazarus/overgrown)
+"wCm" = (
+/obj/item/tool/shovel/spade,
+/turf/open/floor/engine,
+/area/lv624/lazarus/hydroponics/aux)
+"wCM" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	dir = 1;
+	name = "Corporate Dome"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"wCT" = (
+/turf/open/floor,
+/area/lv624/ground/river2)
+"wDe" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"wDG" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/river2)
+"wDV" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"wEs" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"wEB" = (
+/obj/structure/table,
+/obj/item/alien_embryo{
+	pixel_y = 4
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"wEQ" = (
+/obj/item/trash/cigbutt,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"wFh" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
+"wFr" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle8)
+"wFT" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central5)
+"wGf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"wGo" = (
+/obj/structure/girder/displaced,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"wGz" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"wGK" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand4)
+"wGN" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/sign/redcross{
+	dir = 4
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"wHd" = (
+/obj/item/tool/crowbar,
+/turf/open/floor/marking/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/spaceport)
+"wHe" = (
+/obj/item/storage/box/beakers,
+/obj/structure/table,
+/obj/structure/sign/biohazard{
+	dir = 8
+	},
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"wHg" = (
+/obj/structure/bed/chair/east{
+	dir = 2
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"wHn" = (
+/obj/structure/rack,
+/obj/machinery/light,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"wHz" = (
+/obj/structure/fence,
+/turf/open/floor/marking/warning,
+/area/lv624/ground/sand2)
+"wIa" = (
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/orange{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"wId" = (
+/obj/structure/flora/pottedplant,
+/obj/machinery/light/spot{
+	dir = 1
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wIg" = (
+/obj/item/trash/cheesie,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/captain)
+"wJe" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 4
+	},
+/area/lv624/ground/sand5)
+"wJf" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"wJm" = (
+/obj/structure/table,
+/obj/structure/cable,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"wJp" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"wJH" = (
+/turf/closed/wall,
+/area/lv624/ground/sand2)
+"wJU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/lv624/ground/filtration)
+"wJV" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/internal_affairs)
+"wJX" = (
+/obj/machinery/power/apc/drained,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"wKM" = (
+/obj/item/tool/kitchen/utensil/fork{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/structure/table/mainship,
+/obj/structure/flora/jungle/vines,
+/obj/item/reagent_containers/food/snacks/pastries/xemeatpie,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"wKT" = (
+/obj/machinery/autodoc,
+/turf/open/floor/mainship/sterile/corner{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"wMs" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"wMv" = (
+/obj/structure/stairs/seamless{
+	dir = 1
+	},
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"wMw" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/sleep_male)
+"wMD" = (
+/obj/machinery/door/poddoor/mainship/open{
+	name = "\improper Forced Blast Door"
+	},
+/obj/machinery/door/airlock/mainship/research/open/free_access{
+	name = "\improper Research Dome"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"wMZ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/yellow,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"wNN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating/catwalk,
+/area/mainship/patrol_base/som)
+"wOj" = (
+/turf/open/floor/plating,
+/area/lv624/lazarus/kitchen)
+"wOy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"wOR" = (
+/turf/open/floor/tile/green/whitegreen{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"wPp" = (
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"wQo" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"wRd" = (
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/sleep_female)
+"wRg" = (
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"wRi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/mainship/orange,
+/area/mainship/patrol_base/som)
+"wRA" = (
+/obj/structure/rack,
+/obj/item/clothing/head/soft/grey,
+/obj/item/clothing/head/soft/grey,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"wRH" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"wRQ" = (
+/obj/item/trash/cheesie,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wSb" = (
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/item/ammo_casing,
+/obj/item/attachable/flashlight,
+/obj/structure/cable,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wSQ" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/dark_blue,
+/obj/effect/ai_node,
+/turf/open/floor/plating/asteroidwarning/down,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"wTq" = (
+/obj/structure/catwalk,
+/turf/open/ground/grass/beach{
+	dir = 8
+	},
+/area/lv624/ground/jungle9)
+"wTu" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/obj/effect/spawner/random/misc/structure/flavorvending/cigaretteweighted/colony,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wTw" = (
+/obj/machinery/mineral/unloading_machine,
+/turf/open/floor/plating/platebotc,
+/area/lv624/ground/caves/central1/garbledradio)
+"wTG" = (
+/obj/effect/spawner/random/engineering/structure/tank/fuelweighted,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"wTO" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand3)
+"wUu" = (
+/obj/structure/bed/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/cult/clock,
+/area/lv624/lazarus/bar)
+"wUC" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"wUE" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2/garbledradio)
+"wUV" = (
+/obj/effect/decal/remains/xeno,
+/obj/effect/turf_decal/sandytile,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"wVc" = (
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"wVo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"wWM" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
+"wXx" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"wXy" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"wYe" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone{
+	dir = 2
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"wYU" = (
+/obj/machinery/light/small,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"wZl" = (
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"wZu" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_ccw,
+/obj/effect/turf_decal/trimline/dark_blue/filled/shrink_cw{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/asteroidfloor,
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"xaO" = (
+/obj/item/spacecash/c500{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"xaY" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/sand9)
+"xbe" = (
+/obj/structure/fence,
+/obj/effect/turf_decal/riverdecal/edge{
+	dir = 8
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"xbo" = (
+/obj/docking_port/stationary/crashmode,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/lv624/ground/filtration)
+"xbs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"xbC" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal{
+	amount = 30;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"xbG" = (
+/obj/structure/sign/redcross{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/compound/n)
+"xbH" = (
+/obj/machinery/power/geothermal,
+/obj/structure/lattice,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
+"xcc" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"xcl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/ai_node,
+/turf/open/floor/wood/broken,
+/area/lv624/lazarus/bar)
+"xcY" = (
+/obj/structure/flora/jungle/planttop1,
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"xdo" = (
+/obj/effect/landmark/corpsespawner/miner{
+	corpseback = /obj/item/storage/backpack;
+	corpseidjob = "Laborer";
+	name = "Colonist Roester Kalin"
+	},
+/turf/open/floor/tile/red/yellowfull,
+/area/lv624/ground/sand4)
+"xdD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/sand8)
+"xdL" = (
+/obj/structure/bed/chair/east{
+	dir = 2
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"xdN" = (
+/obj/structure/window_frame/colony,
+/obj/item/shard,
+/turf/open/floor/plating,
+/area/lv624/lazarus/overgrown)
+"xdW" = (
+/obj/structure/bookcase,
+/obj/item/book/manual/chef_recipes,
+/obj/item/book/manual/nuclear,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"xep" = (
+/obj/structure/table,
+/obj/item/trash/cheesie,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"xeR" = (
+/obj/machinery/door/window{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"xeU" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"xfe" = (
+/obj/effect/ai_node,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle4)
+"xfx" = (
+/obj/machinery/vending/weapon/som,
+/turf/open/floor/mainship/orange{
+	dir = 4
+	},
+/area/mainship/patrol_base/som)
+"xfA" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"xfM" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/corporate_affairs)
+"xga" = (
+/obj/structure/disposalpipe/junction/flipped{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"xgc" = (
+/obj/machinery/light,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"xgx" = (
+/turf/closed/wall/r_wall,
+/area/lv624/ground/jungle2)
+"xgA" = (
+/obj/machinery/power/apc/drained{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/freezer,
+/area/lv624/lazarus/toilet)
+"xgU" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"xgW" = (
+/obj/machinery/floodlight/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"xhy" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"xhz" = (
+/obj/item/ammo_casing,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/tablefort)
+"xhS" = (
+/obj/structure/showcase,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced/windowstake{
+	dir = 4
+	},
+/obj/structure/window/reinforced/windowstake{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"xii" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle6)
+"xiw" = (
+/obj/machinery/floodlight/colony,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle10)
+"xiy" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/fence,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"xiz" = (
+/obj/machinery/newscaster,
+/turf/closed/wall,
+/area/lv624/lazarus/corporate_affairs)
+"xiC" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 9
+	},
+/turf/open/floor/tile/green/whitegreen{
+	dir = 8
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"xjf" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Leisure Dome"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/fitness)
+"xjt" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"xjS" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/river1)
+"xkk" = (
+/obj/structure/table,
+/obj/item/armor_module/storage/uniform/webbing,
+/obj/item/armor_module/storage/uniform/webbing,
+/obj/item/armor_module/storage/uniform/webbing,
+/obj/item/compass,
+/obj/item/compass,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 8
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"xkL" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/lazarus/overgrown)
+"xld" = (
+/obj/machinery/vending/tool,
+/turf/open/floor/tile/dark/brown2{
+	dir = 8
+	},
+/area/lv624/lazarus/atmos)
+"xly" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/lv624/fog_blocker,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"xlz" = (
+/obj/structure/dispenser/oxygen,
+/turf/open/floor/tile/dark/brown2{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"xlD" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/ground/jungle9)
+"xmb" = (
+/turf/open/floor/marking/asteroidwarning{
+	dir = 6
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"xmf" = (
+/obj/structure/sign/botany,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"xmH" = (
+/turf/open/ground/grass/grass2,
+/area/lv624/lazarus/overgrown)
+"xmK" = (
+/obj/machinery/miner/damaged/platinum,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1)
+"xnj" = (
+/turf/open/floor/plating/icefloor/warnplate{
+	dir = 10
+	},
+/area/shuttle/drop1/lz1)
+"xnm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"xnu" = (
+/obj/structure/flora/jungle/vines/heavy,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"xnB" = (
+/turf/open/floor/plating/warning,
+/area/lv624/ground/sand8)
+"xod" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/ground/ruin)
+"xou" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/jungle/vines,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"xoJ" = (
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall/r_wall,
+/area/lv624/lazarus/corporate_affairs)
+"xpu" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"xqd" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle2)
+"xqg" = (
+/obj/effect/landmark/start/job/survivor,
+/obj/effect/landmark/start/latejoinsurvivor,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 1
+	},
+/area/lv624/lazarus/internal_affairs)
+"xqm" = (
+/obj/structure/stairs/seamless/platform{
+	dir = 1
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"xqB" = (
+/turf/closed/wall,
+/area/lv624/ground/compound/ne)
+"xqZ" = (
+/turf/open/liquid/water/river/autosmooth/deep,
+/area/lv624/ground/river3)
+"xrq" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"xrI" = (
+/obj/machinery/door/airlock/mainship/generic/corporate{
+	name = "Corporate Dome"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/wood,
+/area/lv624/lazarus/corporate_affairs)
+"xrU" = (
+/obj/effect/ai_node,
+/turf/open/floor/tile/neutral,
+/area/lv624/lazarus/spaceport2)
+"xrW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle2)
+"xsx" = (
+/obj/item/weapon/sword/machete,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle6)
+"xsR" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/item/weapon/broken_bottle,
+/turf/open/floor/grimy,
+/area/lv624/lazarus/bar)
+"xsT" = (
+/turf/open/floor/tile/blue/whiteblue,
+/area/lv624/lazarus/internal_affairs)
+"xsZ" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"xtf" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"xtz" = (
+/obj/effect/landmark/xeno_resin_door,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"xtD" = (
+/obj/structure/table,
+/obj/effect/decal/remains/human,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"xtI" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/ammo_casing,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 8
+	},
+/area/lv624/lazarus/main_hall)
+"xtL" = (
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"xtO" = (
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle9)
+"xtT" = (
+/obj/effect/landmark/corpsespawner/chef{
+	corpsesuit = null;
+	corpseuniform = /obj/item/clothing/under/colonist;
+	name = "Colonist Jed Willis"
+	},
+/obj/effect/decal/cleanable/blood/splatter/animated,
+/obj/item/weapon/harpoon,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"xtY" = (
+/turf/open/floor/marking/loadingarea{
+	dir = 8
+	},
+/area/lv624/ground/sand2)
+"xua" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/landmark/weed_node,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"xue" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"xuz" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"xuF" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle8)
+"xuX" = (
+/obj/structure/flora/jungle/plantbot1/alien,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle5)
+"xvf" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"xvr" = (
+/obj/structure/window_frame/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/comms)
+"xvs" = (
+/obj/machinery/floodlight,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"xvL" = (
+/obj/item/shard,
+/turf/open/ground/grass/grass2,
+/area/lv624/lazarus/overgrown)
+"xvO" = (
+/obj/structure/cargo_container/green{
+	dir = 8
+	},
+/turf/open/floor/plating/platebotc,
+/area/lv624/lazarus/quartstorage/outdoors)
+"xvP" = (
+/obj/machinery/status_display{
+	pixel_y = -1
+	},
+/turf/closed/wall,
+/area/lv624/lazarus/corporate_affairs)
+"xvV" = (
+/obj/effect/landmark/xeno_resin_wall,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4/garbledradio)
+"xvW" = (
+/turf/open/floor/marking/warning/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport2)
+"xwb" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating,
+/area/lv624/ground/jungle9)
+"xwi" = (
+/obj/machinery/floodlight,
+/turf/open/floor/plating/warning{
+	dir = 10
+	},
+/area/lv624/lazarus/tablefort)
+"xwk" = (
+/obj/structure/table,
+/obj/effect/ai_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"xwD" = (
+/obj/item/mecha_parts/part/gygax_torso,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"xwL" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"xwQ" = (
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass/grass2,
+/area/lv624/ground/jungle7)
+"xwS" = (
+/turf/open/floor/tile/red/full,
+/area/lv624/lazarus/security)
+"xxd" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"xxi" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirtgrassborder{
+	dir = 1
+	},
+/area/lv624/ground/jungle5)
+"xxo" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"xyb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/tile/whiteyellow{
+	dir = 1
+	},
+/area/lv624/lazarus/main_hall)
+"xza" = (
+/obj/structure/flora/grass/green,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"xzw" = (
+/obj/structure/catwalk,
+/obj/effect/turf_decal/riverdecal,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river1)
+"xzD" = (
+/obj/machinery/door/airlock/multi_tile/mainship/generic{
+	dir = 1;
+	name = "\improper Nexus Dome"
+	},
+/obj/machinery/door/poddoor/mainship/open{
+	id = "nexus_blast";
+	name = "\improper Nexus Blast Door"
+	},
+/turf/open/floor/tile/whiteyellow/corner{
+	dir = 4
+	},
+/area/lv624/lazarus/main_hall)
+"xzH" = (
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/obj/structure/barricade/metal{
+	is_wired = 1;
+	can_wire = 0
+	},
+/turf/open/floor/mainship/silver/full,
+/area/mainship/patrol_base/som)
+"xAn" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"xAx" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/engineering)
+"xAN" = (
+/obj/structure/window/framed/colony/reinforced,
+/turf/open/floor/plating,
+/area/lv624/lazarus/atmos)
+"xAO" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central3/garbledradio)
+"xAT" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Blast Door"
+	},
+/obj/structure/flora/jungle/vines,
+/turf/closed/wall,
+/area/lv624/lazarus/overgrown)
+"xAV" = (
+/obj/structure/mineral_door/wood,
+/obj/structure/cable,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"xAX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/bucket{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/tile/green/greentaupe{
+	dir = 5
+	},
+/area/lv624/lazarus/hydroponics)
+"xAZ" = (
+/turf/open/liquid/water/river,
+/area/lv624/ground/jungle9)
+"xBm" = (
+/obj/structure/rack,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/obj/effect/spawner/random/weaponry/gun/sidearms,
+/turf/open/floor/plating/platebot,
+/area/lv624/lazarus/secure_storage)
+"xBx" = (
+/obj/structure/largecrate/supply/supplies/tables_racks,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage/dome)
+"xCc" = (
+/obj/effect/turf_decal/warning_stripes/thick{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor,
+/area/lv624/lazarus/spaceport2)
+"xCq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/warning{
+	dir = 6
+	},
+/area/lv624/ground/filtration)
+"xCL" = (
+/obj/structure/flora/tree/jungle,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle4)
+"xCT" = (
+/obj/effect/spawner/random/misc/structure/girder/regularweighted,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"xDm" = (
+/obj/structure/flora/jungle/plantbot1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle1)
+"xDq" = (
+/obj/structure/barricade/wooden{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"xDu" = (
+/obj/structure/flora/jungle/planttop1,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"xDv" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"xDy" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand2)
+"xED" = (
+/obj/structure/bed/chair{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"xEF" = (
+/obj/machinery/door/airlock/mainship/medical/glass/free_access{
+	name = "\improper Nexus Dome Canteen"
+	},
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"xEQ" = (
+/turf/closed/gm/dense,
+/area/shuttle/drop1/lz1)
+"xET" = (
+/obj/structure/largecrate/supply/medicine/blood,
+/obj/effect/turf_decal/tile/transparent/dark_green/anticorner/contrasted,
+/turf/open/floor/plating/asteroidfloor,
+/area/ice_colony/underground/medical/treatment{
+	name = "CLF clinic"
+	})
+"xEV" = (
+/obj/machinery/power/geothermal,
+/obj/structure/cable,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/engineering)
+"xFo" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/secure_storage)
+"xFw" = (
+/obj/structure/table/reinforced/flipped,
+/turf/open/floor/plating/warning,
+/area/lv624/lazarus/tablefort)
+"xFP" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning,
+/area/lv624/lazarus/spaceport)
+"xGk" = (
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle6)
+"xGy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/landmark/weed_node,
+/obj/structure/cable,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"xGG" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/edge{
+	dir = 4
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"xGJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"xGN" = (
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"xGU" = (
+/obj/structure/flora/ausbushes/pointybush,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle4)
+"xGV" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/platform{
+	dir = 4
+	},
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"xHP" = (
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"xHT" = (
+/obj/effect/turf_decal/sandytile,
+/obj/structure/flora/jungle/vines,
+/obj/structure/bed/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"xIw" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central4)
+"xIZ" = (
+/obj/structure/flora/jungle/vines{
+	pixel_y = 1
+	},
+/turf/open/ground/grass,
+/area/lv624/ground/jungle10)
+"xJq" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 1
+	},
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor,
+/area/lv624/ground/sand8)
+"xJr" = (
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/tile/darkish,
+/area/lv624/lazarus/sandtemple)
+"xJw" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/engineering/tech_supply,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/quart)
+"xJZ" = (
+/obj/structure/flora/jungle/vines,
+/obj/structure/flora/tree/jungle/small,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle9)
+"xKs" = (
+/obj/effect/landmark/xeno_resin_door,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/central1)
+"xKx" = (
+/obj/structure/flora/jungle/vines,
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/turf/open/floor/mainship/silver/corner{
+	dir = 8
+	},
+/area/mainship/patrol_base/som)
+"xKW" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/item/weapon/gun/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"xKY" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Robotics Dome"
+	},
+/turf/open/floor/tile/vault{
+	dir = 8
+	},
+/area/lv624/lazarus/robotics)
+"xLe" = (
+/obj/structure/bed/chair/dropship/passenger{
+	dir = 4
+	},
+/turf/open/floor/vault,
+/area/lv624/lazarus/crashed_ship)
+"xLp" = (
+/obj/machinery/light/small,
+/turf/open/floor/wood,
+/area/lv624/lazarus/captain)
+"xLq" = (
+/obj/structure/sign/securearea{
+	dir = 8
+	},
+/obj/structure/fence,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"xLU" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone,
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"xLW" = (
+/obj/structure/table,
+/obj/item/tool/surgery/scalpel{
+	pixel_y = 12
+	},
+/obj/machinery/light,
+/turf/open/floor/tile/purple/whitepurple{
+	dir = 5
+	},
+/area/lv624/lazarus/research)
+"xMb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/asteroid/box,
+/obj/machinery/floodlight/landing,
+/turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"xMg" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/jungle6)
+"xMz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/dark_blue,
+/obj/machinery/power/apc/hyper,
+/turf/open/floor/marking/asteroidwarning{
+	dir = 1
+	},
+/area/deltastation/commons/dorms/barracks{
+	name = "CLF Bunks";
+	outside = 0;
+	ceiling = 6
+	})
+"xMH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/floodlight/colony{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle6)
+"xMP" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/medical/firstaid,
+/turf/open/floor/plating,
+/area/lv624/lazarus/quartstorage)
+"xMU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/layer1{
+	on = 1
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"xNv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/sw)
+"xNX" = (
+/turf/open/ground/grass/beach{
+	dir = 4
+	},
+/area/lv624/ground/jungle9)
+"xOk" = (
+/obj/structure/flora/jungle/vines,
+/obj/effect/ai_node,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"xOn" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"xPp" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle7)
+"xPB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/bookcase,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"xPM" = (
+/obj/item/trash/cheesie,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"xQK" = (
+/turf/open/floor/plating/warning{
+	dir = 8
+	},
+/area/lv624/lazarus/tablefort)
+"xQL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+"xQW" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"xRJ" = (
+/obj/item/storage/toolbox/syndicate,
+/obj/structure/rack,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"xRV" = (
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
+"xSj" = (
+/obj/item/tank/oxygen/yellow,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand6)
+"xSk" = (
+/obj/machinery/floodlight/colony{
+	dir = 8
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"xSq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/jungle/vines,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle7)
+"xSD" = (
+/obj/effect/spawner/random/misc/structure/broken_reinforced_window/colonyspawn,
+/obj/machinery/door/poddoor/mainship{
+	dir = 1;
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/turf/open/floor/plating,
+/area/lv624/lazarus/corporate_affairs)
+"xTn" = (
+/obj/structure/table,
+/obj/item/mecha_parts/mecha_equipment/drill,
+/turf/open/floor/tile/vault,
+/area/lv624/lazarus/robotics)
+"xTp" = (
+/turf/closed/wall/r_wall/chigusa,
+/area/lv624/ground/ruin)
+"xTA" = (
+/obj/structure/fence,
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"xTC" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/turf/open/floor/plating,
+/area/lv624/ground/sand6)
+"xTD" = (
+/obj/structure/bed/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/tile/brown{
+	dir = 9
+	},
+/area/lv624/lazarus/comms)
+"xUk" = (
+/obj/structure/dispenser/oxygen,
+/turf/open/floor/tile/dark/brown2/corner{
+	dir = 1
+	},
+/area/lv624/lazarus/atmos)
+"xUp" = (
+/obj/structure/cargo_container/nt{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/ground/sand5)
+"xUG" = (
+/obj/machinery/smartfridge/seeds,
+/turf/open/floor/tile/green/whitegreen{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics/aux)
+"xVm" = (
+/turf/closed/wall/brick,
+/area/deltastation/commons/fitness{
+	name = "CLF training";
+	outside = 0;
+	ceiling = 6
+	})
+"xVp" = (
+/obj/structure/largecrate/random,
+/turf/open/floor/tile/blue/whiteblue{
+	dir = 4
+	},
+/area/lv624/lazarus/internal_affairs)
+"xWg" = (
+/obj/item/stack/sheet/wood{
+	amount = 2
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/turf/open/floor/tile/white,
+/area/lv624/lazarus/main_hall)
+"xWs" = (
+/turf/closed/wall,
+/area/lv624/lazarus/fitness)
+"xWN" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"xXc" = (
+/obj/machinery/door/poddoor/timed_late/containment/landing_zone/lz2,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle9)
+"xXp" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 10
+	},
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/effect/ai_node,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage)
+"xXv" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/compound/n)
+"xXJ" = (
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/east1/garbledradio)
+"xXN" = (
+/obj/effect/landmark/mob_spawner/monkey,
+/turf/open/floor/tile/purple/whitepurplecorner{
+	dir = 4
+	},
+/area/lv624/lazarus/fitness)
+"xXT" = (
+/obj/machinery/door/poddoor/mainship{
+	id = "corporate_blast";
+	name = "\improper Corporate Dome Blast Door"
+	},
+/obj/structure/cable,
+/turf/open/floor,
+/area/lv624/lazarus/corporate_affairs)
+"xXZ" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 5
+	},
+/obj/structure/cable,
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/quartstorage/dome)
+"xYf" = (
+/obj/machinery/door/airlock/mainship/engineering/free_access{
+	name = "\improper Engineering Dome"
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/engineering)
+"xYI" = (
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/ground/jungle10)
+"xYT" = (
+/obj/effect/ai_node,
+/turf/open/floor/marking/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/spaceport)
+"xZE" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/docking_port/stationary/crashmode,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"yas" = (
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/armory)
+"yau" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/liquid/water/river/autosmooth,
+/area/lv624/ground/river2)
+"ybj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/turf/open/floor/wood,
+/area/lv624/lazarus/chapel)
+"ybk" = (
+/obj/structure/extinguisher_cabinet{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/storage/belt/utility/full,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"ybq" = (
+/obj/effect/turf_decal/siding/wideplating_new/light{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sink/bathroom{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/open/floor/grayscale/edge,
+/area/deltastation/commons/toilet/restrooms{
+	name = "CLF restrooms";
+	outside = 0;
+	ceiling = 6
+	})
+"ybP" = (
+/obj/machinery/hydroponics,
+/obj/structure/sink{
+	dir = 8
+	},
+/turf/open/floor/tile/green/greentaupe{
+	dir = 1
+	},
+/area/lv624/lazarus/hydroponics)
+"ybW" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/start/job/xenomorph,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/caves/west1)
+"yck" = (
+/obj/effect/landmark/excavation_site_spawner,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/sand7)
+"ydn" = (
+/obj/structure/table,
+/obj/machinery/processor,
+/turf/open/floor/tile/barber,
+/area/lv624/lazarus/kitchen)
+"ydv" = (
+/obj/structure/bed/stool,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/canteen)
+"ydH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable,
+/turf/open/floor/plating/ground/dirt,
+/area/lv624/ground/jungle2)
+"yep" = (
+/obj/structure/bed/stool,
+/turf/open/floor/tile/bar,
+/area/lv624/lazarus/kitchen)
+"yfb" = (
+/obj/item/tool/kitchen/utensil/spoon,
+/obj/structure/table/mainship,
+/obj/structure/flora/jungle/vines,
+/obj/item/reagent_containers/food/snacks/soup/stew,
+/turf/open/floor/tile/whiteyellow/full,
+/area/lv624/lazarus/sandtemple/garbledradio)
+"yfz" = (
+/turf/open/floor/tile/green/greentaupe{
+	dir = 9
+	},
+/area/lv624/lazarus/hydroponics)
+"yfX" = (
+/obj/machinery/door/airlock/mainship/command/locked/free_access{
+	name = "\improper Nexus Dome Marshal's Quarter"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/lv624/lazarus/captain)
+"ygv" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/bed/chair/comfy/black,
+/obj/effect/landmark/weed_node,
+/turf/open/floor/tile/purple/taupepurple{
+	dir = 9
+	},
+/area/lv624/lazarus/sleep_female)
+"ygE" = (
+/turf/closed/wall/cult,
+/area/lv624/ground/caves/central3)
+"ygG" = (
+/turf/open/floor/tile/green/whitegreencorner,
+/area/lv624/lazarus/main_hall)
+"yhf" = (
+/obj/effect/spawner/random/misc/structure/flavorvending/snackweighted,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"yhB" = (
+/obj/structure/table/wood,
+/obj/item/trash/candle,
+/turf/open/floor/tile/chapel{
+	dir = 1
+	},
+/area/lv624/lazarus/chapel)
+"yic" = (
+/obj/structure/window_frame/colony,
+/turf/open/floor/plating/ground/dirtgrassborder/autosmooth,
+/area/lv624/lazarus/overgrown)
+"yid" = (
+/obj/alien/weeds/node/resting,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/coffee/cafe_latte{
+	pixel_y = 7;
+	pixel_x = 15
+	},
+/turf/open/floor/plating/ground/dirt,
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"yiu" = (
+/obj/structure/closet/open,
+/turf/open/floor/tile/blue/taupebluecorner,
+/area/lv624/lazarus/sleep_male)
+"yiy" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 8
+	},
+/obj/effect/spawner/random/weaponry/explosive/grenade,
+/obj/item/ammo_magazine/smg/m25,
+/turf/open/floor/plating,
+/area/lv624/lazarus/tablefort)
+"yiz" = (
+/obj/effect/turf_decal/riverdecal,
+/turf/open/floor/plating,
+/area/lv624/ground/sand8)
+"yiT" = (
+/obj/structure/flora/jungle/vines/heavy{
+	pixel_y = 24
+	},
+/turf/closed/gm/dense,
+/area/lv624/ground/caves/rock)
+"yja" = (
+/turf/open/ground/coast/corner{
+	dir = 1
+	},
+/area/lv624/ground/jungle9)
+"yje" = (
+/obj/machinery/power/smes/preset,
+/turf/open/floor/plating/ground/desertdam/asphalt/threeside{
+	dir = 1
+	},
+/area/deltastation/engineering/lobby{
+	name = "CLF engineering";
+	outside = 0
+	})
+"yjg" = (
+/obj/structure/fence,
+/turf/open/floor/plating/warning{
+	dir = 1
+	},
+/area/lv624/ground/sand8)
+"yju" = (
+/turf/open/floor/bcircuit/off,
+/area/lv624/lazarus/sandtemple)
+"yjy" = (
+/obj/structure/table/reinforced/flipped{
+	dir = 4
+	},
+/obj/effect/ai_node,
+/turf/open/floor/plating/warning{
+	dir = 4
+	},
+/area/lv624/lazarus/tablefort)
+"yjL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/tile/dark,
+/area/lv624/lazarus/atmos)
+"yjS" = (
+/obj/structure/cargo_container{
+	dir = 1
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"yjW" = (
+/obj/effect/ai_node,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	dir = 1
+	},
+/turf/open/floor/tile/blue/whitebluefull,
+/area/lv624/lazarus/internal_affairs)
+"yjZ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/landmark/weed_node,
+/turf/open/floor/wood,
+/area/lv624/lazarus/bar)
+"yke" = (
+/obj/structure/barricade/plasteel{
+	is_wired = 1;
+	can_wire = 0;
+	dir = 8
+	},
+/turf/open/floor/mainship/silver{
+	dir = 1
+	},
+/area/mainship/patrol_base/som)
+"ykw" = (
+/obj/structure/cargo_container/nt{
+	dir = 8
+	},
+/turf/open/floor,
+/area/lv624/lazarus/spaceport)
+"yky" = (
+/turf/open/floor/plating/ground/dirtgrassborder/corner2,
+/area/lv624/ground/jungle5)
+"ykG" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/open/floor/plating/icefloor,
+/area/shuttle/drop2/lz2)
+"ykR" = (
+/turf/open/floor/marking/bot,
+/area/lv624/lazarus/spaceport)
+"yld" = (
+/obj/effect/decal/remains/xeno,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle3)
+"ylC" = (
+/obj/structure/flora/jungle/vines/heavy,
+/turf/open/ground/grass,
+/area/lv624/ground/jungle7)
+"ylD" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/monitor,
+/turf/open/floor/plating,
+/area/lv624/lazarus/engineering)
+"ylX" = (
+/obj/effect/turf_decal/warning_stripes/thin,
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/turf/open/floor,
+/area/lv624/ground/jungle7)
+"ymf" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/lv624/lazarus/main_hall)
+
+(1,1,1) = {"
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+"}
+(2,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+qBU
+qBU
+qBU
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+eCN
+vOr
+ndT
+ndT
+eCN
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+jiZ
+mZk
+xYI
+xYI
+xYI
+fGe
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(3,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+qBU
+vxT
+qBU
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+gge
+gge
+oQc
+oQc
+gge
+oQc
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+eCN
+ndT
+ndT
+ndT
+eCN
+fXP
+amT
+amT
+eCN
+eCN
+ndT
+ndT
+eCN
+gge
+gge
+gge
+hUG
+mZk
+mZk
+mZk
+qYE
+mZk
+qyD
+bsM
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(4,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+qBU
+qBU
+qBU
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hLK
+osr
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+gge
+csp
+oQc
+csp
+oQc
+oQc
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+yic
+ioJ
+ioJ
+ioJ
+xCT
+amT
+xvL
+xmH
+eCN
+mho
+amT
+hrw
+fXP
+bsM
+bsM
+bsM
+bsM
+bsM
+mZk
+mZk
+mZk
+qyD
+hUG
+bsM
+bsM
+mZk
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(5,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+hLK
+osr
+feI
+osr
+feI
+osr
+osr
+hLK
+xvV
+xvV
+xvV
+xvV
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+gge
+oQc
+oQc
+oQc
+hSD
+hSD
+oQc
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+mZk
+xYI
+xYI
+xYI
+xdN
+iMn
+frA
+joe
+esV
+faq
+amT
+wBp
+doH
+amT
+gnf
+amT
+fXP
+bsM
+bsM
+bsM
+bsM
+bsM
+bsM
+bsM
+wwN
+bsM
+bsM
+jiZ
+bsM
+bsM
+bsM
+hUG
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(6,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+sWE
+xIw
+xvV
+osr
+sMt
+osr
+sMt
+feI
+osr
+osr
+osr
+osr
+feI
+xvV
+xvV
+xvV
+hTt
+hTt
+hTt
+hTt
+wmm
+oQD
+hTt
+hTt
+hLK
+osr
+xvV
+xvV
+hTt
+hTt
+hTt
+hTt
+gge
+oQc
+hSD
+hSD
+csp
+oQc
+hSD
+oQc
+gge
+gge
+gge
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+bsM
+rsc
+xYI
+xYI
+ceL
+sxP
+eCN
+tuY
+bAE
+ejs
+ndT
+ioJ
+ioJ
+ioJ
+eCN
+kBQ
+amT
+mFl
+eCN
+gge
+gge
+gge
+gge
+gge
+bsM
+oqg
+rvb
+rvb
+atU
+oqg
+rvb
+uQx
+bsM
+bsM
+bsM
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(7,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+sWE
+xIw
+xIw
+xIw
+osr
+osr
+osr
+hLK
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+xvV
+xvV
+rRT
+hTt
+oQD
+hTt
+osr
+osr
+osr
+osr
+xvV
+xvV
+xvV
+hTt
+hTt
+gge
+oQc
+oQc
+nIe
+ejE
+oQc
+csp
+hSD
+gge
+gge
+bsM
+mZa
+mZk
+gge
+gge
+gge
+gge
+gge
+bsM
+bsM
+mZk
+xYI
+gfy
+gfy
+ndT
+eCN
+xAT
+hmN
+xAT
+eCN
+iTX
+bAE
+iTX
+xCT
+eCN
+amT
+eCN
+eCN
+eCN
+gge
+gge
+gge
+gge
+rvb
+rvb
+iuu
+iiI
+mRm
+pUm
+nPZ
+rvb
+uQx
+hUG
+bsM
+hUG
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(8,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+sWE
+sWE
+xIw
+wWM
+vTo
+xIw
+osr
+ffv
+osr
+sMt
+osr
+osr
+hLK
+xvV
+xvV
+hLK
+osr
+osr
+osr
+feI
+osr
+osr
+osr
+hLK
+euw
+osr
+feI
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+hTt
+hTt
+gge
+oQc
+hSD
+vAh
+vAh
+csp
+hSD
+gge
+bsM
+bsM
+bsM
+bsM
+rsc
+bsM
+bsM
+bsM
+rsc
+bsM
+bsM
+mZk
+xYI
+ceL
+gfy
+iTX
+iTX
+ioJ
+dVx
+wBp
+ioJ
+ioJ
+iMn
+tly
+ioJ
+kBQ
+tBZ
+ioJ
+ioJ
+eCN
+gge
+gge
+gge
+rvb
+rvb
+knL
+fMe
+fAI
+voq
+fAI
+mBz
+lEN
+rvb
+uQx
+bsM
+bsM
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(9,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+feI
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+osr
+euw
+osr
+osr
+hLK
+osr
+osr
+hLK
+osr
+osr
+osr
+hTt
+hTt
+gge
+csp
+hSD
+vAh
+vAh
+csp
+svT
+eUt
+uex
+bsM
+bsM
+bsM
+bsM
+bsM
+hLn
+nWK
+imH
+mZk
+mZk
+hJN
+xYI
+jrk
+lGp
+bAE
+iTX
+ioJ
+wBp
+srV
+nLE
+ioJ
+ioJ
+ioJ
+ioJ
+xmH
+cBr
+iTX
+ioJ
+eCN
+gge
+gge
+rvb
+rvb
+vmn
+ola
+gmc
+jQz
+itA
+iDO
+cyd
+sFx
+atY
+rvb
+oRM
+bsM
+gge
+gge
+gge
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+uwP
+dMl
+"}
+(10,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+sWE
+vTo
+sWE
+xIw
+xIw
+osr
+osr
+sMt
+osr
+sMt
+osr
+feI
+osr
+osr
+feI
+osr
+feI
+osr
+osr
+feI
+hLK
+xvV
+xvV
+osr
+euw
+osr
+feI
+osr
+osr
+osr
+osr
+osr
+hLK
+feI
+hTt
+hTt
+oQc
+oQc
+nIe
+nIe
+nIe
+csp
+csp
+xYI
+xYI
+xYI
+xWN
+mZk
+imH
+imH
+mZk
+mZk
+mZk
+vYj
+mZk
+xYI
+xYI
+gfy
+gfy
+iTX
+iTX
+ioJ
+amT
+amT
+dVx
+amT
+amT
+amT
+amT
+amT
+ioJ
+ioJ
+ioJ
+eCN
+gge
+gge
+rvb
+rvb
+oon
+hoP
+cvl
+lgF
+lgF
+wpF
+msM
+fAI
+lPJ
+rvb
+uQx
+bsM
+gge
+gge
+gge
+uwP
+gge
+hFz
+mMJ
+dYe
+gge
+gge
+gge
+gge
+gge
+gge
+uwP
+dMl
+"}
+(11,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+xIw
+xIw
+sWE
+xvV
+osr
+osr
+hLK
+osr
+hLK
+osr
+xvV
+xvV
+osr
+hLK
+osr
+xvV
+xvV
+osr
+iPr
+osr
+osr
+hLK
+euw
+osr
+osr
+feI
+osr
+osr
+xvV
+xvV
+osr
+osr
+hTt
+hTt
+oQc
+hSD
+nIe
+nIe
+csp
+csp
+csp
+xYI
+xYI
+xiw
+xYI
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+hJN
+xYI
+xYI
+gfy
+gfy
+gfy
+xkL
+eCN
+eCN
+abd
+ndT
+ndT
+fXP
+tma
+amT
+eCN
+eCN
+tma
+amT
+eCN
+eCN
+gge
+gge
+rvb
+xBm
+gmc
+fdt
+wpF
+jKM
+lgF
+jKM
+wpF
+xbC
+cyd
+nsK
+uQx
+bsM
+hFz
+hFz
+dYe
+tcf
+nrV
+joJ
+hFz
+dYe
+hFz
+hFz
+hFz
+hFz
+ukv
+gge
+uwP
+dMl
+"}
+(12,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+vTo
+xIw
+sWE
+xvV
+osr
+sMt
+osr
+sMt
+osr
+osr
+xvV
+xvV
+aqt
+aqt
+aqt
+xvV
+xvV
+osr
+osr
+osr
+osr
+osr
+euw
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+osr
+hTt
+hTt
+csp
+hSD
+csp
+nIe
+nIe
+xfA
+csp
+xYI
+xWN
+xYI
+xYI
+xYI
+xYI
+xYI
+xYI
+xYI
+xYI
+xYI
+xYI
+ceL
+gfy
+gfy
+gfy
+ceL
+eCN
+wdB
+ioJ
+ioJ
+ndT
+pUq
+xmH
+xmH
+xCT
+gYZ
+ioJ
+xgc
+eCN
+gge
+gge
+gge
+rvb
+kbA
+bnY
+fdt
+kaR
+tcG
+qwi
+tcG
+kaR
+pAU
+phB
+uzq
+uQx
+bsM
+hFz
+hFz
+hFz
+uwP
+xTp
+xTp
+ioe
+xTp
+fxs
+nrV
+nrV
+mIm
+hFz
+gge
+uwP
+dMl
+"}
+(13,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+vVO
+vVO
+vVO
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+gSc
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+hPs
+feI
+osr
+osr
+osr
+aqt
+osr
+osr
+osr
+aqt
+osr
+osr
+osr
+osr
+osr
+osr
+oQD
+xvV
+osr
+hLK
+osr
+osr
+osr
+hLK
+osr
+osr
+rck
+hTt
+nZa
+csp
+nIe
+nIe
+nIe
+csp
+csp
+xYI
+imH
+xYI
+xYI
+xYI
+mjJ
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+xdN
+egd
+tBZ
+amT
+qqC
+amT
+xmH
+wBp
+mIV
+iMn
+bAE
+iTX
+ojo
+gge
+gge
+gge
+rvb
+lxv
+gmc
+fdt
+wpF
+eAo
+lgF
+eAo
+wpF
+bQh
+cyd
+cWU
+xgx
+bsM
+hFz
+hFz
+hFz
+uwP
+xTp
+tts
+vrn
+vrn
+fxs
+xTp
+fxs
+gge
+mIm
+gge
+uwP
+dMl
+"}
+(14,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+vVO
+fnA
+vVO
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+xIw
+wWM
+xIw
+xIw
+osr
+sMt
+feI
+sMt
+osr
+osr
+osr
+aqt
+osr
+rwc
+osr
+aqt
+osr
+osr
+hLK
+osr
+osr
+hTt
+oQD
+xvV
+xvV
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+kHI
+mTB
+mTB
+csp
+nIe
+nIe
+nIe
+csp
+csp
+xYI
+fGe
+xYI
+ceL
+gfy
+gfy
+gfy
+ceL
+lGp
+gfy
+ceL
+gfy
+gfy
+gfy
+lGp
+gfy
+gfy
+lHW
+ioJ
+pkG
+doH
+eCN
+ioJ
+tBZ
+xOn
+xCT
+iTX
+iTX
+iTX
+ojo
+gge
+gge
+gge
+rvb
+rvb
+nQs
+wEs
+dSk
+wpF
+lgF
+wpF
+xFo
+wEs
+wGz
+rvb
+xgx
+bsM
+hFz
+hFz
+gge
+uwP
+xTp
+xgU
+vrn
+dMP
+tqk
+tyC
+xTp
+yiT
+hFz
+gge
+uwP
+dMl
+"}
+(15,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+vVO
+vVO
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+wWM
+sWE
+vTo
+osr
+osr
+osr
+hLK
+osr
+osr
+dGo
+osr
+aqt
+feI
+osr
+osr
+aqt
+osr
+feI
+osr
+osr
+osr
+hTt
+oQD
+hTt
+xvV
+osr
+hLK
+osr
+osr
+xvV
+xvV
+osr
+kHI
+rEZ
+nAB
+csp
+rCX
+rCX
+gJS
+csp
+ceL
+fGe
+xYI
+gfy
+gfy
+gfy
+gfy
+vbN
+mcj
+aUT
+mcj
+vbN
+gfy
+ceL
+gfy
+gfy
+lGp
+gfy
+eCN
+xdN
+lHW
+lHW
+eCN
+iTX
+iTX
+iTX
+eCN
+lHW
+xdN
+lHW
+eCN
+dlv
+dlv
+dlv
+fcv
+rvb
+igV
+gVl
+jDH
+wpF
+lgF
+wpF
+lfT
+dsc
+aUc
+uQx
+bsM
+hUG
+hFz
+gge
+gge
+uwP
+xTp
+iJQ
+dMP
+dMP
+dMP
+ghP
+xTp
+euy
+hFz
+uzY
+uwP
+dMl
+"}
+(16,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+gSc
+hMr
+fsg
+fsg
+gSc
+fsg
+vVO
+vVO
+hMr
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+rRT
+hTt
+rRT
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+vVO
+vVO
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+vTo
+xIw
+xIw
+xIw
+osr
+osr
+sMt
+osr
+sMt
+osr
+osr
+xvV
+xvV
+aqt
+aqt
+aqt
+xvV
+xvV
+osr
+osr
+osr
+hTt
+oQD
+hTt
+hTt
+xvV
+osr
+osr
+osr
+osr
+xvV
+xvV
+osr
+kHI
+upB
+sat
+aYO
+oKj
+aYO
+aYO
+lCX
+lGp
+gfy
+gfy
+vbN
+mcj
+mcj
+mcj
+vbN
+aoW
+iEP
+vNw
+vbN
+mcj
+mcj
+mcj
+vbN
+gfy
+iMg
+gfy
+gfy
+iMg
+gfy
+ndT
+xkL
+rHz
+iMn
+ndT
+svT
+svT
+gfy
+gfy
+gfy
+gfy
+gfy
+rbz
+rvb
+rvb
+hCu
+etc
+qiW
+ndB
+qzK
+cyd
+anN
+rvb
+xgx
+hUG
+bsM
+hFz
+mMJ
+hFz
+nrh
+nHH
+xgU
+mqL
+dMP
+dMP
+pnL
+xTp
+kqD
+hFz
+hFz
+uwP
+dMl
+"}
+(17,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+fsg
+gSc
+fsg
+fsg
+fsg
+hMr
+fsg
+gSc
+fsg
+hMr
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+hMr
+eXf
+fsg
+hMr
+fsg
+fsg
+hMr
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+hTt
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+sWE
+sWE
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+osr
+hLK
+osr
+xvV
+xvV
+hLK
+osr
+osr
+oQD
+hTt
+hTt
+hTt
+xvV
+feI
+osr
+osr
+osr
+osr
+osr
+feI
+kHI
+upB
+fcR
+xzw
+iZW
+pXJ
+otb
+iMU
+gfy
+gfy
+gfy
+mcj
+gPy
+tlK
+nXL
+yjZ
+aoW
+hcQ
+aoW
+opU
+boE
+nXL
+bwC
+mcj
+gfy
+gfy
+gfy
+svT
+gfy
+lGp
+gfy
+ceL
+pnj
+gfy
+gfy
+gfy
+ceL
+lGp
+gfy
+gfy
+jiV
+gfy
+rbz
+mZk
+rvb
+rvb
+tpH
+cMs
+iWQ
+dZp
+tpH
+rvb
+xgx
+bsM
+bsM
+bsM
+hFz
+hFz
+hFz
+tcf
+nHH
+eut
+rhf
+dsv
+pli
+rhf
+pnL
+pOI
+mMJ
+hFz
+uwP
+dMl
+"}
+(18,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+vVO
+vVO
+hMr
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+nzb
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+vVO
+vVO
+fyw
+fsg
+eZd
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+sWE
+xIw
+xIw
+vTo
+xIw
+osr
+sMt
+osr
+sMt
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+oQD
+hTt
+hTt
+hTt
+xvV
+xvV
+osr
+osr
+osr
+osr
+osr
+kHI
+kHI
+aGH
+upB
+sXi
+mkL
+jcs
+otb
+vpo
+gfy
+gfy
+gfy
+mcj
+kjx
+msX
+tCQ
+mhz
+wUu
+sQD
+olZ
+mhz
+seK
+mBh
+nXL
+mcj
+gfy
+gfy
+wxb
+lkp
+lkp
+lkp
+lkp
+lkp
+mRe
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+rbz
+mZk
+mZk
+rvb
+abV
+wpF
+eco
+wpF
+wpF
+xgx
+bsM
+bsM
+bsM
+bsM
+hFz
+hFz
+hFz
+uwP
+xTp
+xgU
+dMP
+dMP
+dMP
+rhf
+xTp
+qEf
+dYe
+hFz
+uwP
+dMl
+"}
+(19,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+hMr
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+gSc
+fsg
+eXf
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fyw
+fsg
+fsg
+hMr
+fsg
+vVO
+hTt
+hTt
+hTt
+hTt
+rRT
+sWE
+xIw
+sWE
+sWE
+osr
+osr
+osr
+hLK
+osr
+xvV
+xvV
+osr
+osr
+osr
+osr
+xvV
+xvV
+osr
+feI
+osr
+xvV
+oQD
+hTt
+hTt
+hTt
+hTt
+xvV
+xvV
+osr
+rck
+kHI
+rck
+kHI
+kHI
+upB
+sat
+aYO
+aVj
+reb
+aYO
+lCX
+ceL
+gfy
+gfy
+vbN
+gIN
+lok
+aoW
+aSS
+oEB
+oAZ
+aoW
+dHg
+rtH
+awT
+clP
+vbN
+gfy
+gfy
+qea
+gfy
+gfy
+gfy
+obD
+rbz
+rbz
+rbz
+obD
+rbz
+rbz
+rbz
+obD
+gfy
+gfy
+gfy
+obD
+mZk
+mZa
+rvb
+rvb
+cMs
+cPx
+dZp
+xgx
+siE
+bsM
+bsM
+hUG
+gge
+gge
+nrV
+gge
+uwP
+xTp
+eut
+dMP
+vrn
+xod
+xgU
+xTp
+rRr
+lLd
+odA
+uwP
+dMl
+"}
+(20,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fyw
+fsg
+hTt
+hTt
+hTt
+fsg
+vVO
+vVO
+fsg
+fsg
+chU
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+gSc
+vVO
+vVO
+hTt
+hTt
+hTt
+rRT
+sWE
+xIw
+sWE
+sWE
+xIw
+osr
+iPr
+osr
+osr
+xvV
+xvV
+hLK
+osr
+osr
+osr
+xvV
+xvV
+feI
+osr
+xvV
+xvV
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+mTB
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+mrb
+csp
+qRK
+gOE
+otb
+qRK
+snU
+gfy
+gfy
+vbN
+vbN
+jOT
+rLm
+nXL
+rJD
+oqF
+mhz
+mzQ
+nPX
+iwG
+vku
+nXL
+vbN
+vbN
+ceL
+qea
+gfy
+ceL
+xYI
+rbz
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+rbz
+gfy
+gfy
+gfy
+rbz
+mZk
+mZk
+mZk
+rbz
+lqV
+wvV
+gfy
+xLq
+mZk
+mZk
+hUG
+gge
+gge
+gge
+mMJ
+hFz
+nrh
+xTp
+xgU
+ePD
+dMP
+xgU
+iKl
+xTp
+boN
+hFz
+hFz
+uwP
+dMl
+"}
+(21,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+hTt
+hTt
+hTt
+hTt
+sWE
+wWM
+xIw
+xIw
+xIw
+osr
+osr
+osr
+osr
+hLK
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+mTB
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+csp
+csp
+nIe
+csp
+csp
+syl
+gfy
+gfy
+mcj
+dQz
+aoW
+kte
+qVa
+aoW
+nXL
+rDi
+eMM
+aoW
+oKe
+nXL
+eHX
+nXL
+mcj
+lGp
+qea
+gfy
+gfy
+xYI
+kEm
+imH
+eaA
+eaA
+xYI
+mZk
+vYj
+jiZ
+rbz
+svT
+gfy
+gfy
+xrq
+mZk
+goR
+mZk
+rbz
+gfy
+lsO
+lqV
+rbz
+mZk
+mZk
+gge
+gge
+gge
+gge
+hFz
+hFz
+rCv
+xTp
+lwB
+tHG
+xgU
+xTp
+oBN
+xTp
+dYe
+hFz
+hFz
+uwP
+dMl
+"}
+(22,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+gSc
+qyP
+fsg
+qyP
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+vVO
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+hMr
+fsg
+fsg
+hMr
+fsg
+vVO
+hTt
+hTt
+hTt
+xIw
+wWM
+xIw
+xIw
+xIw
+vTo
+osr
+osr
+rtU
+osr
+osr
+osr
+osr
+osr
+feI
+hLK
+osr
+osr
+rtU
+xvV
+xvV
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+mTB
+mTB
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+csp
+csp
+ceL
+gfy
+lGp
+pEU
+aoW
+kHa
+piF
+sGp
+nfi
+sGp
+xcl
+sGp
+fqX
+dJE
+fqX
+iOF
+vYc
+qMN
+lkp
+cye
+gfy
+gfy
+xYI
+kEm
+mZk
+xYI
+afW
+xYI
+mZk
+jiZ
+mZk
+rbz
+gfy
+ceL
+gfy
+rbz
+xYI
+xYI
+xYI
+obD
+gfy
+qea
+gfy
+rbz
+mZk
+mZk
+bsM
+gge
+gge
+gge
+hFz
+hFz
+uwP
+xTp
+xTp
+xTp
+xTp
+xTp
+dYe
+vEl
+hFz
+hFz
+hFz
+uwP
+dMl
+"}
+(23,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+hTt
+fsg
+hMr
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+hTt
+hTt
+hTt
+wWM
+xIw
+xIw
+vTo
+xIw
+osr
+xvV
+xvV
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+mTB
+mTB
+kHI
+kHI
+aoQ
+kHI
+kHI
+csp
+csp
+nIe
+csp
+csp
+gfy
+gfy
+gfy
+mcj
+swa
+mzQ
+gIC
+wEQ
+hgT
+rZy
+aoW
+nXL
+aSS
+moC
+mhX
+vmp
+hcQ
+mcj
+gfy
+qea
+gfy
+gfy
+xYI
+kEm
+nsY
+xYI
+xYI
+xYI
+gcU
+mZk
+mZk
+rbz
+gfy
+gfy
+gfy
+rbz
+xYI
+dWR
+xYI
+rbz
+gfy
+qea
+lqV
+obD
+gcU
+mZk
+gge
+gge
+gge
+gge
+nrV
+gge
+uwP
+uwP
+fSn
+ikw
+wpv
+fSn
+iMD
+iMD
+iMD
+tcf
+ksA
+uwP
+dMl
+"}
+(24,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+fsg
+qyP
+fsg
+qyP
+vVO
+vVO
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+rRT
+vTo
+xIw
+xIw
+xIw
+xIw
+osr
+xvV
+xvV
+osr
+osr
+osr
+hLK
+osr
+osr
+hLK
+osr
+osr
+osr
+xvV
+xvV
+oQD
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+mTB
+kHI
+rck
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+csp
+csp
+gfy
+gfy
+gfy
+vbN
+vbN
+buk
+xeR
+xsR
+aRw
+nXL
+aoW
+mzQ
+vku
+mFT
+vku
+pKS
+vbN
+vbN
+ceL
+qea
+gfy
+ceL
+xYI
+kEm
+mZk
+mZk
+gcU
+mZk
+gcU
+mZk
+mZk
+rbz
+gfy
+gfy
+svT
+rbz
+xYI
+xYI
+xYI
+rbz
+gfy
+qea
+gfy
+rbz
+mZk
+gcU
+mZk
+gge
+gge
+gge
+nrV
+gge
+gge
+gge
+gge
+hFz
+gge
+gge
+pOI
+mkx
+pOI
+dYe
+gge
+gge
+dMl
+"}
+(25,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+gSc
+fsg
+fsg
+fsg
+gSc
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fse
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+oQD
+vbU
+vbU
+vbU
+vbU
+oQD
+oQD
+oQD
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+tWV
+rRT
+fsg
+fsg
+hMr
+fsg
+hMr
+fsg
+hTt
+rRT
+xIw
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+xvV
+oQD
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+mTB
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+csp
+csp
+ceL
+gfy
+gfy
+ceL
+vbN
+pDy
+iki
+fdU
+hzw
+nXL
+hrd
+aoW
+nXL
+nXL
+nXL
+clP
+vbN
+svT
+gfy
+qea
+gfy
+gfy
+xYI
+obD
+rbz
+rbz
+rbz
+obD
+rbz
+rbz
+rbz
+obD
+gfy
+gfy
+gfy
+obD
+rbz
+rbz
+rbz
+obD
+gfy
+pZq
+gfy
+rbz
+mZk
+mZk
+mZk
+mZk
+gge
+gge
+nrV
+gge
+gge
+gge
+gge
+gge
+gge
+hFz
+pOI
+qNm
+pOI
+ttx
+gge
+gge
+dMl
+"}
+(26,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+gSc
+qyP
+fsg
+qyP
+fsg
+fyw
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+rcB
+fsg
+fsg
+gSc
+rRT
+rRT
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+tWV
+mjK
+tWV
+rRT
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+xIw
+xIw
+sWE
+sWE
+vTo
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+osr
+xvV
+xvV
+xvV
+xvV
+oQD
+wjA
+wmm
+wmm
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+hTt
+hTt
+kHI
+kHI
+kHI
+rck
+kHI
+csp
+csp
+nIe
+csp
+csp
+gfy
+gfy
+gfy
+gfy
+mcj
+rxG
+dmo
+fDH
+aRw
+nXL
+rZy
+aoW
+klc
+klc
+qQZ
+klc
+mcj
+svT
+gfy
+qea
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+svT
+gfy
+gfy
+gfy
+lGp
+qea
+gfy
+obD
+mZk
+mZk
+gge
+gge
+gge
+gge
+nrV
+gge
+gge
+gge
+dYe
+ttx
+hFz
+hFz
+pOI
+pOI
+suO
+gge
+gge
+gge
+dMl
+"}
+(27,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+hMr
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+rcB
+fsg
+fsg
+fsg
+fsg
+rRT
+rRT
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+tWV
+tWV
+tWV
+tWV
+tWV
+rRT
+fsg
+fsg
+fsg
+fsg
+hTt
+cgl
+xIw
+xIw
+sWE
+sWE
+xIw
+xIw
+hLK
+osr
+osr
+hLK
+osr
+osr
+xvV
+xvV
+oQD
+oQD
+oQD
+wmm
+wmm
+rck
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+kHI
+aoQ
+kHI
+kHI
+csp
+csp
+nIe
+csp
+csp
+ceL
+gfy
+lGp
+gfy
+mcj
+eRW
+dKh
+wdb
+mwc
+aoW
+olZ
+pXV
+wls
+lie
+lie
+uWw
+mcj
+ceL
+gfy
+ulT
+lkp
+cZH
+lkp
+lkp
+lkp
+hOR
+lkp
+lkp
+lkp
+aRN
+lkp
+lkp
+lkp
+cZH
+lkp
+lkp
+lkp
+cZH
+lkp
+nYP
+lkp
+cVq
+gfy
+rbz
+mZk
+mZk
+gge
+gge
+gge
+gge
+hFz
+hFz
+gge
+nkP
+hyN
+hFz
+pOI
+pOI
+pOI
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(28,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+qyP
+hMr
+qyP
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fse
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+hMr
+fsg
+fsg
+fsg
+tsp
+fsg
+fsg
+fsg
+hMr
+fsg
+rRT
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+ibE
+tWV
+ibE
+tWV
+tWV
+rRT
+gSc
+fsg
+fsg
+fsg
+xIw
+cgl
+wWM
+vTo
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+feI
+osr
+osr
+xvV
+ohG
+oQD
+hTt
+wmm
+wmm
+wmm
+kHI
+kHI
+kHI
+kHI
+lmg
+kHI
+kHI
+kHI
+dKd
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+csp
+csp
+gfy
+gfy
+gfy
+gfy
+vbN
+mcj
+mcj
+mcj
+vbN
+efu
+fxP
+aoW
+vbN
+mcj
+mcj
+mcj
+vbN
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+svT
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+dVQ
+gfy
+rbz
+mZk
+gge
+gge
+gge
+gge
+gge
+hFz
+dYe
+dYe
+hFz
+pOI
+suO
+pOI
+hwX
+pOI
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(29,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+hMr
+fsg
+gSc
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vbU
+fsg
+fsg
+fsg
+bmY
+fsg
+fsg
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+tWV
+mjK
+tWV
+mjK
+tWV
+rRT
+fsg
+fsg
+fsg
+fsg
+xIw
+cgl
+xIw
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+hLK
+osr
+osr
+xvV
+xvV
+oQD
+hTt
+wmm
+wmm
+rck
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+csp
+csp
+csp
+nIe
+csp
+csp
+ceL
+gfy
+gfy
+ceL
+gfy
+gfy
+gfy
+gfy
+vbN
+mcj
+aUT
+mcj
+vbN
+svT
+gfy
+gfy
+gfy
+gfy
+svT
+gfy
+gfy
+obD
+rbz
+rbz
+rbz
+obD
+rbz
+rbz
+rbz
+obD
+rbz
+rbz
+obD
+rbz
+rbz
+rbz
+obD
+rbz
+rbz
+obD
+gfy
+lsO
+gfy
+obD
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+dYe
+hFz
+hFz
+suO
+qNm
+mkx
+qNm
+pOI
+hFz
+gge
+gge
+gge
+gge
+dMl
+"}
+(30,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+vbU
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+rRT
+tWV
+tWV
+tWV
+rRT
+fsg
+fsg
+hMr
+fsg
+fsg
+vTo
+cgl
+xIw
+xIw
+xIw
+xIw
+xIw
+osr
+osr
+osr
+osr
+osr
+xvV
+oQD
+wmm
+wmm
+wmm
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoE
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+nIe
+csp
+csp
+gfy
+gfy
+xYI
+xYI
+xYI
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+lqV
+gfy
+gfy
+gfy
+gfy
+lGp
+ceL
+gfy
+rbz
+gcU
+imH
+mZk
+mZk
+imH
+mZk
+gcU
+gcU
+mZk
+imH
+gcU
+mZk
+mZk
+gcU
+mZk
+mZk
+mZk
+rbz
+gfy
+qea
+gfy
+rbz
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+pOI
+pOI
+pOI
+qNm
+qNm
+pOI
+pOI
+dYe
+dYe
+gge
+gge
+gge
+dMl
+"}
+(31,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+gSc
+fsg
+fsg
+gSc
+fsg
+fsg
+gSc
+fsg
+gSc
+hTt
+hTt
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+gSc
+fsg
+fsg
+fsg
+eZd
+fsg
+fsg
+gSc
+fsg
+hTt
+hTt
+vbU
+hMr
+fsg
+fsg
+nYW
+fsg
+fsg
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+vVO
+rRT
+tWV
+rRT
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+xIw
+cgl
+vTo
+xIw
+xIw
+vTo
+xIw
+xIw
+hLK
+osr
+xvV
+xvV
+xvV
+oQD
+wmm
+wmm
+kHI
+kHI
+kHI
+lmg
+kHI
+kHI
+dKd
+kHI
+aoQ
+kHI
+kHI
+kHI
+kYp
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+csp
+csp
+nIe
+bNm
+nIe
+csp
+csp
+gfy
+xYI
+saz
+obD
+ceL
+gfy
+gfy
+vDV
+gfy
+gfy
+lqV
+ceL
+lGp
+lqV
+gfy
+ceL
+gfy
+gfy
+gfy
+gfy
+rbz
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+imH
+rbz
+gfy
+qea
+gfy
+rbz
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+pOI
+mkx
+qNm
+hwX
+pOI
+pOI
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(32,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+fsg
+fsg
+vVO
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+rRT
+rRT
+rRT
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+gSc
+hTt
+hTt
+vbU
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+xIw
+rRT
+xIw
+xIw
+xIw
+xIw
+sWE
+osr
+osr
+osr
+hTt
+oQD
+oQD
+hTt
+wmm
+hTt
+rck
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+nIe
+mdp
+csp
+csp
+gfy
+xYI
+iKJ
+rbz
+gfy
+gfy
+lGp
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+obD
+rbz
+rbz
+rbz
+obD
+mZk
+mZk
+mZk
+mZk
+mZk
+vYj
+mZk
+mZk
+mZk
+mZk
+ojt
+goR
+mZk
+mZk
+hpw
+gcU
+mZk
+rbz
+gfy
+qea
+gfy
+rbz
+mZk
+mZk
+gge
+gge
+gge
+gge
+gge
+hFz
+pOI
+qNm
+elp
+bXq
+pOI
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(33,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+fsg
+fsg
+vVO
+fsg
+fsg
+vVO
+fsg
+vVO
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+hMr
+fsg
+wmm
+wmm
+wmm
+wmm
+rRT
+fse
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+hTt
+vbU
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+rRT
+rRT
+rRT
+rRT
+xIw
+xIw
+sWE
+sWE
+sWE
+xIw
+osr
+eyO
+oQD
+hTt
+hTt
+hTt
+wmm
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+lmg
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+xfA
+nIe
+nIe
+csp
+csp
+csp
+lGp
+xYI
+rbz
+gfy
+gfy
+gfy
+obD
+rbz
+rbz
+rbz
+rbz
+rbz
+rbz
+rbz
+rbz
+obD
+mZk
+imH
+imH
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+mZk
+xYI
+xYI
+xYI
+imH
+rbz
+gfy
+lsO
+gfy
+rbz
+mZk
+mZk
+mZk
+gge
+gge
+gge
+gge
+nkP
+noj
+hwX
+qNm
+qNm
+pOI
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(34,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+vVO
+rRT
+hTt
+hTt
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+hTt
+hTt
+rRT
+tWV
+rRT
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+hTt
+vbU
+fsg
+fsg
+fsg
+fsg
+fsg
+rRT
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+gSc
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+xIw
+cgl
+wWM
+xIw
+sWE
+hTt
+oQD
+oQD
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+fEk
+kHI
+aoQ
+kHI
+dKd
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+kHI
+kHI
+rck
+kHI
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+csp
+fGe
+rbz
+gfy
+gfy
+gfy
+rbz
+mZk
+mZk
+mZk
+mZk
+mZk
+imH
+mZk
+gcU
+mZk
+jiZ
+mZk
+mZk
+mZa
+bsM
+bsM
+bsM
+mZk
+bsM
+bsM
+bsM
+mZk
+bsM
+bsM
+bsM
+bsM
+mZk
+xYI
+afW
+xYI
+mZk
+vnD
+gfy
+qea
+gfy
+obD
+rbz
+rbz
+rbz
+rbz
+obD
+fpV
+fpV
+fpV
+sMB
+mkx
+qNm
+qNm
+sMB
+dYe
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(35,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+gSc
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+rRT
+hTt
+hTt
+hTt
+fsg
+fsg
+njE
+vVO
+fsg
+hTt
+rRT
+tWV
+mjK
+tWV
+rRT
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+vVO
+vVO
+fsg
+fsg
+fsg
+hMr
+fsg
+vbU
+vbU
+fsg
+fsg
+hMr
+fsg
+rRT
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gSc
+vVO
+vVO
+hMr
+fsg
+hMr
+fsg
+xIw
+jnO
+xIw
+xIw
+sWE
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+dKd
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+oxl
+xYI
+rbz
+gfy
+gfy
+gfy
+rbz
+mZk
+mZk
+mZk
+mZa
+bsM
+bsM
+bsM
+mZk
+mZk
+bsM
+mZk
+bsM
+bsM
+bsM
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+bsM
+bsM
+xYI
+xYI
+xYI
+mZk
+rbz
+gfy
+qea
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+gfy
+qNm
+qNm
+qNm
+qNm
+qNm
+qNm
+qNm
+fpV
+dil
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(36,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+vVO
+rRT
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+fsg
+rRT
+tWV
+tWV
+tWV
+tWV
+tWV
+rRT
+vVO
+gSc
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vbU
+vbU
+gSc
+fsg
+rRT
+rRT
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+eZd
+xIw
+cgl
+xIw
+xIw
+sWE
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+kHI
+kHI
+kHI
+kHI
+fEk
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+hcF
+csp
+csp
+csp
+csp
+xfA
+nIe
+nIe
+csp
+csp
+csp
+xYI
+obD
+gfy
+ceL
+svT
+obD
+mZk
+mZk
+mZk
+bsM
+gge
+gge
+bsM
+bsM
+bsM
+mZk
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+bsM
+bsM
+mZk
+gcU
+mZk
+rbz
+gfy
+veC
+lkp
+lkp
+nYP
+lkp
+lkp
+lkp
+lkp
+irz
+irz
+irz
+irz
+ntg
+gHS
+qNm
+fpV
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(37,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+vVO
+rRT
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fyw
+eXf
+tWV
+tWV
+tWV
+tWV
+tWV
+eXf
+gSc
+fsg
+fsg
+vVO
+fsg
+qyP
+fsg
+ybW
+fsg
+gSc
+hMr
+fsg
+vVO
+vVO
+vbU
+vbU
+vbU
+vbU
+oQD
+oQD
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+xIw
+jnO
+xIw
+xIw
+sWE
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+rck
+kHI
+fNS
+kHI
+kHI
+rck
+kHI
+fVY
+kHI
+fEk
+rck
+kHI
+fVY
+fVY
+kHI
+rck
+kHI
+kHI
+rck
+kHI
+csp
+csp
+csp
+csp
+mdp
+nIe
+nIe
+csp
+cVI
+csp
+xYI
+rbz
+gfy
+lGp
+gfy
+rbz
+mZk
+mZk
+bsM
+gge
+gge
+gge
+gge
+gge
+xIZ
+mZk
+xIZ
+xIZ
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+bsM
+mZk
+mZk
+imH
+rbz
+gfy
+ceL
+gfy
+gfy
+gfy
+iMg
+gfy
+gfy
+gfy
+mkx
+qNm
+qNm
+qNm
+cJS
+euc
+qNm
+fpV
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(38,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+vVO
+rRT
+hTt
+hTt
+hTt
+fsg
+vVO
+fsg
+fsg
+fsg
+eXf
+tWV
+mjK
+tWV
+mjK
+tWV
+eXf
+hMr
+fsg
+fsg
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+gSc
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+vVO
+fsg
+xIw
+cgl
+xIw
+sWE
+sWE
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+bTQ
+kHI
+fVY
+kHI
+lmg
+fVY
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+csp
+xYI
+rbz
+gfy
+gfy
+gfy
+rbz
+mZk
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+xIZ
+mZk
+mZk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+bsM
+mZk
+mZk
+mZk
+obD
+rbz
+obD
+gfy
+gfy
+gfy
+obD
+rbz
+rbz
+obD
+fpV
+fpV
+fpV
+sMB
+uYH
+qNm
+qNm
+sMB
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(39,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+gSc
+rRT
+rRT
+rRT
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+rRT
+tWV
+tWV
+tWV
+rRT
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+jPG
+fsg
+qyP
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+rRT
+hTt
+hTt
+vVO
+vVO
+sWE
+sWE
+sWE
+sWE
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+mTB
+kHI
+kHI
+kHI
+kHI
+kHI
+fVY
+tsn
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+fEk
+kHI
+kHI
+kHI
+kHI
+kHI
+rEZ
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+xfA
+csp
+sus
+ife
+sYY
+sYY
+sYY
+ife
+oot
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+hqs
+cjl
+wgE
+wgE
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+nmN
+pQj
+nmN
+nmN
+evu
+wgE
+wgE
+wgE
+fpV
+qNm
+bXq
+qNm
+fpV
+hFz
+dil
+hFz
+hFz
+hFz
+hFz
+fpV
+ftz
+qNm
+qNm
+uNd
+nrV
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(40,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+fsg
+hMr
+vVO
+vVO
+fsg
+fsg
+vVO
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+hTt
+hTt
+hTt
+rRT
+tWV
+rRT
+wmm
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+hMr
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+hMr
+fsg
+rRT
+hTt
+hTt
+hTt
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+mTB
+aoQ
+kHI
+uHJ
+lLN
+blb
+lLN
+lLN
+nPo
+xQK
+irf
+lLN
+lLN
+lLN
+lLN
+xwi
+kHI
+aoQ
+rck
+kHI
+pPo
+qRK
+csp
+csp
+nIe
+rCX
+rCX
+rCX
+csp
+csp
+csp
+xMH
+ife
+sYY
+sYY
+sYY
+ife
+lgj
+gge
+gge
+gge
+gge
+gge
+gge
+oot
+mGl
+pfV
+qox
+qKi
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+nmN
+pQj
+nmN
+nmN
+hkC
+nmN
+wgE
+gLU
+wgE
+fpV
+hwX
+mkx
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+nrV
+nrV
+uNd
+uYH
+mkx
+qNm
+uNd
+nrV
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(41,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+fsg
+fsg
+vVO
+vVO
+fyw
+fsg
+fsg
+hMr
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+qyP
+fsg
+qyP
+fsg
+vVO
+vVO
+eXf
+eXf
+eXf
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+vVO
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wjA
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+mTB
+kHI
+kHI
+ghM
+fNz
+shc
+shc
+fNz
+iCw
+sWN
+qUu
+shc
+shc
+bZb
+gDG
+ikX
+fVY
+kHI
+kHI
+kHI
+oJT
+xjS
+qRK
+xjS
+xjS
+oTK
+lCX
+xjS
+otb
+xjS
+fUm
+tBu
+nGZ
+iLA
+pfV
+sYY
+ubL
+lgj
+gge
+gge
+gge
+gge
+gge
+gge
+hbA
+sus
+sus
+qKi
+wgE
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+pQj
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+wgE
+wgE
+nmN
+vuP
+moW
+qpP
+moW
+vuP
+hFz
+hFz
+hFz
+hFz
+nkP
+hyN
+uNd
+uYH
+bXq
+qNm
+fpV
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(42,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+fsg
+gSc
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+gSc
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+fsg
+gSc
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+hMr
+fsg
+gSc
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wjA
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+mTB
+fVY
+fVY
+ghM
+csH
+qCI
+uej
+shc
+cVX
+hFT
+jdt
+etD
+gEM
+qCI
+fDc
+xFw
+kHI
+kHI
+aoE
+kHI
+kDJ
+fUm
+qRK
+otb
+gOE
+rmB
+vic
+eSE
+otb
+otb
+vic
+gAq
+sYY
+sYY
+sYY
+sYY
+ife
+lgj
+gge
+gge
+gge
+gge
+gge
+gge
+oot
+hbA
+hbA
+nmN
+gge
+gge
+swn
+nmN
+nmN
+nmN
+swn
+gge
+gge
+gge
+pQj
+nmN
+hkC
+nmN
+aUP
+nmN
+nmN
+vuP
+moW
+moW
+moW
+vuP
+vXz
+jzZ
+eGs
+vuP
+moW
+moW
+moW
+vuP
+hFz
+hFz
+sMB
+uYH
+qNm
+qNm
+sMB
+epG
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(43,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gSc
+fsg
+vVO
+fsg
+fsg
+qyP
+fsg
+qyP
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+hTt
+gSc
+fsg
+fsg
+fsg
+eXf
+gSc
+fsg
+fsg
+hMr
+fsg
+eXf
+fsg
+fsg
+gSc
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+mTB
+mTB
+kHI
+kHI
+qHl
+shc
+fDc
+shc
+vqo
+yiy
+xKW
+kUV
+iFo
+fDc
+fDc
+shc
+xFw
+kHI
+kHI
+kHI
+kHI
+fIl
+noE
+lCX
+lCX
+lCX
+vpW
+kdk
+lCX
+kei
+lCX
+rmB
+eKM
+dPd
+sYY
+owi
+sYY
+ife
+oot
+gge
+gge
+hYR
+hYR
+oot
+lgj
+lgj
+lgj
+nwv
+nmN
+nnu
+nmN
+aom
+nmN
+aom
+nmN
+aom
+swn
+swn
+nmN
+nmN
+nmN
+nmN
+nmN
+evu
+hkC
+nmN
+moW
+kCG
+aiE
+iec
+rKg
+mfu
+fog
+eTl
+jlo
+ugK
+voL
+vkI
+moW
+dil
+hFz
+fpV
+uYH
+qNm
+qNm
+fpV
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(44,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fse
+vVO
+vVO
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+hMr
+eXf
+fsg
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+mTB
+kHI
+fEk
+kHI
+ghM
+owt
+qCI
+bCv
+vxx
+bCv
+shc
+vfT
+eIT
+shc
+fDc
+shc
+xFw
+aoQ
+kHI
+rck
+kHI
+kDJ
+fUm
+jXn
+vic
+lCX
+lCX
+nGY
+vpW
+lCX
+vpo
+vpW
+twt
+uCa
+sYY
+sYY
+sYY
+ife
+oot
+gge
+hYR
+hYR
+vTA
+oot
+oot
+oot
+xGk
+oot
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+hkC
+nmN
+nmN
+nmN
+moW
+qfF
+msA
+wAp
+hcw
+cUZ
+rLx
+tMQ
+ivh
+lOZ
+bJW
+qwT
+moW
+hFz
+hFz
+bQn
+uYH
+bXq
+qNm
+fpV
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(45,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+njE
+vVO
+fsg
+fsg
+vVO
+hTt
+hTt
+hTt
+hTt
+vVO
+eXf
+eXf
+nzb
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gSc
+fsg
+fsg
+fsg
+fsg
+ybW
+fsg
+ybW
+fsg
+fsg
+eXf
+fsg
+fsg
+chU
+fsg
+fsg
+gSc
+fsg
+hMr
+fsg
+fsg
+fsg
+eXf
+hMr
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+mTB
+mTB
+kHI
+kHI
+aoQ
+cNc
+csH
+fDc
+oBv
+fNz
+rqw
+tWj
+jqt
+shc
+bui
+fDc
+fDc
+shc
+kHI
+kHI
+kHI
+kHI
+fIl
+lCX
+eNZ
+otb
+gOE
+cQG
+lCX
+mZw
+gOE
+otb
+lCX
+fOQ
+sYY
+sYY
+pfV
+sYY
+ife
+oot
+hYR
+hYR
+oot
+oot
+oot
+oot
+oPC
+nwv
+knx
+nmN
+nmN
+nmN
+nmN
+nmN
+nnu
+nmN
+nmN
+nmN
+nmN
+nmN
+aUP
+nmN
+nmN
+nmN
+nmN
+nmN
+nmN
+moW
+rvj
+aJN
+vla
+kWa
+mfu
+qta
+ufA
+kWa
+jnp
+lOZ
+ntl
+moW
+hFz
+hFz
+fpV
+uYH
+mkx
+qNm
+fpV
+hFz
+dYe
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(46,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+fsg
+fsg
+vVO
+vVO
+hTt
+hTt
+hTt
+vVO
+fsg
+fsg
+fsg
+vVO
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+eXf
+fsg
+fsg
+fsg
+eZd
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wjA
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+mTB
+kHI
+kHI
+kHI
+kHI
+cNc
+xvs
+csH
+gqm
+krh
+tnM
+mso
+lrp
+bnC
+aJh
+fDc
+sWN
+fDc
+kHI
+kHI
+kHI
+kHI
+orf
+aYO
+xjS
+aYO
+lCX
+xjS
+xjS
+xjS
+xjS
+otb
+lCX
+wrP
+ubL
+ife
+ife
+ife
+ubL
+oot
+hYR
+oot
+oot
+oot
+oot
+oot
+oot
+oot
+oot
+wgE
+wgE
+wgE
+wgE
+wgE
+wgE
+wgE
+cTP
+wgE
+aom
+aom
+swn
+xCL
+aom
+nmN
+hkC
+nmN
+vuP
+vuP
+nmV
+nfn
+kWa
+kWa
+knh
+gTM
+ufA
+kWa
+kWa
+hLg
+hbc
+vuP
+vuP
+fpV
+sMB
+uYH
+qNm
+qNm
+sMB
+hFz
+dYe
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(47,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+vVO
+vVO
+hTt
+hTt
+vVO
+fsg
+fsg
+fsg
+vVO
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+fsg
+hMr
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+eXf
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+eXf
+fsg
+fsg
+fsg
+wjA
+wjA
+wjA
+wjA
+wjA
+wjA
+wjA
+wjA
+oQD
+oQD
+oQD
+wjA
+wjA
+wjA
+wjA
+wmm
+wmm
+wmm
+wjA
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+cNc
+shc
+qCI
+cWy
+oTz
+jqt
+ggQ
+ptg
+fDc
+uud
+csH
+shc
+shc
+fVY
+kHI
+rck
+kHI
+pPo
+qRK
+csp
+jcs
+rCX
+rCX
+nIe
+nIe
+nIe
+csp
+csp
+ptK
+sus
+oot
+oot
+oot
+oot
+oot
+xGk
+oot
+oot
+oot
+oot
+knx
+oot
+sus
+sus
+wgE
+wRg
+wRg
+wRg
+wRg
+wRg
+wRg
+wRg
+cTP
+wgE
+wgE
+wgE
+cTP
+wgE
+evu
+nmN
+nmN
+moW
+wOR
+pff
+lgA
+xiC
+jzZ
+uRG
+gTM
+eTl
+fJU
+jzZ
+uRG
+eTl
+eGs
+moW
+qNm
+qNm
+uYH
+qNm
+qNm
+fpV
+dYe
+dYe
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(48,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+fsg
+gSc
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+vVO
+rRT
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+eXf
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+gSc
+fsg
+hMr
+eXf
+fsg
+fsg
+wmm
+wjA
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wjA
+wmm
+wmm
+wmm
+wjA
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+fVY
+ghM
+fDc
+shc
+qCI
+ldD
+shc
+shc
+fDc
+fNz
+shc
+fDc
+shc
+xFw
+fVY
+kHI
+kHI
+kHI
+pQw
+csp
+csp
+csp
+nIe
+nIe
+nIe
+nIe
+nIe
+csp
+csp
+xMg
+sus
+oot
+oot
+knx
+oot
+xGk
+oot
+oot
+uoU
+oot
+sus
+sus
+sus
+eHQ
+ovx
+wRg
+xGU
+wRg
+wRg
+wpD
+wRg
+hTA
+wRg
+wRg
+wRg
+wRg
+wRg
+wRg
+cTP
+wgE
+nmN
+nmN
+cVC
+fFn
+nlz
+pqc
+pqc
+pqc
+pqc
+lLx
+pqc
+qBj
+pqc
+pqc
+nlz
+hKq
+uDU
+bCZ
+irz
+ffS
+bwf
+qNm
+fpV
+dYe
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(49,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+vVO
+fsg
+fsg
+fsg
+qyP
+fsg
+jPG
+fsg
+vVO
+rRT
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+vVO
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+eXf
+fsg
+fsg
+wmm
+wjA
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wjA
+wmm
+wmm
+wmm
+wjA
+wmm
+wmm
+wmm
+wmm
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+ghM
+shc
+fDc
+shc
+siR
+jsT
+xZE
+jsT
+rEY
+shc
+fDc
+oTz
+xFw
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+nIe
+csp
+csp
+hKv
+sus
+sus
+sus
+sus
+sus
+sus
+sus
+oot
+oot
+sus
+sus
+hKv
+hKv
+hKv
+hKv
+hTA
+wRg
+wRg
+wRg
+wRg
+hTA
+wRg
+wRg
+wpD
+wRg
+wRg
+wRg
+wRg
+wpD
+cTP
+nmN
+nWJ
+moW
+cwW
+hJn
+cMt
+gDZ
+jOU
+ewC
+gTM
+dOj
+jOU
+jOU
+lOZ
+dOj
+mym
+moW
+qNm
+qNm
+uYH
+qNm
+qNm
+eLx
+dil
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(50,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+gSc
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+rRT
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+vVO
+vVO
+vVO
+fsg
+fsg
+vVO
+fsg
+vVO
+hMr
+fsg
+vVO
+vVO
+vVO
+vVO
+vVO
+wmm
+wmm
+wmm
+wjA
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wjA
+wmm
+wmm
+wmm
+wjA
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+fVY
+ghM
+fDc
+lZO
+fDc
+shc
+gEM
+csH
+shc
+shc
+krh
+rSg
+fNz
+aae
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+xfA
+csp
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+sus
+sus
+sus
+sus
+wUC
+kiw
+hKv
+hKv
+hKv
+wRg
+wRg
+udO
+udO
+wRg
+wRg
+wRg
+wRg
+uPd
+wRg
+hTA
+wRg
+kgw
+wRg
+wgE
+nmN
+nmN
+vuP
+vuP
+nmV
+nfn
+kWa
+kWa
+kuX
+gTM
+ufA
+kWa
+kWa
+kRG
+uTf
+vuP
+vuP
+fpV
+tvW
+uYH
+mkx
+qNm
+tvW
+hFz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(51,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+qyP
+fsg
+qyP
+fsg
+vVO
+rRT
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+hMr
+gSc
+fsg
+vVO
+fsg
+fsg
+fsg
+fsg
+vVO
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+kHI
+fwc
+fwc
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+ghM
+shc
+csH
+qWd
+gDG
+csH
+sWN
+shc
+fDc
+shc
+rqw
+kRe
+xFw
+kHI
+kHI
+rck
+kHI
+kHI
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+csp
+hKv
+uqP
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+uqP
+hKv
+hKv
+wRg
+wRg
+udO
+udO
+udO
+udO
+wRg
+wRg
+wRg
+wRg
+wRg
+wRg
+wRg
+wRg
+wgE
+nmN
+nmN
+nmN
+moW
+jrc
+pwN
+ipI
+kWa
+eZN
+gTM
+ufA
+kWa
+xUG
+jwz
+ssX
+moW
+hFz
+hFz
+bQn
+uYH
+qNm
+qNm
+fpV
+mMJ
+hFz
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(52,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+vVO
+vVO
+fsg
+fsg
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+hMr
+fsg
+fsg
+vVO
+rRT
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+eXf
+eXf
+eXf
+vVO
+vVO
+hTt
+hTt
+hTt
+hTt
+oQD
+oQD
+oQD
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+pha
+shQ
+fwc
+fwc
+fwc
+fwc
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+rIa
+yjy
+vDL
+vDL
+vDL
+jfg
+jfg
+xhz
+vDL
+vDL
+acY
+vDL
+uVB
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+cVI
+hKv
+hKv
+vBC
+vBC
+iTp
+hKv
+kiw
+hKv
+wUC
+hKv
+tUV
+hKv
+hKv
+hKv
+hKv
+uqP
+wRg
+udO
+udO
+udO
+udO
+wRg
+wRg
+udO
+udO
+wRg
+wpD
+wRg
+wRg
+qZc
+wgE
+nmN
+hkC
+nmN
+moW
+bTR
+aiE
+rsG
+hcw
+wfJ
+pMY
+eTl
+qGj
+uRG
+bJW
+rSw
+moW
+dil
+hFz
+fpV
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(53,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+vVO
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+qyP
+fsg
+qyP
+rRT
+rRT
+rRT
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+pha
+pha
+shQ
+fwc
+fwc
+fwc
+fwc
+kHI
+kHI
+kHI
+kHI
+kHI
+fEk
+kHI
+kHI
+kHI
+kHI
+fVY
+fVY
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+kHI
+kHI
+csp
+csp
+csp
+nIe
+nIe
+nIe
+xfA
+csp
+mdp
+csp
+hKv
+hKv
+hKv
+vBC
+vBC
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+jQj
+hKv
+vBC
+hKv
+hKv
+udO
+wRg
+udO
+udO
+xAn
+pkt
+wRg
+wRg
+udO
+udO
+wRg
+wRg
+wRg
+dkn
+wgE
+nmN
+nmN
+nmN
+moW
+dvS
+wCm
+nUD
+rKg
+oQz
+gTM
+dOj
+ivh
+rBl
+vQp
+cwF
+moW
+hFz
+ryZ
+fpV
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+hFz
+gge
+gge
+gge
+gge
+dMl
+"}
+(54,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+vVO
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+vVO
+fsg
+hMr
+vVO
+vVO
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+rRT
+rRT
+vbU
+rRT
+rRT
+qsZ
+qsZ
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+rRT
+rRT
+rRT
+rRT
+oQD
+hTt
+pha
+pha
+pha
+pha
+shQ
+fwc
+hTt
+fwc
+kHI
+kHI
+kHI
+kHI
+kHI
+bTQ
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+fVY
+fVY
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+csp
+csp
+ovx
+hKv
+wUC
+hKv
+uqP
+hKv
+iTp
+hKv
+hKv
+jQj
+hKv
+hKv
+vBC
+vBC
+vBC
+hKv
+wpD
+wRg
+udO
+udO
+udO
+wRg
+wRg
+wRg
+wRg
+uPd
+wRg
+kgw
+wRg
+dLf
+wgE
+nmN
+nnu
+nmN
+vuP
+moW
+moW
+moW
+vuP
+mli
+nqt
+mym
+vuP
+moW
+moW
+moW
+vuP
+hFz
+hFz
+tvW
+uYH
+qNm
+qNm
+sMB
+hFz
+hFz
+hFz
+gge
+gge
+gge
+gge
+dMl
+"}
+(55,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+vVO
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+jPG
+fsg
+ybW
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+hMr
+vVO
+vVO
+vVO
+vVO
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+jEN
+qsZ
+qsZ
+qsZ
+oLJ
+hNP
+hNP
+syy
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+bpy
+shQ
+pha
+flT
+pha
+pha
+pha
+flT
+oQD
+oQD
+oQD
+hTt
+hTt
+kHI
+rck
+kHI
+kHI
+rck
+aoQ
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+fEk
+kHI
+rck
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+aoE
+kHI
+csp
+csp
+csp
+nIe
+nIe
+nIe
+nIe
+csp
+xjt
+csp
+eHQ
+sus
+hKv
+hKv
+hKv
+hKv
+sHg
+hKv
+hKv
+hKv
+hKv
+uqP
+hKv
+xza
+hKv
+hKv
+wRg
+aAk
+wRg
+udO
+udO
+udO
+wRg
+wpD
+wRg
+wRg
+wRg
+aAk
+hTA
+wRg
+wgE
+nmN
+nmN
+nmN
+nmN
+hFz
+hFz
+hFz
+vuP
+moW
+lSn
+moW
+vuP
+hFz
+hFz
+nkP
+hyN
+hFz
+hFz
+fpV
+uYH
+mkx
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(56,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+vVO
+vVO
+vVO
+vVO
+fsg
+fsg
+vVO
+vVO
+gSc
+fsg
+fsg
+hMr
+fsg
+gSc
+hMr
+fsg
+fsg
+jEN
+qsZ
+qsZ
+pzd
+lgl
+hNP
+oYT
+hNP
+hNP
+hNP
+hNP
+nvD
+hNP
+hNP
+hNP
+nvD
+bpy
+shQ
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+hTt
+hTt
+oQD
+oQD
+wmm
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+aoQ
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+oxl
+csp
+sus
+sus
+sus
+sus
+sus
+sus
+sus
+wUC
+hKv
+xtT
+uqP
+hKv
+hKv
+hKv
+hKv
+uqP
+wRg
+wRg
+wRg
+xxd
+udO
+wRg
+wRg
+wRg
+udO
+hTA
+wRg
+wRg
+wpD
+wRg
+wgE
+aom
+lMn
+vIM
+vIM
+fpV
+sMB
+fpV
+fpV
+qNm
+mkx
+qNm
+fpV
+fpV
+sMB
+fpV
+fpV
+fpV
+bQn
+sMB
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(57,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+vVO
+gSc
+fsg
+hMr
+fsg
+fsg
+fsg
+fyw
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+jEN
+qsZ
+qsZ
+oLJ
+hNP
+oYT
+hNP
+hNP
+hNP
+hNP
+syy
+hNP
+hNP
+hNP
+syy
+hNP
+bpy
+shQ
+pha
+flT
+pha
+hTt
+hTt
+hTt
+hTt
+oCi
+oCi
+oCi
+hTt
+wjA
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+sus
+oot
+oot
+oot
+oot
+oot
+sus
+teN
+hKv
+jQj
+hKv
+hKv
+hKv
+fPW
+hKv
+hKv
+wRg
+uPd
+wRg
+wRg
+wRg
+wRg
+ddy
+wRg
+wRg
+wRg
+wRg
+hTA
+wRg
+wRg
+wgE
+nmN
+vIM
+gTp
+gTp
+qNm
+qNm
+qNm
+qNm
+qNm
+bXq
+qNm
+hwX
+qNm
+qNm
+hwX
+qNm
+hUb
+qNm
+qNm
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+dil
+hFz
+gge
+gge
+gge
+dMl
+"}
+(58,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+vVO
+vVO
+fsg
+fsg
+fsg
+vVO
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+fsg
+rRT
+rRT
+rRT
+vbU
+rRT
+rRT
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+bpy
+shQ
+pha
+pha
+pha
+pha
+tYA
+pha
+oCi
+oCi
+flT
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+uSd
+kHI
+kHI
+kHI
+kHI
+kHI
+aoQ
+kHI
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+sus
+oot
+gge
+gge
+oot
+oot
+sus
+hKv
+tUV
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+tUV
+wRg
+wRg
+wpD
+wRg
+hTA
+wRg
+wRg
+wRg
+wRg
+wpD
+wRg
+wRg
+wRg
+wRg
+wgE
+szB
+vIM
+gTp
+czg
+qNm
+qNm
+qNm
+mkx
+qNm
+qNm
+qNm
+qNm
+qNm
+urK
+qNm
+qNm
+qNm
+qNm
+mkx
+sXv
+qNm
+qNm
+tvW
+ttx
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(59,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hMr
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+rRT
+hNP
+hNP
+hNP
+hNP
+syy
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+hNP
+bpy
+shQ
+flT
+pha
+eeQ
+pha
+tYA
+pha
+flT
+pha
+pha
+eeQ
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+csp
+csp
+csp
+csp
+csp
+nIe
+csp
+csp
+xfA
+csp
+sus
+gge
+gge
+gge
+gge
+oot
+sus
+wUC
+hKv
+hKv
+hKv
+wUC
+hKv
+kiw
+hKv
+wUC
+wpD
+wRg
+wRg
+wRg
+wRg
+wRg
+wpD
+wRg
+wRg
+wRg
+wRg
+cTP
+wgE
+waB
+waB
+nmN
+vIM
+gTp
+dwx
+qNm
+hwX
+qNm
+qNm
+hwX
+qNm
+bXq
+qNm
+bXq
+qNm
+qNm
+hUb
+qNm
+qNm
+qNm
+uYH
+qNm
+qNm
+eLx
+hFz
+hFz
+hFz
+gge
+gge
+gge
+gge
+dMl
+"}
+(60,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+gSc
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+gSc
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+rRT
+pha
+pha
+pha
+bpy
+bpy
+hNP
+pha
+pha
+bpy
+bpy
+bpy
+bpy
+bpy
+shQ
+pha
+eeQ
+pha
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+xfA
+nIe
+csp
+csp
+csp
+oxl
+sus
+lgj
+gge
+gge
+gge
+lgj
+sus
+eHQ
+sus
+hmr
+hKv
+hKv
+hKv
+hKv
+hKv
+hKv
+wRg
+cTP
+wgE
+wgE
+wgE
+wgE
+wgE
+wgE
+wgE
+wgE
+cTP
+wgE
+aom
+sLs
+nmN
+hkC
+lMn
+gTp
+gTp
+hwX
+sMB
+fpV
+fpV
+fpV
+fpV
+fpV
+fpV
+fpV
+sMB
+fpV
+fpV
+tGE
+fpV
+sMB
+sCq
+kCC
+vdS
+bwR
+egF
+egF
+kPb
+kPb
+kPb
+kPb
+kGO
+dMl
+"}
+(61,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hMr
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vVO
+vVO
+vVO
+vVO
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+rRT
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+flT
+pha
+pha
+pha
+flT
+pha
+shQ
+cll
+pha
+pha
+hTt
+hTt
+rRT
+pha
+pha
+pha
+pha
+flT
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+aoE
+csp
+csp
+csp
+nIe
+umJ
+csp
+csp
+csp
+sus
+oot
+gge
+gge
+gge
+lgj
+eyv
+nwv
+oot
+sus
+wpu
+dDa
+dDa
+dDa
+dDa
+dDa
+xfe
+tpL
+wtk
+wtk
+tqi
+tqi
+enC
+bnu
+icC
+icC
+icC
+gWE
+bnu
+icC
+tVy
+tVy
+tpL
+eXo
+jJc
+pvq
+mPD
+mZq
+bIp
+ckJ
+hFz
+dil
+hFz
+hFz
+ttx
+gge
+hFz
+hFz
+hFz
+fpV
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dRc
+dMl
+"}
+(62,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wjA
+wmm
+hTt
+rRT
+eeQ
+flT
+pha
+pha
+pha
+pha
+rTI
+pha
+pha
+pha
+pha
+pha
+pha
+shQ
+pha
+pha
+pha
+hTt
+hTt
+rRT
+flT
+pha
+pha
+pha
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+rck
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+ovx
+eHQ
+oot
+lgj
+jVp
+gge
+gge
+gge
+oot
+gqI
+gqI
+apo
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+mjn
+ojs
+kRi
+kRi
+kRi
+lMu
+kjM
+kRi
+aox
+kRi
+ctO
+pKP
+hFz
+gge
+gge
+gge
+hFz
+mMJ
+hFz
+epG
+dYe
+eLx
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dRc
+dMl
+"}
+(63,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+wmm
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+eXf
+eXf
+nzb
+eXf
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wjA
+wmm
+hTt
+hTt
+pha
+eeQ
+pha
+pha
+pha
+pha
+pha
+eeQ
+pha
+pha
+pha
+flT
+pha
+shQ
+pha
+eeQ
+pha
+oCi
+hTt
+oCi
+oCi
+pha
+pha
+pha
+pha
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+rck
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+sYY
+sus
+oot
+oot
+oot
+lgj
+oot
+gqI
+oot
+gge
+gge
+apo
+kRi
+lMu
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+aAt
+xvW
+tMr
+aAt
+aAt
+jTg
+mjn
+jrN
+hFz
+gge
+gge
+gge
+dYe
+dYe
+dYe
+dYe
+dYe
+tvW
+uYH
+qNm
+qNm
+tvW
+dYe
+hyN
+hFz
+gge
+gge
+gge
+dRc
+dMl
+"}
+(64,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+fsg
+fsg
+fsg
+fsg
+fsg
+fsg
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+kev
+kev
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wjA
+wmm
+hTt
+hTt
+pha
+pSU
+oCi
+oCi
+pha
+pha
+pha
+pha
+pha
+oCi
+tYA
+oCi
+pha
+shQ
+pha
+pha
+oCi
+oCi
+hTt
+hTt
+oCi
+pha
+flT
+pha
+pha
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+fwL
+sus
+oot
+oPC
+oot
+oot
+oot
+oot
+oot
+gge
+wMs
+apo
+kRi
+dkO
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+iiz
+mjn
+jrN
+dil
+hFz
+gge
+gge
+gge
+dYe
+dYe
+dYe
+hFz
+fpV
+uYH
+qNm
+qNm
+fpV
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dRc
+dMl
+"}
+(65,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+pMe
+pMe
+kev
+kev
+kev
+fsg
+fsg
+kev
+kev
+kev
+kev
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wjA
+wmm
+hTt
+hTt
+pha
+pha
+oCi
+oCi
+pha
+pha
+pha
+flT
+oCi
+oCi
+pha
+oCi
+oCi
+shQ
+pha
+pha
+oCi
+hTt
+hTt
+hTt
+oCi
+pha
+pha
+oCi
+pha
+pha
+hTt
+hTt
+wmm
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+aoQ
+rck
+kHI
+kHI
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+sYY
+sus
+gge
+oot
+lgj
+gge
+gge
+oot
+oPC
+wMs
+gge
+apo
+kRi
+dkO
+ewP
+lQS
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+ewP
+ewP
+iiz
+mjn
+rbD
+nrV
+hFz
+gge
+gge
+gge
+mIm
+hFz
+yld
+hFz
+jcu
+uYH
+mkx
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+gge
+gge
+dRc
+dMl
+"}
+(66,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+pMe
+pMe
+kev
+kev
+cix
+kev
+kev
+kev
+kev
+cix
+kev
+kev
+cix
+kev
+hTt
+hTt
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wjA
+wmm
+hTt
+hTt
+hTt
+pha
+pha
+flT
+pha
+hTt
+pha
+pha
+tYA
+pha
+pha
+pha
+tYA
+shQ
+pha
+flT
+oCi
+oCi
+hTt
+hTt
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+sYY
+sus
+lgj
+oot
+gqI
+gge
+gge
+oot
+oot
+gvO
+gge
+apo
+kRi
+dkO
+lQS
+lOy
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+hvF
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+qkX
+lOy
+iiz
+kUn
+vOx
+grK
+hFz
+gge
+gge
+gge
+mMJ
+hFz
+dil
+hFz
+fpV
+fYS
+hwX
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+mMJ
+gge
+dRc
+dMl
+"}
+(67,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+pMe
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wjA
+wmm
+hTt
+hTt
+hTt
+pha
+pha
+pha
+hTt
+hTt
+hTt
+pha
+oCi
+oCi
+pha
+oCi
+oCi
+shQ
+pha
+pha
+pha
+pha
+pha
+hTt
+oCi
+flT
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+nIe
+csp
+csp
+csp
+sYY
+sus
+gge
+oot
+wMs
+wMs
+oot
+oot
+oot
+oot
+oot
+apo
+kRi
+dkO
+ewP
+vyG
+osP
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+iwp
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+mOz
+tPj
+sGJ
+iiz
+kUn
+vOx
+wMs
+mMJ
+gge
+gge
+hFz
+hFz
+hFz
+yld
+hFz
+fpV
+aeI
+bXq
+qNm
+fpV
+hFz
+hFz
+hFz
+mMJ
+hFz
+gge
+dRc
+dMl
+"}
+(68,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+pMe
+pMe
+kev
+kev
+kev
+cix
+kev
+kev
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+pha
+hTt
+hTt
+hTt
+pha
+pha
+pha
+oCi
+tYA
+oCi
+eeQ
+shQ
+pha
+eeQ
+pha
+flT
+eeQ
+tYA
+pha
+pha
+pha
+eeQ
+oCi
+oCi
+flT
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+rck
+kHI
+kHI
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+sYY
+eHQ
+gge
+gqI
+oot
+wMs
+gqI
+oot
+wMs
+xGk
+oot
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+psr
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+oMv
+psr
+dgh
+qZd
+sGJ
+iiz
+kUn
+rbD
+nrV
+dil
+gge
+gge
+gge
+hFz
+nkP
+hyN
+hFz
+bQn
+aeI
+qNm
+qNm
+fpV
+aNN
+hFz
+gge
+hFz
+hFz
+gge
+dRc
+dMl
+"}
+(69,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+cix
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+kev
+kev
+kev
+pMe
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+pha
+pha
+eeQ
+flT
+pha
+eeQ
+pha
+flT
+pha
+eeQ
+pha
+shQ
+pha
+hTt
+pha
+pha
+pha
+tYA
+flT
+pha
+pha
+pha
+oCi
+oCi
+pha
+pha
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+aoQ
+kHI
+kHI
+kHI
+aoQ
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+sYY
+sus
+gaP
+oot
+gvO
+oot
+oot
+wMs
+xGk
+oot
+oot
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+ykG
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+qZd
+sGJ
+iiz
+kUn
+vOx
+hFz
+hFz
+gge
+gge
+gge
+hFz
+dil
+hFz
+hFz
+sMB
+tnP
+qNm
+qNm
+sMB
+mIm
+dil
+gge
+gge
+hFz
+gge
+dRc
+dMl
+"}
+(70,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+seE
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+kev
+seE
+kev
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+oQD
+hTt
+hTt
+hTt
+pha
+pha
+hTt
+rRT
+rRT
+pha
+pha
+flT
+pha
+pha
+pha
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+sYY
+sus
+oot
+oot
+gge
+gge
+oot
+lgj
+lgj
+gqI
+gge
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+qZd
+sGJ
+iiz
+ctO
+apo
+hFz
+dil
+hFz
+gge
+gge
+dYe
+hFz
+hFz
+hFz
+fpV
+uYH
+mkx
+qNm
+fpV
+hFz
+hFz
+gge
+gge
+hFz
+gge
+dRc
+dMl
+"}
+(71,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+cix
+kev
+pMe
+kev
+cix
+kev
+kev
+kev
+kev
+kev
+hTt
+kev
+kev
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+pha
+pha
+pha
+oCi
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+oQD
+hTt
+wFT
+wFT
+ghe
+ghe
+wFT
+wFT
+rRT
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+aoE
+kHI
+yck
+kHI
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+sYY
+sus
+oot
+oot
+wMs
+gge
+wMs
+oPC
+oot
+gge
+gge
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+qZd
+sGJ
+iiz
+mjn
+apo
+vSG
+mZq
+dYe
+gge
+gge
+dYe
+hFz
+gge
+sfs
+hwS
+oVs
+qNm
+qNm
+fpV
+hFz
+hFz
+gge
+gge
+hFz
+gge
+dRc
+dMl
+"}
+(72,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+rVi
+kev
+kev
+kev
+pMe
+pMe
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+shQ
+shQ
+shQ
+twu
+twu
+shQ
+shQ
+shQ
+oQD
+oQD
+oQD
+oQD
+hTt
+oCi
+pha
+pha
+pha
+pha
+oCi
+oCi
+pha
+eeQ
+pha
+pha
+pha
+pha
+pha
+flT
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+xfA
+csp
+nIe
+csp
+csp
+sYY
+sus
+oot
+oot
+oot
+oot
+oot
+oot
+oot
+gge
+gge
+apo
+kRi
+qrp
+ewP
+vyG
+bIf
+dgh
+dgh
+dgh
+ykG
+dgh
+dgh
+dgh
+dgh
+dgh
+ldj
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+qZd
+sGJ
+iiz
+mjn
+gge
+dil
+ckJ
+hFz
+gge
+gge
+dYe
+gge
+gge
+uet
+fpV
+bXq
+qNm
+bXq
+fpV
+hFz
+hFz
+hFz
+hFz
+mMJ
+gge
+dRc
+dMl
+"}
+(73,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kev
+kev
+kev
+kev
+pMe
+kev
+kev
+kev
+kev
+cix
+kev
+pMe
+kev
+cix
+kev
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+pha
+pha
+flT
+pha
+pha
+pha
+pha
+hTt
+hTt
+hTt
+hTt
+hTt
+oCi
+pha
+flT
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+pha
+flT
+pha
+pha
+pha
+pha
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rck
+kHI
+kHI
+rck
+kHI
+kHI
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+sus
+sus
+oot
+lgj
+lgj
+lgj
+lgj
+hYR
+lgj
+lgj
+gge
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+ykG
+dgh
+qZd
+sGJ
+iiz
+kRi
+gge
+gge
+eOS
+vEx
+pOI
+hFz
+dYe
+hFz
+hFz
+uet
+oLa
+qNm
+bXq
+qNm
+fpV
+hFz
+hFz
+gge
+hFz
+hFz
+gge
+dRc
+dMl
+"}
+(74,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+awl
+awl
+awl
+mif
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+hTt
+hTt
+hTt
+oCi
+oCi
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+pha
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+xfA
+csp
+nIe
+nIe
+csp
+csp
+sus
+oot
+oot
+oot
+sUR
+lgj
+oot
+hYR
+gge
+lgj
+gvO
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+oMv
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+qZd
+sGJ
+iiz
+kRi
+gge
+gge
+ums
+eiZ
+bAh
+ddS
+ddS
+ddS
+ddS
+eAe
+fpV
+qNm
+qNm
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+hFz
+gge
+dRc
+dMl
+"}
+(75,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+pMe
+pMe
+kev
+kev
+kev
+kev
+cix
+kev
+seE
+awl
+awl
+mif
+pha
+eeQ
+pha
+pha
+pha
+hTt
+hTt
+hTt
+oCi
+oCi
+oCi
+pha
+pha
+pha
+oCi
+flT
+pha
+pha
+pha
+pha
+flT
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+aoQ
+kHI
+kHI
+kHI
+rck
+csp
+csp
+csp
+nIe
+csp
+csp
+bNm
+sus
+xii
+oot
+oot
+oot
+oot
+lgj
+lgj
+hYR
+lgj
+gge
+apo
+kRi
+dkO
+lQS
+vyG
+bIf
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+qZd
+sGJ
+iiz
+kRi
+uuT
+gge
+bEH
+lwd
+pOI
+hFz
+dYe
+dYe
+hFz
+hFz
+tYq
+xAN
+jCe
+xAN
+tYq
+hFz
+hFz
+hFz
+hFz
+hFz
+hFz
+dRc
+dMl
+"}
+(76,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pMe
+kev
+kev
+kev
+lvz
+kev
+cix
+kev
+kev
+kev
+pMe
+kev
+kev
+kev
+pMe
+lvz
+kev
+kev
+kev
+awl
+bQI
+mif
+pha
+pha
+hTt
+hTt
+hTt
+hTt
+hTt
+oCi
+oCi
+pha
+pha
+flT
+pha
+pha
+pha
+pha
+pha
+pha
+cll
+pha
+pha
+oCi
+oCi
+pha
+flT
+pha
+pha
+pha
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+kHI
+aoQ
+kHI
+kHI
+kHI
+kHI
+kHI
+csp
+csp
+xfA
+csp
+bNm
+csp
+csp
+sus
+oot
+ejt
+oot
+oot
+gqI
+oot
+lgj
+gge
+gge
+gge
+apo
+kRi
+dkO
+ewP
+vyG
+bIf
+dgh
+psr
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+dgh
+oMv
+dgh
+dgh
+dgh
+psr
+dgh
+qZd
+sGJ
+iiz
+kRi
+kRi
+tjJ
+eOS
+gVh
+gxZ
+hFz
+tYq
+xAN
+xAN
+xAN
+tYq
+rVX
+dad
+pkJ
+tYq
+xAN
+xAN
+xAN
+tYq
+mMJ
+mMJ
+dRc
+dMl
+"}
+(77,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pMe
+kev
+cix
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+awl
+xue
+xue
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oCi
+pha
+pha
+pha
+pha
+eeQ
+pha
+pha
+eeQ
+oCi
+oCi
+pha
+pha
+pha
+oCi
+oCi
+pha
+pha
+pha
+pha
+flT
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+aoQ
+kHI
+kHI
+kHI
+kHI
+kHI
+oMS
+csp
+csp
+csp
+nIe
+csp
+csp
+csp
+sus
+gqI
+gqI
+sUR
+ggq
+gkk
+oot
+lgj
+oot
+gge
+gge
+apo
+kRi
+dkO
+ewP
+vyG
+fmm
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+rPf
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+pQI
+jgI
+sGJ
+iiz
+kAi
+jJH
+kRi
+dIs
+rTr
+pOI
+hFz
+xAN
+pSF
+abO
+bVf
+rMh
+gQb
+blc
+oiz
+fgd
+dad
+dad
+nLA
+xAN
+dil
+hFz
+dRc
+dMl
+"}
+(78,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pMe
+kev
+pMe
+lyu
+lyu
+lyu
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+pMe
+lyu
+lyu
+hTt
+kev
+gzQ
+gzQ
+gdJ
+xue
+hTt
+hTt
+hTt
+hTt
+hTt
+oCi
+oCi
+pha
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+pha
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nKP
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+xfA
+csp
+hqs
+oot
+gqI
+oot
+sus
+sus
+sus
+oot
+gge
+gge
+gge
+apo
+kRi
+dkO
+ewP
+lOy
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+tGf
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+dlh
+lOy
+tMr
+jTg
+ikj
+tjJ
+eOS
+aeI
+pOI
+hFz
+xAN
+odx
+hxE
+mCt
+tgF
+aVg
+bPD
+pmT
+fkB
+uLP
+vPV
+xlz
+xAN
+hFz
+hFz
+dRc
+dMl
+"}
+(79,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kev
+cix
+lyu
+kev
+kev
+kev
+lyu
+kev
+seE
+cix
+kev
+kev
+cix
+kev
+kev
+kev
+kev
+hTt
+seE
+gzQ
+gzQ
+gzQ
+bKE
+bKE
+rRT
+hTt
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+flT
+pha
+pha
+flT
+pha
+pha
+pha
+flT
+pha
+eeQ
+pha
+flT
+pha
+pha
+pha
+eeQ
+pha
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+nIe
+cVI
+csp
+csp
+sus
+gqI
+nwv
+gqI
+hqs
+pfV
+sus
+hqs
+hqs
+sus
+ddx
+apo
+kRi
+dkO
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+ewP
+ewP
+xrU
+iiz
+ikj
+tjJ
+pZm
+aeI
+pOI
+qno
+xAN
+rAe
+rve
+dYl
+jrz
+gQb
+yjL
+pmT
+jrz
+eIN
+uLP
+qKm
+xAN
+dil
+hFz
+dRc
+dMl
+"}
+(80,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+seE
+kev
+lyu
+kev
+kev
+kev
+lyu
+seE
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+seE
+kev
+kev
+kev
+gzQ
+gzQ
+gzQ
+gdJ
+gdJ
+rRT
+hTt
+hTt
+hTt
+pha
+pha
+flT
+pha
+hTt
+hTt
+eeQ
+pha
+pha
+pha
+eeQ
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+eeQ
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nkp
+nKP
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+csp
+csp
+csp
+csp
+sus
+hqs
+oot
+knx
+sus
+wtX
+sYY
+sus
+hqs
+vzQ
+iAF
+apo
+kRi
+qrp
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+lka
+ewP
+vFH
+ewP
+tAh
+rZd
+tAh
+eJU
+tAh
+fFe
+ewP
+vuc
+tWm
+ikj
+tjJ
+pZm
+jhq
+pOI
+tYq
+tYq
+csx
+jCe
+jrz
+jrz
+qnL
+jNk
+axD
+jrz
+jrz
+pjb
+vuT
+tYq
+tYq
+hFz
+dRc
+dMl
+"}
+(81,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kev
+kev
+lyu
+kev
+cix
+kev
+lyu
+kev
+kev
+kev
+kev
+pMe
+pMe
+kev
+kev
+kev
+seE
+kev
+kev
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+rRT
+hTt
+hTt
+hTt
+pha
+pha
+pha
+pha
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+oCi
+pha
+pha
+pha
+oCi
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+csp
+xfA
+csp
+xfA
+csp
+csp
+sYY
+sus
+gqI
+oot
+hqs
+sus
+sus
+sus
+sus
+bdM
+ddx
+apo
+kRi
+dkO
+lQS
+ewP
+lQS
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+ewP
+lQS
+ewP
+ewP
+jML
+ewP
+tAh
+oCC
+eJU
+eJU
+tAh
+gpv
+eyj
+iiz
+kAi
+jJH
+kRi
+eOS
+aeI
+qNm
+xAN
+hjS
+bcb
+awu
+lJD
+pMu
+tUo
+aIe
+tMp
+oMY
+faf
+ucz
+oiz
+sMe
+xAN
+hFz
+dRc
+dMl
+"}
+(82,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kev
+kev
+pMe
+lyu
+lyu
+lyu
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+cix
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+hTt
+hTt
+hTt
+hTt
+pha
+oCi
+pha
+pha
+pha
+hTt
+oCi
+oCi
+oCi
+pha
+flT
+pha
+pha
+pha
+pha
+oCi
+pha
+pha
+oCi
+oCi
+pha
+pha
+flT
+oCi
+oCi
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+xfA
+nIe
+csp
+csp
+csp
+csp
+csp
+iLA
+hqs
+oot
+oot
+oot
+gge
+gge
+gge
+gge
+lgj
+lgj
+apo
+kRi
+pPX
+grV
+tHS
+tHS
+tHS
+tHS
+grV
+tHS
+tHS
+cnc
+grV
+dJI
+lka
+ewP
+lka
+ewP
+sXh
+lka
+tAh
+oCC
+eJU
+eJU
+tAh
+maZ
+eyj
+iiz
+kRi
+kRi
+kRi
+eOS
+rwP
+gqf
+fNQ
+mwi
+jhU
+wvT
+vEF
+wvT
+wvT
+aBq
+vtw
+ugi
+wvT
+wvT
+tsM
+weO
+fNQ
+mMJ
+gdo
+dMl
+"}
+(83,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+hTt
+hTt
+rRT
+rRT
+pha
+pha
+pha
+oCi
+pha
+hTt
+hTt
+hTt
+oCi
+pha
+pha
+pha
+cll
+pha
+flT
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nKP
+nkp
+nkp
+csp
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+xfA
+csp
+sYY
+sus
+xGk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+apo
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+dkO
+vWI
+ewP
+lka
+lka
+lka
+ewP
+tAh
+hlS
+tAh
+tAh
+tAh
+tAh
+ewP
+iiz
+kRi
+gge
+gge
+ckJ
+vad
+rwV
+xAN
+mNw
+mef
+gAv
+usq
+xld
+myQ
+hgU
+oiz
+tUo
+tne
+eTN
+bVp
+pCt
+xAN
+hFz
+gge
+dMl
+"}
+(84,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+kev
+kev
+cix
+kev
+kev
+kev
+cix
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+hTt
+hTt
+pha
+pha
+pha
+eeQ
+pha
+pha
+pha
+hTt
+hTt
+hTt
+oCi
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+flT
+pha
+pha
+flT
+pha
+pha
+oCi
+oQD
+hTt
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+xfA
+csp
+nIe
+oxl
+csp
+csp
+csp
+csp
+sYY
+hqs
+oot
+xGk
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+apo
+bIp
+bIp
+bIp
+bIp
+bIp
+bIp
+bIp
+bIp
+bIp
+bIp
+apo
+kRi
+oKI
+ewP
+oKs
+lka
+ewP
+ocH
+ewP
+srN
+eJU
+eow
+eow
+eow
+eow
+ewP
+iiz
+kRi
+gge
+hFz
+pKP
+rAM
+iSY
+tYq
+tYq
+csx
+jCe
+jrz
+jrz
+fCn
+kbQ
+pmT
+jrz
+jrz
+ybk
+jdR
+tYq
+tYq
+hFz
+gge
+dMl
+"}
+(85,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+seE
+kev
+kev
+kev
+kev
+kev
+kev
+kev
+cix
+kev
+kev
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+hTt
+hTt
+pha
+flT
+hTt
+hTt
+eeQ
+flT
+pha
+hTt
+hTt
+hTt
+hTt
+oCi
+pha
+pha
+oCi
+pha
+pha
+oCi
+oCi
+oCi
+pha
+pha
+pSU
+pha
+pha
+flT
+oCi
+oQD
+hTt
+hTt
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+dlz
+pyI
+csp
+csp
+csp
+csp
+csp
+nIe
+csp
+csp
+csp
+csp
+csp
+csp
+sus
+sus
+oot
+oot
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+oot
+leO
+oot
+lgj
+olS
+rbD
+kRi
+toS
+beR
+beR
+beR
+beR
+ens
+beR
+ewP
+ewP
+fpW
+rFo
+pyQ
+dgq
+ewP
+iiz
+kRi
+gge
+hFz
+ckJ
+vad
+pOI
+jgc
+xAN
+ikH
+tYB
+smF
+jrz
+ldb
+jNk
+pmT
+jrz
+czV
+uBY
+qKm
+xAN
+hFz
+hFz
+gge
+dMl
+"}
+(86,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+pMe
+pMe
+pMe
+pMe
+kev
+pMe
+kev
+kev
+kev
+kev
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+hTt
+hTt
+pha
+pha
+hTt
+hTt
+hTt
+eeQ
+pha
+pha
+flT
+hTt
+hTt
+hTt
+eeQ
+pha
+pha
+pha
+eeQ
+oCi
+oCi
+oCi
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+gQx
+hTt
+hTt
+dlz
+nkp
+nKP
+nkp
+nkp
+dlz
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+csp
+csp
+csp
+sus
+sus
+oot
+oot
+oot
+gge
+gge
+gge
+gge
+gge
+jVp
+gge
+gge
+wMs
+kru
+sus
+sus
+bmZ
+sus
+sus
+bmZ
+sus
+sus
+apo
+kRi
+dkO
+ewP
+lQS
+ewP
+ewP
+mCB
+eyj
+beR
+eyj
+ewP
+ccu
+ewP
+qOq
+ewP
+oGV
+kRi
+gge
+gge
+ckJ
+dYe
+hFz
+mIm
+xAN
+pSF
+abO
+lky
+tgF
+aVg
+bhe
+pmT
+fkB
+uLP
+pmT
+xlz
+xAN
+hFz
+dil
+gge
+dMl
+"}
+(87,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+kev
+kev
+kev
+kev
+kev
+ygE
+ygE
+ygE
+kev
+kev
+kev
+kev
+kev
+kev
+gzQ
+gzQ
+gzQ
+gzQ
+rRT
+hTt
+rRT
+pha
+pha
+hTt
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+hTt
+pha
+flT
+pha
+pha
+eeQ
+pha
+pha
+pha
+oCi
+pha
+eeQ
+pha
+hTt
+gQx
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+mdp
+csp
+bNm
+sus
+sus
+sus
+sus
+oot
+oot
+oot
+aHa
+myJ
+gge
+gge
+gge
+gge
+gge
+lgj
+gge
+sus
+sus
+sYY
+sYY
+sYY
+sYY
+sYY
+sYY
+iLA
+sus
+wpu
+kRi
+pPX
+dJI
+vuc
+uaf
+grV
+dJI
+ewP
+brR
+ewP
+ewP
+aVs
+xCc
+sbW
+qyG
+iiz
+kRi
+gge
+gge
+ckJ
+hFz
+dYe
+hFz
+xAN
+odx
+hxE
+vbL
+rMh
+gQb
+jNk
+bVp
+oCL
+bkq
+bco
+xUk
+xAN
+hFz
+hFz
+gge
+dMl
+"}
+(88,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+cix
+kev
+kev
+cix
+kev
+ygE
+pMe
+kev
+kev
+kev
+kev
+kev
+kev
+fTz
+rRT
+rRT
+rRT
+rRT
+hTt
+rRT
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+hTt
+gQx
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+csp
+csp
+sus
+sus
+xGk
+oot
+oot
+oot
+oot
+lgj
+uNx
+gqI
+gge
+gge
+gge
+gge
+eyv
+oot
+oot
+hqs
+sYY
+owi
+sYY
+owi
+sYY
+pfV
+sYY
+sYY
+sYY
+oxC
+kRi
+kRi
+pPX
+pqV
+kRi
+kRi
+kRi
+ewP
+beR
+beR
+beR
+beR
+beR
+beR
+ewP
+iiz
+tjJ
+gge
+gge
+ckJ
+hFz
+rTY
+dYe
+tYq
+xAN
+xAN
+xAN
+tYq
+mOA
+uFd
+daa
+tYq
+xAN
+xAN
+xAN
+tYq
+mMJ
+mMJ
+gge
+dMl
+"}
+(89,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+hTt
+wmm
+wmm
+wmm
+hTt
+awl
+awl
+seE
+xue
+kev
+fnD
+pMe
+awl
+awl
+kev
+awl
+awl
+pMe
+rRT
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+pha
+flT
+pha
+pha
+flT
+pha
+oCi
+pha
+oCi
+flT
+pha
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+flT
+pha
+pha
+hTt
+gQx
+hTt
+hTt
+nkp
+nkp
+nKP
+nkp
+nkp
+csp
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+vTc
+csp
+csp
+sus
+sus
+gge
+oot
+oot
+oot
+oot
+oot
+gge
+lgj
+ejt
+lgj
+gge
+gge
+oot
+oot
+gqI
+oot
+sus
+iLA
+sYY
+sYY
+sus
+sus
+hqs
+sus
+djz
+sus
+tXo
+mNt
+xXc
+xXc
+xXc
+skB
+gsp
+kRi
+kRi
+kRi
+kRi
+kRi
+kRi
+juO
+beR
+kyi
+kRi
+kRi
+gge
+dil
+ckJ
+hFz
+aRK
+hFz
+hFz
+mIm
+hFz
+mnp
+tYq
+xAN
+bYX
+xAN
+tYq
+hFz
+hFz
+hFz
+hFz
+hFz
+hFz
+gge
+dMl
+"}
+(90,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+hTt
+wmm
+wmm
+wmm
+hTt
+awl
+awl
+awl
+nUX
+awl
+fnD
+xue
+xue
+xue
+awl
+bQI
+awl
+xue
+rRT
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+pha
+pha
+pha
+pha
+hTt
+hTt
+pha
+pha
+pha
+pha
+flT
+pha
+pha
+oCi
+pha
+pha
+hTt
+gQx
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+nIe
+mdp
+csp
+csp
+csp
+syl
+sus
+oot
+gge
+hYR
+lgj
+lgj
+lgj
+gge
+gge
+gge
+oot
+xGk
+lgj
+lgj
+lgj
+ejt
+oot
+oot
+nkC
+krd
+vPR
+krd
+nkC
+oot
+oot
+gqI
+oot
+sus
+jOd
+mAe
+vMW
+mAe
+mAe
+xtO
+vKW
+gsp
+gsp
+gsp
+gsp
+uUV
+mwp
+mzs
+eiv
+mzs
+lch
+bIp
+bIp
+bIp
+fBH
+mMJ
+eIB
+aRK
+dYe
+hFz
+hFz
+dYe
+fpV
+qNm
+iFv
+qNm
+fpV
+hFz
+mMJ
+dil
+hFz
+mMJ
+gge
+gge
+dMl
+"}
+(91,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+hTt
+wmm
+wmm
+wmm
+hTt
+awl
+xue
+xue
+awl
+awl
+fnD
+fnD
+fnD
+fnD
+mif
+mif
+xue
+rRT
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+pha
+pha
+pha
+pha
+pha
+eeQ
+oCi
+rCx
+pha
+pha
+pha
+hTt
+hTt
+pha
+pha
+flT
+pha
+pha
+oCi
+pha
+pha
+pha
+hTt
+gQx
+hTt
+hTt
+nkp
+nKP
+nkp
+nkp
+nkp
+pyI
+csp
+oxl
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+csp
+sus
+sus
+gge
+gge
+lgj
+lgj
+hYR
+kjZ
+gge
+gge
+gge
+oot
+sus
+sus
+uJN
+nkC
+krd
+krd
+krd
+nkC
+uHT
+kQN
+uez
+nkC
+krd
+krd
+krd
+nkC
+oot
+xtO
+jOd
+mAe
+mAe
+mAe
+xtO
+jOd
+jOd
+jOd
+kXe
+tMY
+mqh
+xoJ
+qTz
+xXT
+qTz
+xoJ
+gge
+gge
+gge
+gge
+dYe
+eIB
+aRK
+dYe
+djK
+aRK
+dYe
+fpV
+qNm
+mEZ
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(92,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+xue
+xue
+nUX
+awl
+awl
+awl
+nUX
+awl
+awl
+xue
+rRT
+hTt
+hTt
+hTt
+rRT
+rRT
+rRT
+rRT
+pha
+pha
+hTt
+hTt
+pha
+eeQ
+oCi
+oCi
+oCi
+tYA
+tYA
+hTt
+hTt
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+pha
+hTt
+gQx
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+csp
+csp
+sus
+oot
+gge
+gge
+oot
+hYR
+hYR
+hYR
+gge
+gge
+gge
+lgj
+sus
+lLz
+sus
+krd
+dDV
+caG
+hGl
+nkC
+ugj
+uFl
+ppH
+nkC
+kcp
+aCb
+kcp
+krd
+uoN
+sHr
+jOd
+mAe
+mAe
+mAe
+sHr
+jOd
+lhd
+saf
+vWu
+vWu
+vWu
+saf
+taz
+tRY
+iCQ
+saf
+mpu
+mpu
+mpu
+xoJ
+dYe
+aRK
+hFz
+dYe
+dYe
+aRK
+dYe
+fpV
+qNm
+hTZ
+qNm
+fpV
+hFz
+hFz
+hFz
+hFz
+gge
+gge
+gge
+dMl
+"}
+(93,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+bQI
+awl
+xue
+xue
+awl
+awl
+nUX
+awl
+xue
+rRT
+rRT
+rRT
+rRT
+rRT
+xue
+xue
+xue
+pha
+pha
+hTt
+hTt
+pha
+flT
+oCi
+aDN
+pha
+pha
+pha
+hTt
+pha
+pha
+pha
+hTt
+pha
+flT
+pha
+pha
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+nkp
+nKP
+nkp
+nkp
+nkp
+nkp
+nkp
+csp
+csp
+csp
+nIe
+nIe
+csp
+csp
+oxl
+csp
+qcx
+sYY
+sus
+oPC
+gge
+gge
+oot
+hYR
+lgj
+gge
+gge
+gge
+gge
+gge
+sus
+sus
+sus
+krd
+kzq
+uRd
+dDV
+tSI
+bPn
+cHd
+bPn
+tSI
+dDV
+dDV
+kcp
+krd
+oot
+mvh
+jOd
+mAe
+mAe
+mAe
+xtO
+frz
+erc
+ood
+sxe
+sTe
+nyl
+mPt
+tpU
+tRY
+pce
+mPt
+xdW
+nOw
+rEk
+xSD
+dil
+hFz
+hFz
+hFz
+aRK
+aRK
+dYe
+tvW
+qNm
+hTZ
+qNm
+sMB
+hFz
+hFz
+hFz
+gge
+gge
+gge
+gge
+dMl
+"}
+(94,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+awl
+awl
+awl
+awl
+xue
+xue
+awl
+awl
+awl
+nUX
+awl
+nUX
+awl
+awl
+awl
+awl
+awl
+awl
+mif
+pha
+flT
+pha
+hTt
+pha
+pha
+oCi
+bsm
+pha
+flT
+hTt
+hTt
+pha
+sXD
+sXD
+hTt
+pha
+pha
+sXD
+sXD
+gQx
+gQx
+gQx
+hTt
+hTt
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nKP
+nkp
+csp
+csp
+csp
+nIe
+xfA
+csp
+csp
+csp
+sYY
+sus
+sus
+sus
+oot
+lgj
+gge
+ddx
+sus
+uJN
+gge
+gge
+gge
+gge
+gge
+oot
+oot
+oot
+krd
+gmi
+dDV
+qQq
+nkC
+qCk
+cHd
+wYU
+nkC
+rcU
+bdK
+aCb
+krd
+oot
+mvh
+jOd
+fOJ
+mAe
+fOJ
+xtO
+wPp
+wPp
+ood
+ebN
+lwC
+caB
+cEr
+tpU
+oLh
+iCQ
+wCM
+kAG
+lwC
+wri
+xSD
+mMJ
+mMJ
+hFz
+hFz
+hFz
+aRK
+dYe
+fpV
+qNm
+hTZ
+qNm
+fpV
+dil
+hFz
+hFz
+gge
+gge
+gge
+gge
+dMl
+"}
+(95,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+bQI
+awl
+awl
+awl
+awl
+awl
+awl
+bQI
+awl
+awl
+mif
+pha
+pha
+pha
+pha
+pha
+pha
+oCi
+pha
+pha
+gQx
+gQx
+gQx
+whW
+tYA
+hTt
+gQx
+gQx
+gQx
+tYA
+tYA
+hTt
+hTt
+hTt
+hTt
+nkp
+nKP
+nkp
+nkp
+nkp
+nkp
+dlz
+nkp
+hlh
+csp
+csp
+csp
+nIe
+csp
+csp
+csp
+csp
+sYY
+sus
+sus
+gqI
+hqs
+oPl
+sus
+sus
+sYY
+ovf
+gge
+gge
+lgj
+lgj
+lgj
+sus
+sus
+nkC
+nkC
+nkC
+xKY
+nkC
+nkC
+paa
+vJd
+wXx
+nkC
+nkC
+xKY
+nkC
+nkC
+nkC
+xtO
+jOd
+mAe
+mAe
+mAe
+xtO
+wPp
+kXe
+ood
+ebN
+kAG
+hvb
+mPt
+nMT
+tRY
+wgX
+mPt
+kAG
+kAG
+dDF
+xSD
+dil
+hFz
+hFz
+hFz
+dYe
+hFz
+hFz
+fpV
+qNm
+gbz
+qNm
+fpV
+hFz
+mMJ
+hFz
+gge
+uOZ
+gge
+gge
+dMl
+"}
+(96,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+rRT
+rRT
+awl
+awl
+nUX
+awl
+awl
+awl
+bPX
+awl
+awl
+awl
+vlD
+awl
+awl
+awl
+awl
+awl
+awl
+mGf
+eeQ
+pha
+pha
+pha
+pha
+pha
+tYA
+pha
+gQx
+hTt
+hTt
+hTt
+nOK
+nOK
+nOK
+nOK
+hTt
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+dlz
+nkp
+nkp
+nkp
+nKP
+nkp
+nkp
+dlz
+nkp
+kFz
+kVB
+jcs
+rCX
+rCX
+qRK
+csp
+sYY
+owi
+sYY
+sus
+gqI
+oPl
+htU
+sYY
+owi
+sYY
+sus
+sus
+oot
+kjZ
+lgj
+xGk
+sus
+sYY
+krd
+amB
+bPn
+naz
+pbm
+bPn
+bPn
+usC
+fDh
+oAL
+bPn
+qhd
+bPn
+tZc
+krd
+mAe
+mAe
+vMW
+mAe
+mAe
+sHr
+xtO
+saf
+saf
+mPt
+cVM
+mPt
+mPt
+hzS
+tRY
+ayc
+mPt
+mPt
+xrI
+mPt
+saf
+saf
+tJK
+tJK
+dPf
+tJK
+tJK
+tJK
+dPf
+gtL
+lKq
+gtL
+dPf
+iwU
+xrW
+unX
+unX
+xrW
+unX
+uOZ
+dMl
+"}
+(97,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xue
+xue
+awl
+bQI
+xue
+xue
+awl
+awl
+xue
+xue
+nUX
+awl
+xue
+xue
+xue
+xue
+xue
+xue
+xue
+pha
+pha
+pha
+pha
+pha
+flT
+tYA
+sXD
+pha
+pha
+hTt
+hTt
+nOK
+nOK
+wvb
+nOK
+nOK
+nOK
+bYy
+nOK
+wvb
+nOK
+nOK
+bYy
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+nKP
+gYx
+aYO
+xjS
+fUm
+aYO
+aYO
+vpo
+iLA
+sus
+sus
+sus
+oot
+oPl
+uJN
+sus
+xsx
+sYY
+sYY
+sus
+oot
+lgj
+kjZ
+oot
+eHQ
+iOt
+cOq
+bKu
+rMC
+fZP
+fZP
+fZP
+fZP
+lkm
+fZP
+fZP
+fZP
+fZP
+rMC
+lyJ
+cOq
+qjf
+qjf
+deS
+bKX
+mAe
+mAe
+mAe
+xSD
+hBc
+qSN
+qSN
+lFT
+qSN
+nhp
+kux
+gRS
+ena
+rAW
+qSN
+mWC
+hke
+xSD
+gtL
+gtL
+gtL
+gtL
+gtL
+gtL
+gtL
+gtL
+lKq
+dze
+tJK
+iwU
+unX
+snc
+unX
+unX
+gOA
+kdS
+dMl
+"}
+(98,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+nUX
+xue
+xue
+awl
+awl
+xue
+xue
+awl
+hTt
+hTt
+hTt
+hTt
+xue
+hTt
+hTt
+rRT
+eeQ
+flT
+pha
+pha
+pha
+eeQ
+whW
+pha
+edv
+sTg
+nOK
+nOK
+nOK
+bYy
+nOK
+nOK
+nOK
+bYy
+nOK
+azJ
+nOK
+nOK
+sTy
+nOK
+dhG
+nkp
+nkp
+nkp
+nkp
+nKP
+nkp
+nkp
+nkp
+syl
+lDn
+kVB
+fUm
+kVB
+qRK
+lCX
+sYY
+sus
+oot
+gge
+gge
+gge
+hYR
+sus
+sYY
+sus
+sus
+sus
+oot
+lgj
+hYR
+oot
+sus
+sYY
+krd
+amB
+bPn
+bPn
+bPn
+qhd
+xwD
+bKI
+ern
+bPn
+uef
+bPn
+wmr
+qEh
+krd
+mAe
+fOJ
+lUn
+qjf
+uvD
+qjf
+qjf
+nHi
+eJS
+owh
+wbp
+iCQ
+cFU
+asY
+rmS
+lHx
+vrJ
+wkx
+boc
+jWc
+kbc
+rzx
+xNv
+xNv
+jKz
+xNv
+vRv
+xNv
+xNv
+xNv
+rMW
+gtL
+tJK
+iwU
+unX
+unX
+unX
+unX
+qKp
+oYf
+dMl
+"}
+(99,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+awl
+awl
+awl
+nUX
+awl
+awl
+awl
+awl
+awl
+awl
+hTt
+hTt
+hTt
+hTt
+xue
+hTt
+hTt
+rRT
+nOK
+nOK
+nOK
+hTt
+nOK
+nOK
+jcN
+nOK
+nOK
+nOK
+nOK
+nOK
+wvb
+nOK
+nOK
+nOK
+nOK
+wvb
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nKP
+nkp
+nkp
+nkp
+nkp
+nkp
+nkp
+dlz
+hlh
+vpo
+qRK
+qRK
+mkL
+qRK
+kVB
+vpo
+sYY
+eHQ
+oot
+gge
+gge
+gge
+gge
+uJN
+iAF
+uJN
+hYR
+gge
+gge
+gge
+gge
+oot
+sus
+sus
+nkC
+nkC
+nkC
+xKY
+nkC
+nkC
+jZM
+bKI
+naz
+nkC
+nkC
+xKY
+nkC
+nkC
+nkC
+xtO
+xtO
+mAe
+vMW
+mAe
+mAe
+mAe
+xSD
+aHx
+fXT
+lXV
+iqQ
+lXV
+nyR
+sqZ
+fTD
+lXV
+oIs
+dav
+iqQ
+lXV
+xSD
+gtL
+jqV
+gtL
+dze
+gtL
+jqV
+gtL
+gtL
+jqV
+gtL
+tJK
+iwU
+xrW
+unX
+unX
+xrW
+bOP
+gOc
+dMl
+"}
+(100,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+bQI
+awl
+awl
+awl
+awl
+xAO
+awl
+xue
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+nOK
+nOK
+nOK
+hTt
+hTt
+nOK
+jcN
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+wvb
+nOK
+nkp
+nkp
+nkp
+nkp
+nKP
+nkp
+dlz
+nkp
+nkp
+lCX
+fUm
+xjS
+gDH
+xjS
+lCX
+lCX
+sYY
+sus
+oot
+oot
+gge
+gge
+gge
+ddx
+dDv
+ddx
+gge
+gge
+gge
+gge
+gge
+oot
+oot
+oot
+oot
+krd
+aDb
+dDV
+jHV
+nkC
+mJb
+bKI
+oAL
+nkC
+mxt
+dDV
+dhy
+krd
+wPp
+wPp
+sHr
+xtO
+xtO
+sHr
+xtO
+xtO
+saf
+saf
+mPt
+cVM
+mPt
+mPt
+lpg
+tRY
+pTR
+mPt
+mPt
+cVM
+mPt
+saf
+saf
+tJK
+tJK
+dPf
+gtL
+dze
+gtL
+dPf
+tJK
+tJK
+tJK
+dPf
+iwU
+unX
+unX
+xrW
+xrW
+unX
+uOZ
+dMl
+"}
+(101,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+xue
+awl
+awl
+xue
+xue
+nUX
+xue
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+nOK
+nOK
+nOK
+hTt
+hTt
+hag
+jcN
+upL
+nOK
+nOK
+dkB
+dkB
+gHI
+gHI
+gHI
+dkB
+dkB
+nOK
+wvb
+nOK
+byZ
+nOK
+nOK
+nOK
+dlz
+nkp
+nkp
+nkp
+nkp
+dlz
+pyI
+nkp
+nkp
+csp
+otb
+rCX
+nIe
+vWq
+qRK
+lHD
+sYY
+sus
+oot
+gqI
+lgj
+kjZ
+oot
+sus
+sus
+sus
+hYR
+gge
+gge
+gge
+gge
+gge
+sus
+sus
+sus
+krd
+rEP
+bdK
+dDV
+tSI
+bPn
+cME
+qhd
+tSI
+dDV
+uRd
+kcp
+krd
+wPp
+irD
+wPp
+wPp
+frz
+xgW
+jOd
+wPp
+wPp
+xSD
+pRy
+kAG
+cKp
+mPt
+epN
+tRY
+pTR
+xiz
+fEw
+kAG
+ggx
+xSD
+jOd
+jOd
+jOd
+tJK
+gtL
+gtL
+xhy
+tJK
+huk
+huk
+xqd
+unX
+unX
+xrW
+unX
+nnU
+nnU
+nnU
+gge
+dMl
+"}
+(102,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+xue
+awl
+awl
+xue
+xue
+awl
+xue
+xue
+hTt
+hTt
+hTt
+hTt
+rRT
+nOK
+wvb
+nOK
+hTt
+hTt
+jcN
+iYi
+iYi
+wvb
+nOK
+dkB
+aSC
+gQS
+qnm
+qnm
+aSC
+dkB
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nkp
+nkp
+nKP
+nkp
+nkp
+csp
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+sYY
+eHQ
+oot
+gqI
+kjZ
+lgj
+oot
+oot
+xGk
+oot
+oot
+gge
+jVp
+gge
+gge
+gge
+sus
+lLz
+sus
+krd
+cdU
+kzq
+rdT
+nkC
+oDk
+bKI
+xTn
+nkC
+raD
+kzq
+kcp
+krd
+wPp
+gge
+gge
+wPp
+xDu
+iQm
+wPp
+wPp
+kXe
+xSD
+vqS
+lwC
+kAG
+cEr
+tpU
+sSe
+xfM
+cEr
+ndF
+cgr
+omU
+xSD
+jOd
+lhd
+jOd
+tJK
+gtL
+gtL
+gtL
+tJK
+huk
+nwu
+xqd
+unX
+unX
+unX
+nnU
+nnU
+nnU
+nnU
+gge
+dMl
+"}
+(103,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+xue
+awl
+bQI
+awl
+xue
+awl
+bQI
+xue
+hTt
+hTt
+hTt
+hTt
+rRT
+nOK
+nOK
+nOK
+hTt
+hTt
+gQx
+nOK
+nOK
+nOK
+nOK
+gHI
+pDo
+qnm
+qnm
+qnm
+qnm
+gHI
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+csp
+csp
+csp
+csp
+csp
+csp
+oxl
+csp
+csp
+nIe
+xfA
+nIe
+hdN
+csp
+csp
+sus
+sus
+gqI
+gqI
+gge
+gge
+oot
+oot
+oot
+oot
+gge
+gge
+gge
+gge
+gge
+gge
+sus
+sus
+uJN
+nkC
+krd
+krd
+krd
+nkC
+qdt
+uLq
+hxA
+nkC
+krd
+krd
+krd
+nkC
+irD
+gge
+gge
+irD
+wPp
+wPp
+irD
+wPp
+wPp
+xSD
+pvX
+tGG
+nJG
+xvP
+ieB
+cdf
+wgX
+mPt
+oqR
+bCp
+pkm
+xSD
+jOd
+jOd
+jOd
+tJK
+gtL
+gtL
+jqV
+tJK
+huk
+huk
+xqd
+unX
+unX
+nnU
+nnU
+gge
+gge
+nnU
+gge
+dMl
+"}
+(104,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+xue
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+hTt
+hTt
+hTt
+hTt
+rRT
+nOK
+nOK
+nOK
+hTt
+hTt
+gQx
+nOK
+nOK
+bYy
+nOK
+luS
+qnm
+qnm
+heA
+xdo
+qnm
+luS
+bYy
+nOK
+nOK
+azJ
+nOK
+wvb
+nOK
+csp
+csp
+csp
+csp
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+csp
+csp
+csp
+csp
+sus
+oot
+gqI
+gge
+oot
+gge
+sus
+sus
+sus
+oot
+gge
+gge
+gge
+gge
+gge
+oot
+oot
+oot
+lgj
+lgj
+oot
+oot
+oot
+nkC
+krd
+fqV
+krd
+nkC
+wPp
+wPp
+wPp
+wPp
+wPp
+gge
+gge
+irD
+irD
+irD
+gge
+gge
+irD
+xoJ
+mpu
+mpu
+mpu
+saf
+tpU
+byh
+gKD
+saf
+mpu
+mpu
+mpu
+saf
+iih
+vfI
+wPp
+dPf
+gtL
+gtL
+gtL
+dPf
+iwU
+iwU
+unX
+unX
+unX
+jcw
+wMs
+gge
+gge
+nnU
+gge
+dMl
+"}
+(105,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+nUX
+bQI
+awl
+awl
+awl
+awl
+awl
+nUX
+awl
+nUX
+hTt
+hTt
+hTt
+hTt
+rRT
+bYy
+nOK
+nOK
+hTt
+gQx
+nOK
+nOK
+nOK
+nOK
+nOK
+gHI
+qnm
+qnm
+qnm
+qnm
+qnm
+gHI
+nOK
+sTy
+nOK
+nOK
+csp
+csp
+csp
+csp
+csp
+csp
+csp
+csp
+csp
+oxl
+csp
+nIe
+nIe
+nIe
+csp
+csp
+oxl
+csp
+csp
+sus
+oot
+oot
+gge
+hYR
+gge
+sus
+sYY
+ovf
+oot
+gge
+gge
+gge
+gge
+lgj
+oot
+oot
+oot
+lgj
+lgj
+oot
+oot
+oot
+eig
+sLi
+hGO
+sLi
+eig
+wPp
+wPp
+wPp
+irD
+gge
+gge
+gge
+wPp
+wPp
+wPp
+gge
+gge
+irD
+irD
+wPp
+wPp
+wPp
+saf
+mpu
+htz
+mpu
+saf
+wPp
+irD
+irD
+irD
+irD
+gge
+irD
+tJK
+gtL
+gtL
+gtL
+tJK
+iwU
+iwU
+xrW
+unX
+unX
+nnU
+wMs
+gge
+gge
+nnU
+gge
+dMl
+"}
+(106,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+rRT
+rRT
+rRT
+awl
+awl
+xue
+awl
+awl
+xue
+xue
+awl
+awl
+awl
+awl
+awl
+awl
+rRT
+hTt
+rRT
+nOK
+bYy
+nOK
+gQx
+nOK
+nOK
+wvb
+nOK
+bYy
+nOK
+dkB
+aSC
+qnm
+qnm
+qnm
+aSC
+dkB
+nOK
+wvb
+nOK
+nOK
+csp
+csp
+csp
+rTA
+csp
+csp
+bNm
+oxl
+csp
+csp
+nIe
+nIe
+nIe
+xfA
+csp
+csp
+csp
+csp
+syl
+sus
+oot
+oot
+hYR
+lgj
+oot
+sus
+pfV
+sus
+gge
+gge
+gge
+gge
+gge
+oot
+oot
+oot
+oot
+gge
+gge
+oot
+oot
+oot
+eig
+sLi
+lqL
+sLi
+eig
+wPp
+wPp
+wPp
+gge
+gge
+gge
+kpb
+wPp
+wPp
+wPp
+gge
+gge
+gge
+irD
+irD
+wPp
+wPp
+xtO
+mAe
+xnm
+mAe
+tJK
+wPp
+gge
+gge
+gge
+gge
+gge
+irD
+tJK
+gtL
+gtL
+gtL
+tJK
+iwU
+iwU
+unX
+unX
+unX
+nnU
+xou
+wMs
+gge
+nnU
+gge
+dMl
+"}
+(107,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rRT
+awl
+awl
+awl
+awl
+xue
+awl
+awl
+xue
+xue
+awl
+awl
+bQI
+awl
+awl
+awl
+rRT
+hTt
+rRT
+nOK
+nOK
+bYy
+wGK
+nOK
+nOK
+nOK
+bYy
+nOK
+wvb
+dkB
+dkB
+gHI
+gHI
+gHI
+dkB
+dkB
+nOK
+nOK
+pQD
+wvb
+csp
+csp
+csp
+csp
+csp
+nIe
+nIe
+csp
+nIe
+nIe
+nIe
+nIe
+nIe
+csp
+csp
+csp
+csp
+csp
+sus
+sus
+oot
+oot
+lgj
+lgj
+oot
+uJN
+sYY
+sus
+gge
+gge
+gge
+gge
+lgj
+hYR
+oot
+xGk
+oot
+gge
+gge
+gge
+oot
+oot
+eig
+sLi
+hGO
+sLi
+eig
+wPp
+wPp
+wPp
+irD
+nrL
+vfI
+kpb
+wPp
+wPp
+wPp
+gge
+gge
+gge
+gge
+gge
+wPp
+wPp
+xtO
+fOJ
+xnm
+mAe
+tJK
+wPp
+gge
+gge
+gge
+gge
+fhY
+irD
+tJK
+gtL
+dze
+jqV
+tJK
+iwU
+iwU
+unX
+rDq
+unX
+unX
+nnU
+xou
+xou
+nnU
+gge
+dMl
+"}
+(108,1,1) = {"
+dMl
+dMl
+dMl
+wmm
+wmm
+wmm
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+bQI
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+xue
+awl
+bQI
+awl
+hTt
+hTt
+rRT
+wvb
+nOK
+tFe
+bDk
+nOK
+nOK
+rRT
+mZp
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+azJ
+nOK
+nOK
+nOK
+nOK
+csp
+csp
+csp
+csp
+nIe
+nIe
+nIe
+nIe
+nIe
+xfA
+csp
+nIe
+csp
+csp
+cFg
+csp
+csp
+sus
+sus
+oot
+oot
+oot
+lgj
+lgj
+lgj
+uJN
+pfV
+sus
+oot
+gge
+gge
+gge
+oot
+lgj
+gge
+hYR
+hYR
+gge
+gge
+gge
+lgj
+oot
+srn
+sLi
+hGO
+sLi
+srn
+eig
+eig
+eig
+srn
+gge
+gge
+kpb
+irD
+irD
+wPp
+gge
+gge
+gge
+gge
+gge
+irD
+wPp
+sHr
+mAe
+rQB
+mAe
+mYq
+wPp
+irD
+xJZ
+wPp
+wPp
+wPp
+irD
+dPf
+xhy
+gtL
+gtL
+dPf
+iwU
+iwU
+rDq
+unX
+unX
+unX
+unX
+nnU
+uEa
+nnU
+uEa
+dMl
+"}
+(109,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+hTt
+hTt
+awl
+awl
+awl
+awl
+xue
+awl
+bQI
+awl
+awl
+awl
+bQI
+awl
+awl
+awl
+awl
+awl
+awl
+hTt
+hTt
+rRT
+tFe
+tFe
+nOK
+rRT
+rRT
+rRT
+rRT
+rRT
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+wvb
+nOK
+nOK
+nOK
+nOK
+nOK
+nOK
+jCT
+jCT
+jCT
+jCT
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+csp
+oxl
+csp
+csp
+csp
+sus
+sus
+oot
+oot
+oot
+gge
+gge
+oot
+lgj
+uJN
+iAF
+uJN
+lgj
+gge
+gge
+gge
+oot
+gge
+lgj
+hYR
+lgj
+gge
+gge
+gge
+gge
+oot
+eig
+sLi
+lqL
+sLi
+sLi
+sbF
+sLi
+sLi
+eig
+jOd
+gge
+irD
+irD
+irD
+irD
+gge
+gge
+gge
+gge
+gge
+wPp
+wPp
+xtO
+mAe
+xnm
+mAe
+dPf
+fhY
+irD
+wPp
+wPp
+wPp
+lDt
+wPp
+tJK
+gtL
+gtL
+gtL
+tJK
+iwU
+fil
+xqd
+xqd
+unX
+unX
+rVG
+unX
+unX
+unX
+gOA
+dMl
+"}
+(110,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+hTt
+hTt
+awl
+awl
+awl
+awl
+lOC
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+rRT
+rRT
+gQx
+jLz
+jLz
+xDy
+xDy
+xDy
+rRT
+dLD
+lCQ
+gkr
+qti
+qti
+neU
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+jPE
+jPE
+jPE
+jCT
+jCT
+jCT
+jCT
+jCT
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+csp
+csp
+csp
+ovx
+sYY
+sus
+nwv
+oPC
+oot
+xGk
+oot
+gge
+gge
+hYR
+ddx
+ddx
+ddx
+hYR
+lgj
+gge
+gge
+gge
+gge
+lgj
+lgj
+gge
+gge
+gge
+gge
+gge
+oot
+eig
+sLi
+gsc
+tGU
+tGU
+tGU
+lad
+sLi
+tQb
+jOd
+jOd
+wPp
+rkr
+lDt
+irD
+gge
+gge
+gge
+gge
+gge
+wPp
+wPp
+xtO
+mAe
+xnm
+mAe
+tJK
+wPp
+xJZ
+wPp
+gge
+gge
+gge
+irD
+tJK
+gtL
+gtL
+gtL
+tJK
+iwU
+kre
+ihW
+xqd
+unX
+unX
+unX
+unX
+unX
+unX
+qKp
+dMl
+"}
+(111,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+hTt
+hTt
+awl
+awl
+awl
+awl
+awl
+awl
+xue
+awl
+awl
+nUX
+awl
+awl
+awl
+awl
+nUX
+rRT
+gQx
+hTt
+rRT
+gkr
+gkr
+uMC
+gkr
+rRT
+lCQ
+gkr
+gkr
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+viw
+jPE
+jCT
+jCT
+jCT
+hEF
+kMP
+jcl
+jcl
+jcl
+lUf
+jCT
+jCT
+jCT
+csp
+csp
+eHQ
+sus
+sus
+sus
+oot
+oot
+ejt
+oot
+rTV
+gge
+gge
+gge
+oot
+hYR
+eyv
+hYR
+lgj
+gge
+gge
+gge
+oot
+oot
+oot
+gge
+gge
+gge
+oot
+oot
+oot
+eig
+sLi
+sLi
+sLi
+sLi
+sLi
+hGO
+sLi
+srn
+bPi
+frz
+wPp
+wPp
+wPp
+gge
+gge
+gge
+gge
+irD
+jOd
+jOd
+jOd
+sHr
+fOJ
+xnm
+mAe
+tJK
+wPp
+irD
+wPp
+gge
+gge
+irD
+irD
+tJK
+gtL
+dze
+jqV
+tJK
+iwU
+huk
+xqd
+xqd
+unX
+unX
+unX
+unX
+unX
+unX
+bOP
+dMl
+"}
+(112,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+awl
+nUX
+bQI
+awl
+awl
+awl
+nUX
+awl
+awl
+nUX
+hTt
+hTt
+hTt
+awl
+bQI
+hTt
+gQx
+hTt
+hTt
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+uMC
+gkr
+qti
+qti
+qti
+qti
+qti
+neU
+qti
+qti
+qti
+qti
+qti
+jPE
+jPE
+nFb
+aBI
+aBI
+xga
+wqm
+wqm
+rma
+aBI
+xga
+kqo
+iUp
+khp
+sus
+sus
+sus
+oot
+oot
+oot
+gqI
+gqI
+gge
+hYR
+hYR
+xGk
+oot
+oot
+oot
+oot
+oot
+xGk
+liL
+oot
+gge
+gge
+owY
+bqy
+oot
+oot
+gge
+gge
+gge
+oot
+oot
+ave
+eig
+eig
+srn
+uPU
+sbF
+hGO
+sLi
+eig
+jOd
+jOd
+wPp
+wPp
+kXe
+wPp
+wPp
+wPp
+gge
+wPp
+jOd
+kIx
+jOd
+xtO
+mAe
+xnm
+mAe
+tJK
+wPp
+irD
+wPp
+irD
+irD
+wPp
+wPp
+okV
+unl
+nUs
+unl
+okV
+iwU
+iwU
+unX
+unX
+unX
+unX
+nnU
+nnU
+uEa
+uEa
+uEa
+dMl
+"}
+(113,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+nUX
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+bQI
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+gkr
+gkr
+gkr
+aBX
+gkr
+gkr
+gkr
+gkr
+gkr
+aBX
+qti
+qti
+qti
+qti
+qti
+qti
+aRf
+hwY
+ofS
+jmj
+jmj
+qfa
+qfa
+ulD
+ulD
+ulD
+ulD
+iUl
+rkk
+ulD
+ulD
+ulD
+rkk
+faE
+wDG
+sus
+oot
+sus
+sus
+sus
+oot
+lgj
+hYR
+gge
+gge
+hYR
+oot
+oot
+oot
+oot
+oot
+oot
+sus
+eHQ
+sus
+oot
+oot
+oot
+oot
+xGk
+oot
+lgj
+lgj
+lgj
+uEr
+jYf
+sus
+hqs
+sus
+kGD
+uPU
+sLi
+hGO
+sLi
+eig
+wPp
+wPp
+wPp
+wPp
+wPp
+wPp
+wPp
+wPp
+wPp
+wPp
+jOd
+jOd
+jOd
+xtO
+mAe
+xnm
+mAe
+dPf
+wPp
+xJZ
+wPp
+okV
+unl
+unl
+unl
+okV
+hAc
+oaK
+oaK
+okV
+unl
+unl
+unl
+okV
+unX
+unX
+fNR
+nnU
+gge
+gge
+gge
+dMl
+"}
+(114,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+cKE
+cKE
+cKE
+hTt
+awl
+xue
+xue
+awl
+awl
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+gQx
+hTt
+hTt
+hTt
+gkr
+gkr
+uMC
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+aRf
+qti
+qti
+qti
+qti
+qti
+eje
+dxf
+sGc
+sGc
+sGc
+wCT
+wCT
+rkk
+nNt
+ryI
+ryI
+rkk
+rkk
+ryI
+nNt
+nNt
+rkk
+aQB
+dPd
+sus
+oot
+sus
+dDv
+ijw
+uJN
+uJN
+lgj
+gge
+oot
+sus
+eHQ
+sus
+oot
+oot
+oot
+sus
+hqs
+sYY
+eHQ
+oPC
+oot
+oot
+oot
+gqI
+oot
+lgj
+lgj
+lJh
+oot
+jYf
+sus
+lLz
+sus
+kGD
+uPU
+sLi
+hGO
+sLi
+srn
+eig
+eig
+eig
+srn
+eig
+eig
+srn
+eig
+eig
+srn
+xtO
+xtO
+xtO
+sHr
+mAe
+xnm
+mAe
+tJK
+irD
+wPp
+wPp
+unl
+hod
+oaK
+ute
+oaK
+oaK
+hsf
+oaK
+oaK
+oaK
+eeR
+eeR
+unl
+xrW
+unX
+unX
+nnU
+gge
+gge
+gge
+dMl
+"}
+(115,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pIz
+pIz
+pIz
+lyu
+awl
+xue
+xue
+bQI
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+hTt
+gkr
+uMC
+gkr
+gkr
+gkr
+gkr
+gkr
+uMC
+gkr
+gkr
+rRT
+rRT
+qti
+aRf
+neU
+utr
+utr
+qti
+oyx
+sqQ
+rFj
+sGc
+eke
+wCT
+tdF
+rkk
+nNt
+ryI
+ghT
+rkk
+rkk
+oLi
+wxf
+nNt
+rkk
+gOq
+rut
+sus
+lgj
+xnu
+uJN
+dDv
+dDv
+uJN
+djz
+sus
+sus
+eHQ
+iLA
+sus
+oot
+oot
+oot
+sZP
+kgS
+sYY
+sus
+sus
+oot
+oot
+oot
+gKc
+gKc
+tPx
+dsN
+mQX
+dsN
+tPx
+sus
+sus
+sus
+kGD
+uPU
+sLi
+hGO
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+mAe
+mAe
+mAe
+mAe
+fOJ
+xnm
+mAe
+tJK
+irD
+irD
+wPp
+unl
+bCV
+oaK
+oaK
+rmq
+oaK
+oaK
+oaK
+oaK
+oaK
+oaK
+bDN
+unl
+unX
+unX
+unX
+nnU
+gge
+gge
+gge
+dMl
+"}
+(116,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pIz
+pIz
+iKc
+lyu
+awl
+awl
+awl
+awl
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+rRT
+rRT
+qti
+qti
+qti
+utr
+utr
+qti
+qti
+wnB
+tDj
+eke
+oNG
+tcr
+tcr
+ulD
+ulD
+ulD
+rkk
+ulD
+ulD
+ulD
+ulD
+ulD
+rkk
+uCa
+vzU
+ddx
+gEr
+lgj
+uJN
+sus
+sus
+sus
+sus
+sYY
+sYY
+sYY
+sus
+sus
+sus
+sus
+sus
+ubL
+ife
+wrP
+wrP
+ife
+kGD
+tPx
+dsN
+dsN
+dsN
+tPx
+wvo
+rJY
+tIx
+tPx
+dsN
+dsN
+dsN
+tPx
+uPU
+sbF
+ank
+tGU
+vjK
+tGU
+tGU
+tGU
+vjK
+kAp
+tGU
+kAp
+vjK
+tGU
+tGU
+sLq
+sDE
+sLq
+sLq
+sLq
+agt
+mAe
+tJK
+wPp
+wPp
+rkr
+unl
+ruC
+cTL
+oAf
+gQz
+iFG
+oaK
+oaK
+gQz
+oaK
+fJl
+mZj
+unl
+xrW
+unX
+unX
+unX
+gge
+gge
+gge
+dMl
+"}
+(117,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pIz
+pIz
+khH
+mif
+nUX
+awl
+awl
+awl
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+iwc
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+uBV
+gkr
+gkr
+gkr
+gkr
+rRT
+rRT
+kpN
+qti
+qti
+qti
+utr
+utr
+aYV
+kQw
+uYl
+jpE
+uYl
+kQw
+vYo
+aBI
+buX
+aBI
+vBo
+bho
+wqm
+aBI
+tiV
+aBI
+kEC
+lpX
+sus
+sus
+lgj
+lgj
+uJN
+uJN
+hqs
+oot
+oot
+sus
+wqz
+sus
+hqs
+sus
+wGN
+sus
+mQG
+sus
+kGD
+sus
+pfV
+iLA
+sus
+gvO
+hUv
+wEB
+mkP
+xLW
+sli
+xtD
+ouV
+qJC
+sli
+kBp
+dqk
+sTa
+rrB
+sLi
+vNW
+hGO
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+kWG
+sLi
+sLi
+sLi
+sLi
+mAe
+mAe
+mAe
+mAe
+mAe
+xnm
+mAe
+sHr
+xtO
+xtO
+okV
+okV
+lSi
+oaK
+gQz
+gQz
+phY
+oaK
+oaK
+gQz
+gQz
+oaK
+oCY
+okV
+okV
+unX
+unX
+vHv
+unX
+nnU
+gge
+dMl
+"}
+(118,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pIz
+khH
+pIz
+lyu
+kev
+awl
+awl
+awl
+hTt
+hTt
+hTt
+hTt
+gQx
+gQx
+hTt
+hTt
+iwc
+omB
+iwc
+iwc
+kpN
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+qti
+qti
+qti
+utr
+utr
+lVO
+yjg
+aYV
+lYH
+hfN
+xbe
+aPw
+jCT
+jCT
+jCT
+jcl
+vml
+jcl
+jcl
+jzF
+jCT
+jCT
+wDV
+wDV
+ccm
+ccm
+lYr
+wDV
+jiq
+xSq
+lYr
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+sus
+sus
+sus
+kGD
+hqs
+sYY
+sYY
+sus
+oot
+hUv
+hlj
+drx
+kNJ
+bMg
+tIx
+bWZ
+qDB
+bMg
+sTa
+qBY
+sTa
+rrB
+sLi
+sLi
+hGO
+sLi
+srn
+eig
+eig
+eig
+srn
+eig
+eig
+srn
+eig
+eig
+srn
+xtO
+xtO
+xtO
+sHr
+mAe
+xnm
+mAe
+mAe
+mAe
+mAe
+xvr
+oaK
+oaK
+oaK
+oaK
+uHk
+oaK
+oaK
+oaK
+uHk
+oaK
+oaK
+oaK
+oaK
+unl
+unX
+unX
+unX
+unX
+nnU
+nnU
+dMl
+"}
+(119,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+khH
+pIz
+pIz
+lyu
+kev
+bQI
+awl
+xue
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+hTt
+iwc
+iwc
+iwc
+iwc
+iwc
+gkr
+uMC
+gkr
+gkr
+uMC
+gkr
+gkr
+uMC
+gkr
+gkr
+gkr
+gkr
+neU
+qti
+qti
+utr
+utr
+utr
+yjg
+aYV
+lYH
+aYV
+utr
+eoG
+jCT
+jCT
+jCT
+jCT
+jcl
+jcl
+jCT
+jCT
+jCT
+khp
+wDV
+lYr
+gge
+lYr
+fYn
+wDV
+wDV
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+sus
+sYY
+sYY
+sus
+oot
+hUv
+ajE
+tYs
+iOa
+sli
+nQI
+rJY
+tIx
+sli
+bpW
+sTa
+tEk
+rrB
+sLi
+sLi
+hGO
+sLi
+eig
+jOd
+jOd
+jOd
+wPp
+wPp
+kXe
+wPp
+kXe
+wPp
+wPp
+kXe
+wPp
+wPp
+xtO
+fOJ
+tCT
+sLq
+sLq
+qNF
+sLq
+qOC
+wJf
+igO
+wJf
+wJf
+wJf
+wJf
+omm
+hzl
+wJf
+wJf
+wJf
+igO
+wJf
+qOC
+unX
+rVG
+nnU
+unX
+unX
+nnU
+dMl
+"}
+(120,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+pIz
+pIz
+hTt
+hTt
+awl
+awl
+awl
+xue
+hTt
+hTt
+hTt
+gQx
+hTt
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+qti
+qti
+qti
+utr
+hFJ
+utr
+akY
+aYV
+elm
+aYV
+utr
+eoG
+jCT
+ctH
+jCT
+kMP
+jcl
+ctH
+jCT
+jCT
+jCT
+wDV
+lYr
+gge
+gge
+lYr
+lYr
+lYr
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+bMi
+jsY
+jsY
+bMi
+tPx
+tPx
+fKV
+bWw
+sli
+sli
+sli
+wjm
+sli
+sli
+sli
+uCM
+sli
+tPx
+tPx
+iKn
+hGO
+sLi
+eig
+jOd
+bPi
+jOd
+wPp
+kXe
+wPp
+xDu
+kxm
+gge
+wPp
+wPp
+wPp
+irD
+xtO
+mAe
+mAe
+mAe
+mAe
+mAe
+mAe
+xvr
+oaK
+oaK
+oaK
+oaK
+dtD
+xMU
+nOT
+oaK
+dtD
+oaK
+oaK
+oaK
+oaK
+unl
+vHv
+unX
+unX
+unX
+rVG
+nnU
+dMl
+"}
+(121,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+nUX
+awl
+awl
+xue
+hTt
+hTt
+hTt
+gQx
+hTt
+oeY
+iwc
+iwc
+iwc
+oeY
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+qti
+qti
+qti
+utr
+utr
+utr
+utr
+aYV
+lYH
+aYV
+utr
+gky
+jCT
+jCT
+nNt
+jCT
+jcl
+jCT
+jCT
+jCT
+jCT
+wDV
+gge
+gge
+gge
+lYr
+lYr
+lYr
+cfY
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jsY
+ueG
+jsY
+ueG
+rrB
+wvo
+wvo
+tIx
+iBH
+sli
+diz
+lev
+tFR
+sli
+mYT
+tIx
+wHe
+wvo
+rrB
+sLi
+hGO
+sLi
+srn
+jOd
+jOd
+jOd
+gge
+wPp
+wPp
+irD
+gge
+gge
+gge
+wPp
+wPp
+kXe
+sHr
+xtO
+sHr
+mAe
+mAe
+mAe
+sHr
+okV
+okV
+cNy
+oaK
+gQz
+gQz
+phY
+qUF
+ute
+gQz
+gQz
+ihC
+sYL
+okV
+okV
+unX
+unX
+nnU
+unX
+nnU
+unX
+dMl
+"}
+(122,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+nUX
+awl
+nUX
+awl
+awl
+awl
+pBj
+awl
+iwc
+iwc
+iwc
+iwc
+iwc
+jxI
+eZJ
+eZJ
+eZJ
+jxI
+jxI
+wJp
+xYf
+wJp
+jxI
+jxI
+jxI
+jxI
+jxI
+qti
+qti
+qti
+utr
+utr
+utr
+utr
+aYV
+lYH
+aYV
+yiz
+hxd
+jCT
+jCT
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+wDV
+lYr
+gge
+ccm
+lYr
+owP
+cfY
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jsY
+qdq
+cVn
+rxh
+sLG
+aFp
+aFp
+aFp
+aFp
+cGk
+aFp
+uKn
+nSV
+nJq
+nSV
+guf
+nSV
+nSV
+iaO
+tGU
+muW
+sLi
+eig
+wPp
+wPp
+gge
+gge
+gge
+lDt
+irD
+gge
+gge
+gge
+gge
+gge
+jOd
+jOd
+jOd
+xtO
+mAe
+mAe
+mAe
+xtO
+vCx
+unl
+bjw
+xTD
+oaK
+gQz
+gUc
+qUF
+oaK
+gQz
+duI
+ruz
+eDi
+unl
+unX
+unX
+unX
+nnU
+nnU
+nnU
+nnU
+dMl
+"}
+(123,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+xue
+awl
+awl
+xue
+awl
+awl
+pBj
+bQI
+iwc
+iwc
+omB
+iwc
+iwc
+eZJ
+eZJ
+ylD
+gPO
+gPO
+eyl
+gPO
+mTD
+rrl
+jxI
+gem
+inn
+inn
+jxI
+qti
+qti
+neU
+utr
+utr
+utr
+utr
+aYV
+lYH
+hfN
+eQG
+hxd
+hsw
+jCT
+jCT
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+wDV
+dHw
+ylC
+ccm
+lYr
+lYr
+lMG
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+mVb
+jsY
+jsY
+rrB
+rHr
+pGd
+iBH
+sZk
+sli
+blV
+jrX
+omS
+sli
+mhj
+iBH
+oLx
+hdG
+rrB
+iSw
+sbF
+kWG
+eig
+wPp
+gge
+gge
+gge
+irD
+irD
+irD
+wPp
+gge
+gge
+gge
+wPp
+jOd
+xSk
+jOd
+xtO
+mAe
+mAe
+fOJ
+xtO
+tQA
+unl
+vqE
+oaK
+oaK
+ieD
+oaK
+qUF
+oaK
+oaK
+oaK
+oaK
+iya
+unl
+unX
+unX
+unX
+unX
+nnU
+gge
+gge
+dMl
+"}
+(124,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+nUX
+awl
+nUX
+awl
+pBj
+awl
+iwc
+iwc
+iwc
+iwc
+iwc
+eZJ
+iLu
+tcX
+lBI
+bSk
+cyj
+bSk
+inC
+faC
+wJp
+sHG
+gjs
+tOG
+jxI
+qti
+qti
+qti
+utr
+utr
+lVO
+akY
+uYl
+hyO
+uYl
+prY
+aPw
+jCT
+jCT
+jcl
+jcl
+jcl
+hsw
+jCT
+jCT
+jCT
+wDV
+lYr
+ylC
+ccm
+lYr
+lYr
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+rad
+jsY
+jsY
+tPx
+tPx
+sli
+bWw
+sli
+tPx
+tPx
+uZT
+tPx
+tPx
+sli
+uCM
+sli
+tPx
+tPx
+ooe
+eig
+eig
+srn
+wPp
+irD
+gge
+gge
+irD
+wPp
+wPp
+wPp
+gge
+gge
+irD
+irD
+jOd
+jOd
+jOd
+xtO
+vMW
+mAe
+mAe
+xtO
+wPp
+unl
+eeR
+eeR
+oaK
+oaK
+oaK
+uMM
+oaK
+oaK
+oaK
+oaK
+oaK
+unl
+unX
+unX
+unX
+nnU
+gge
+gge
+gge
+dMl
+"}
+(125,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+awl
+bQI
+nUX
+gQx
+hTt
+hTt
+kQv
+iwc
+iwc
+iwc
+lsv
+prk
+tKd
+voY
+xbH
+xbH
+gPt
+mhS
+faC
+wJp
+fHN
+nZi
+gjs
+jxI
+qti
+bAO
+qti
+qti
+qti
+hfN
+kQw
+wnB
+tMS
+sGc
+kQw
+hxd
+jCT
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+wDV
+wDV
+lYr
+ylC
+ogd
+kaL
+dcw
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+eaa
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+lhJ
+xXv
+jsY
+ueG
+hUv
+tIx
+xtL
+qJC
+tPx
+gmY
+jrX
+iBH
+tPx
+uRe
+tIx
+xep
+rrB
+wPp
+wPp
+wPp
+wPp
+wPp
+wPp
+gge
+gge
+gge
+wPp
+wPp
+mnW
+wPp
+gge
+gge
+irD
+irD
+sVW
+wPp
+wPp
+hvZ
+kOn
+caW
+kOn
+hvZ
+wPp
+okV
+unl
+unl
+unl
+okV
+oaK
+qUF
+oaK
+okV
+unl
+unl
+xvr
+okV
+unX
+unX
+unX
+nnU
+gge
+gge
+gge
+dMl
+"}
+(126,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+mif
+mif
+mif
+gQx
+hTt
+iwc
+iwc
+omB
+iwc
+jxI
+prk
+faC
+mTD
+mTD
+mTD
+mTD
+rGI
+wfy
+vMy
+jgs
+vGi
+gjs
+jxI
+qti
+qti
+qti
+qti
+qti
+qti
+neU
+wnB
+tMS
+eZL
+uYl
+hxd
+jCT
+jCT
+jcl
+jCT
+jCT
+jCT
+jCT
+hsw
+jCT
+pXp
+wDV
+lYr
+ylC
+lYr
+lYr
+cfY
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+uox
+jsY
+jsY
+jsY
+hUv
+qkt
+lRT
+gxa
+bMg
+tIx
+uUk
+gTN
+bMg
+pEg
+uWc
+awY
+rrB
+wPp
+wPp
+wPp
+kXe
+rkr
+irD
+gge
+gge
+gge
+wPp
+wPp
+wPp
+wPp
+gge
+irD
+uIM
+xlD
+kOn
+kOn
+oho
+qeT
+pit
+vMH
+vMH
+sHr
+wPp
+wPp
+tQA
+wPp
+tQA
+okV
+unl
+qsT
+unl
+okV
+oYf
+oYf
+xqd
+lRU
+unX
+xrW
+unX
+gge
+gge
+gge
+gge
+dMl
+"}
+(127,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+xue
+gQx
+hTt
+iwc
+iwc
+iwc
+eZJ
+iZu
+tcX
+sAa
+iqc
+iqc
+xEV
+isN
+faC
+jxI
+yhf
+bgK
+rrZ
+jxI
+neU
+qti
+qti
+qti
+qti
+qti
+qti
+uYl
+pTc
+eZL
+xnB
+hxd
+hsw
+jCT
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+jCT
+pXp
+wDV
+gge
+gge
+lYr
+lYr
+lMG
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+lnJ
+jsY
+jsY
+ueG
+rrB
+mkP
+pEg
+cNQ
+tPx
+iLg
+jrX
+rHr
+tPx
+vql
+wvo
+wvo
+rrB
+wPp
+gge
+wPp
+kpb
+irD
+uIM
+gge
+gge
+gge
+gge
+irD
+irD
+irD
+gge
+nmQ
+uIM
+hvZ
+tQA
+vMH
+vMH
+vMH
+vMH
+vcu
+sfQ
+sHr
+kOn
+kOn
+hvZ
+vCx
+vCx
+xtO
+mAe
+ajt
+sLq
+ydH
+ydH
+wGf
+xqd
+lRU
+unX
+wsK
+rVG
+nnU
+gge
+gge
+gge
+dMl
+"}
+(128,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+bQI
+awl
+xue
+gQx
+hTt
+iwc
+iwc
+iwc
+eZJ
+gQn
+gPO
+iPx
+xAx
+xAx
+xAx
+gjs
+sbo
+jxI
+jxI
+qIM
+jxI
+jxI
+jxI
+jxI
+jxI
+jxI
+qti
+qti
+qti
+qti
+tDj
+eZL
+kQw
+hxd
+jCT
+jCT
+jcl
+jcl
+hsw
+jCT
+jCT
+jCT
+jCT
+wDV
+wDV
+gge
+gge
+ccm
+lYr
+lYr
+cSI
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jsY
+uox
+jsY
+jsY
+wrY
+tPx
+dsN
+dsN
+dsN
+tPx
+mps
+jrX
+qJC
+tPx
+dsN
+dsN
+dsN
+jds
+gge
+gge
+irD
+kpb
+uIM
+irD
+kpb
+kpb
+irD
+gge
+irD
+wPp
+vMH
+wPp
+kXe
+irD
+oho
+vcu
+vMH
+sfQ
+tQA
+vcu
+tQA
+vMH
+vMH
+uOf
+vcu
+bFq
+hvZ
+wPp
+eJD
+jOd
+jOd
+jOd
+wJV
+bHG
+cXK
+bHG
+wJV
+unX
+unX
+nnU
+nnU
+uOZ
+gge
+gge
+dMl
+"}
+(129,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+awl
+awl
+awl
+awl
+awl
+xue
+gQx
+hTt
+iwc
+omB
+iwc
+jxI
+jxI
+wRH
+jUN
+jxI
+eRz
+sVf
+sVf
+lYL
+bYU
+cYs
+fgU
+aMI
+gPt
+gPt
+gPt
+pBK
+wJp
+qti
+neU
+qti
+qti
+tMS
+eZL
+hIK
+hxd
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+jCT
+wDV
+gge
+gge
+lYr
+ccm
+lYr
+wDV
+wDV
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jsY
+uox
+jsY
+jsY
+jsY
+bMi
+llT
+lFa
+lFa
+tPx
+tPx
+wMD
+jME
+tPx
+gKc
+gKc
+wPp
+kpb
+gge
+irD
+irD
+uFy
+irD
+kpb
+kXe
+wPp
+irD
+wPp
+wPp
+wPp
+wPp
+kXe
+tQA
+wPp
+kOn
+vcu
+jHh
+kTT
+xNX
+xNX
+cXR
+xNX
+xNX
+xNX
+iTC
+hje
+hvZ
+wPp
+wJV
+bHG
+bHG
+bHG
+wJV
+gdp
+wxw
+vQm
+wJV
+bHG
+bHG
+bHG
+bgE
+unX
+gge
+gge
+dMl
+"}
+(130,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+awl
+awl
+lOC
+awl
+awl
+xue
+gQx
+hTt
+iwc
+iwc
+oeY
+jxI
+jxI
+mTD
+cYs
+jxI
+jxI
+jxI
+jxI
+jxI
+jxI
+vxV
+mTD
+bgK
+mTD
+kQD
+mTD
+pBK
+wJp
+qti
+qti
+qti
+wnB
+tMS
+eZL
+xnB
+hxd
+jCT
+jCT
+jcl
+jcl
+jCT
+jCT
+jCT
+hsw
+jPE
+wDV
+gge
+gge
+gge
+ccm
+lYr
+wDV
+krm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jsY
+uox
+bMi
+bMi
+bJP
+bMi
+tNj
+uRo
+lFa
+llT
+oac
+aQk
+hGR
+oac
+wPp
+wPp
+kXe
+irD
+gge
+uIM
+jgK
+mKF
+irD
+kpb
+wPp
+srn
+eig
+eig
+eig
+srn
+eig
+eig
+eig
+hvZ
+hvZ
+rTn
+lGh
+aEw
+wmQ
+lkt
+dfl
+xAZ
+tbz
+xAZ
+iGQ
+vcu
+hvZ
+wPp
+jXr
+qUq
+vOe
+iZo
+gnT
+xsT
+yjW
+aSN
+gnT
+qiS
+eQN
+gDe
+jXr
+unX
+gge
+gge
+dMl
+"}
+(131,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+awl
+awl
+awl
+bQI
+awl
+awl
+bQI
+xue
+gQx
+hTt
+iwc
+iwc
+iwc
+jxI
+irj
+inC
+gjs
+wJp
+vwQ
+vwQ
+gnt
+aEf
+qMb
+mTD
+gjs
+jiD
+gPt
+fgs
+gPt
+pBK
+wJp
+qti
+qti
+qti
+wnB
+lYH
+eZL
+xnB
+hxd
+jCT
+jCT
+jcl
+jcl
+kMP
+jCT
+jCT
+jCT
+jPE
+wDV
+lYr
+gge
+gge
+ccm
+lYr
+nBq
+wDV
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jsY
+rad
+bMi
+bMi
+ueG
+bMi
+lFa
+iSB
+lFa
+llT
+cpe
+hUS
+pkz
+cpe
+kXe
+wPp
+wPp
+kpb
+irD
+uIM
+uIM
+irD
+wPp
+wPp
+wPp
+eig
+sLi
+sLi
+kWG
+sLi
+sLi
+sLi
+sLi
+oho
+hOu
+tQA
+lGh
+lxG
+baR
+yja
+sTE
+wmQ
+lkt
+xAZ
+iGQ
+vcu
+aQm
+wPp
+jXr
+iUT
+heS
+vkh
+qGg
+xsT
+oZt
+vQm
+qGg
+cXc
+heS
+kLZ
+jXr
+unX
+unX
+gge
+dMl
+"}
+(132,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+awl
+awl
+awl
+xue
+gQx
+hTt
+iwc
+iwc
+iwc
+jxI
+jxI
+mTD
+mTD
+baJ
+tmX
+tmX
+kQD
+tmX
+tmX
+tmX
+jBe
+uQd
+jxI
+jxI
+jxI
+jxI
+jxI
+jxI
+jVj
+qti
+lBj
+tDj
+eZL
+xnB
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ixm
+vdR
+cfY
+gge
+ccm
+lYr
+cfY
+wDV
+wDV
+wDV
+wDV
+wDV
+hou
+hou
+hou
+hou
+hou
+hou
+bMi
+bMi
+bMi
+bMi
+jsY
+uox
+jsY
+jsY
+jsY
+bMi
+llT
+lFa
+lFa
+lFa
+xWs
+jYE
+qTS
+xWs
+wPp
+wPp
+wPp
+irD
+irD
+gge
+gge
+wPp
+rkr
+kXe
+bne
+eig
+sLi
+kWG
+sLi
+sLi
+sbF
+sLi
+sLi
+jfc
+tQA
+dzp
+lGh
+rcJ
+pDt
+fOJ
+vMW
+clw
+rjJ
+xAZ
+iGQ
+vcu
+bzy
+wPp
+jXr
+iUT
+cXc
+ixn
+gnT
+oFC
+lpa
+vQm
+gnT
+cXc
+cXc
+kvU
+jXr
+unX
+nnU
+gge
+dMl
+"}
+(133,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+xue
+gQx
+hTt
+omB
+iwc
+iwc
+jxI
+irj
+gjs
+gjs
+wJp
+cYs
+mTD
+syT
+bSz
+vwQ
+mTD
+gjs
+xGJ
+jxI
+lsi
+fMf
+hKE
+fEV
+wJp
+jmj
+jmj
+dxf
+tMS
+eZL
+kQw
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+gZy
+nBq
+iEw
+ccm
+wDV
+jKK
+wDV
+slO
+pXp
+pXp
+jiq
+pXp
+xbG
+dUC
+bHU
+pNq
+fqo
+jsY
+jsY
+jsY
+jsY
+bJP
+uox
+jsY
+jsY
+jsY
+xWs
+dre
+dre
+dre
+xWs
+xWs
+pjB
+qMG
+xWs
+dre
+dre
+nya
+qEW
+wPp
+wPp
+gge
+wPp
+wPp
+kXe
+kXe
+eig
+sLi
+sbF
+sLi
+sLi
+sLi
+sLi
+sLi
+kOn
+vcu
+tQA
+uoF
+dfl
+fbv
+mAe
+jWk
+vMW
+oWI
+dfl
+saq
+qbW
+aQm
+wJV
+wJV
+gnT
+ooV
+gnT
+gnT
+xsT
+lpa
+sBr
+gnT
+gnT
+amk
+gnT
+wJV
+wJV
+unX
+nnU
+dMl
+"}
+(134,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+awl
+awl
+awl
+nUX
+xue
+xue
+gQx
+hTt
+iwc
+iwc
+iwc
+jxI
+jxI
+jxI
+jxI
+jxI
+jxI
+hTz
+jxI
+jxI
+jxI
+gth
+oHp
+xGJ
+jxI
+jih
+pnI
+crq
+uSi
+cSN
+iRC
+gil
+mrw
+hEJ
+mkz
+jmj
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ugn
+iNK
+nBq
+sKK
+jKK
+dEm
+avs
+aYC
+aYC
+aYC
+avs
+aYC
+foW
+veE
+ttz
+uRr
+rxh
+rxh
+fib
+rxh
+rxh
+rxh
+lhJ
+xXv
+jsY
+jsY
+dre
+jTy
+shd
+ipY
+fuR
+qMG
+oto
+rQw
+ftw
+jTy
+jTy
+ocT
+lll
+wPp
+wPp
+gge
+frz
+jOd
+frz
+wPp
+srn
+sLi
+sLi
+sLi
+srn
+eig
+eig
+eig
+sHr
+hvZ
+tQA
+lGh
+xAZ
+lxG
+mAe
+vMW
+mAe
+yja
+lkt
+iGQ
+vcu
+bzy
+jXr
+xVp
+fhD
+eyw
+tQY
+eyw
+gIL
+mRR
+qTK
+xaO
+owr
+eyw
+iHJ
+hfd
+jXr
+unX
+nnU
+dMl
+"}
+(135,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+bQI
+awl
+awl
+xue
+hTt
+gQx
+hTt
+iwc
+iwc
+iwc
+iwc
+iwc
+gkr
+gkr
+eZJ
+rjc
+mTD
+gjs
+aam
+jxI
+xPB
+lAw
+nZL
+cSN
+uSi
+pKG
+mJj
+gvC
+wJp
+oNG
+oNG
+sqQ
+uPS
+iRC
+oxT
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+mHL
+wyW
+kUG
+wyh
+aYC
+bPY
+jiq
+wDV
+wDV
+wDV
+wDV
+rpv
+pNq
+dUC
+bHU
+owT
+jsY
+bMi
+bMi
+jsY
+jsY
+jsY
+rad
+bJP
+jsY
+ueG
+dre
+cmp
+rQw
+fFp
+rQw
+rZE
+eXS
+tCx
+tDA
+mXC
+tDA
+qTw
+dre
+wPp
+wPp
+wPp
+jOd
+kGs
+frz
+bne
+eig
+sLi
+sLi
+sLi
+eig
+uPU
+uPU
+nHy
+irD
+kOn
+vcu
+lGh
+xAZ
+rcJ
+kWQ
+knN
+pDt
+vXe
+rjJ
+iGQ
+qbW
+vcu
+jip
+qfC
+rFa
+qfC
+qfC
+qfC
+tUq
+jyA
+nyD
+pif
+tjN
+uMz
+nIC
+qfC
+aYW
+unX
+nnU
+dMl
+"}
+(136,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+awl
+awl
+awl
+xue
+hTt
+gQx
+hTt
+iwc
+iwc
+omB
+iwc
+omB
+fBi
+gkr
+eZJ
+gYf
+mTD
+vEO
+rIz
+jxI
+wJX
+mTD
+mTD
+sVF
+pBK
+fzv
+cTT
+jxI
+jxI
+jVj
+qti
+wnB
+tDj
+sGc
+uYl
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+bLX
+jik
+ylX
+pXp
+aZe
+fgq
+wDV
+nBq
+lYr
+lYr
+wDV
+bzD
+jYU
+kDR
+ivi
+bzD
+bMi
+dyR
+rPl
+bMi
+bMi
+jsY
+uox
+jsY
+jsY
+jsY
+xWs
+hzc
+rQw
+rQw
+ase
+rQw
+eXS
+fip
+gSH
+gSH
+gSH
+dfp
+xWs
+wPp
+wPp
+wPp
+jOd
+frz
+jOd
+kXe
+eig
+sLi
+sbF
+sLi
+eig
+uPU
+vEu
+nHy
+irD
+kOn
+kNl
+lGh
+tbz
+xAZ
+xAZ
+dfl
+rcJ
+kWQ
+sRZ
+siD
+kWt
+vcu
+jXr
+gFz
+aBd
+hwC
+hwC
+hwC
+ptU
+lYS
+leI
+hwC
+eFr
+fbX
+tCw
+hwC
+jXr
+nnU
+nnU
+dMl
+"}
+(137,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+awl
+awl
+awl
+awl
+xue
+hTt
+gQx
+hTt
+iwc
+iwc
+iwc
+qos
+iwc
+gkr
+gkr
+eZJ
+bQA
+vQS
+kQD
+gjs
+jxI
+txY
+mTD
+cKz
+jxI
+fEV
+exU
+itf
+wJp
+qti
+qti
+neU
+wnB
+tMS
+hps
+oNG
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+nyE
+ivl
+wDV
+wDV
+sKK
+sKK
+cfY
+bqw
+jYU
+jYU
+jYU
+bzD
+tjH
+kDR
+hex
+bzD
+jYU
+jYU
+jYU
+bzD
+bMi
+jsY
+uox
+jsY
+jsY
+xWs
+xWs
+iVT
+rQw
+rQw
+rQw
+fFp
+eXS
+bTE
+tlb
+tlb
+tlb
+fFm
+xWs
+xWs
+eig
+eig
+eig
+srn
+eig
+eig
+srn
+sLi
+sLi
+sLi
+eig
+uPU
+nHy
+jcT
+irD
+bFq
+vMH
+ljY
+ogN
+ogN
+ogN
+wTq
+ogN
+ogN
+ogN
+dym
+bFq
+bFq
+wJV
+wJV
+gnT
+ooV
+gnT
+gnT
+qKE
+wiR
+cTd
+gnT
+gnT
+ooV
+gnT
+wJV
+wJV
+nnU
+nnU
+dMl
+"}
+(138,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+awl
+awl
+awl
+awl
+awl
+xue
+xue
+gQx
+iwc
+iwc
+iwc
+iwc
+iwc
+qos
+gkr
+fBi
+eZJ
+bQA
+vQS
+mTD
+mTD
+lQp
+mTD
+sfb
+eJG
+jxI
+sIg
+rAw
+itf
+wJp
+qti
+qti
+qti
+wnB
+tMS
+eZL
+kQw
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ndG
+wDV
+rnA
+ccm
+ccm
+ccm
+cfY
+jYU
+bDW
+kuN
+xAX
+sIx
+kDR
+aQn
+vUk
+yfz
+dPl
+qkJ
+dPl
+jYU
+bMi
+jsY
+uox
+bJP
+jsY
+dre
+rQw
+fFp
+rQw
+rQw
+rQw
+rQw
+eXS
+rQw
+rQw
+sBf
+rQw
+rQw
+rQw
+dre
+sLi
+sLi
+kWG
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+srn
+mfZ
+mfZ
+ave
+tcK
+hvZ
+cIh
+oho
+kOn
+hvZ
+vMH
+sfQ
+tQA
+sHr
+kOn
+kOn
+bFq
+tQA
+wPp
+jXr
+gDs
+cXc
+fMo
+gnT
+lVj
+wxw
+cTd
+mPI
+ser
+cXc
+uWY
+jXr
+vHv
+unX
+gge
+dMl
+"}
+(139,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+awl
+awl
+awl
+bQI
+awl
+bQI
+awl
+xue
+gQx
+omB
+iwc
+hTt
+hTt
+hTt
+iwc
+gkr
+aBX
+eZJ
+bQA
+vQS
+mTD
+gjs
+jxI
+sWf
+jBe
+kmy
+jxI
+cYD
+ufl
+uIT
+wJp
+qti
+qti
+qti
+wnB
+tMS
+sGc
+toT
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kqV
+wDV
+lYr
+lYr
+irS
+irS
+cfY
+jYU
+wrx
+lnj
+ezO
+ezO
+kDR
+sss
+rji
+yfz
+yfz
+qJo
+int
+jYU
+bMi
+jsY
+kEp
+sBS
+mjD
+fqM
+bbJ
+gqw
+gqw
+gqw
+gqw
+gqw
+mgF
+epk
+bbJ
+qLo
+bbJ
+bbJ
+epk
+fqM
+tGU
+kAp
+tGU
+vjK
+tGU
+tGU
+tGU
+vjK
+bXm
+sLi
+uPU
+uPU
+uPU
+uPU
+uPU
+uPU
+jcT
+jcT
+jcT
+hvZ
+kOn
+xwb
+kOn
+bFq
+hzf
+vcu
+irD
+uXx
+wPp
+jXr
+cAg
+heS
+cXc
+qGg
+xsT
+wxw
+xqg
+qGg
+cJs
+iBd
+iUL
+jXr
+vHv
+nnU
+gge
+dMl
+"}
+(140,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+nUX
+awl
+awl
+awl
+awl
+nUX
+awl
+xue
+gQx
+iwc
+iwc
+hTt
+hTt
+hTt
+iwc
+uMC
+gkr
+jxI
+wJp
+wJp
+jxI
+jxI
+jxI
+hsF
+pBK
+pBK
+jxI
+wJp
+wJp
+wJp
+jxI
+qti
+qti
+qti
+wnB
+tDj
+uYl
+xnB
+hxd
+jCT
+jCT
+sKM
+dxL
+sKM
+jcl
+jcl
+yau
+jCT
+jCT
+wDV
+lYr
+nBq
+nBq
+msf
+irS
+bqw
+bGm
+ezO
+gyc
+gyc
+kDR
+hQS
+rji
+cvo
+cvo
+yfz
+jDn
+bzD
+jsY
+jsY
+pcV
+jsY
+jsY
+fHG
+rQw
+gbH
+iNZ
+iNZ
+iNZ
+gbH
+anK
+rQw
+rQw
+hxP
+rQw
+rQw
+rQw
+dre
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+sLi
+bYm
+kAp
+vjK
+tGU
+tGU
+uHg
+sbF
+sLi
+sLi
+sbF
+uPU
+mfZ
+wPp
+irD
+irD
+sfQ
+vMH
+vcu
+vMH
+uXx
+wPp
+jXr
+qZe
+cXc
+pQb
+gnT
+jPo
+dEB
+ibb
+gnT
+ukS
+oTA
+hAk
+jXr
+unX
+nnU
+gge
+dMl
+"}
+(141,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+awl
+awl
+awl
+awl
+awl
+awl
+awl
+xue
+gQx
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+uMC
+gkr
+gkr
+jxI
+xDv
+xYf
+xDv
+jxI
+qti
+qti
+qti
+qti
+qti
+qti
+neU
+sGc
+lYH
+uYl
+xnB
+eoG
+jCT
+kMP
+sKM
+sKM
+sKM
+jCT
+jCT
+jCT
+jCT
+jCT
+wDV
+iSn
+wDV
+pXp
+xmf
+bqw
+bzD
+vhN
+dXv
+gyc
+mel
+kDR
+kDR
+aZK
+hac
+cvo
+yfz
+ncP
+bzD
+bzD
+gbs
+pcV
+jsY
+jsY
+xWs
+xWs
+gbH
+iNZ
+iNZ
+mlF
+gbH
+uAB
+rQw
+xXN
+rQw
+rQw
+uTD
+xWs
+xWs
+eig
+eig
+eig
+srn
+eig
+eig
+srn
+sLi
+sLi
+sLi
+kWG
+sLi
+sLi
+hGO
+sLi
+sLi
+sLi
+kWG
+uPU
+qNW
+bne
+lDt
+vMH
+wim
+vcu
+vcu
+irD
+uXx
+wPp
+bgE
+bHG
+bHG
+bHG
+wJV
+xsT
+wxw
+jCp
+wJV
+bHG
+bHG
+bHG
+wJV
+xrW
+gge
+gge
+dMl
+"}
+(142,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+bQI
+awl
+awl
+awl
+xue
+awl
+xue
+xue
+gQx
+iwc
+iwc
+iwc
+omB
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+qti
+qti
+qti
+qti
+neU
+qti
+qti
+qti
+lYH
+uYl
+ooO
+hxd
+jCT
+jCT
+wGo
+jCT
+sKM
+sKM
+sKM
+jCT
+jCT
+jCT
+wDV
+wDV
+aZe
+pXp
+nBq
+jYU
+rji
+rji
+rji
+sss
+oPQ
+rpO
+jCP
+rpO
+vGK
+rji
+rji
+rji
+sss
+jYU
+jsY
+pcV
+xXv
+jsY
+jsY
+xWs
+kya
+nTJ
+iNZ
+iNZ
+gbH
+rQw
+rQw
+rQw
+rQw
+rQw
+wHn
+xWs
+wPp
+bne
+bne
+frz
+jOd
+frz
+wPp
+eig
+uPU
+uPU
+uPU
+uPU
+uPU
+sLi
+hGO
+sLi
+sLi
+sLi
+sLi
+uPU
+mfZ
+wPp
+vMH
+vMH
+vMH
+qbW
+irD
+tQA
+bzy
+wPp
+kXe
+wPp
+wPp
+bFq
+wJV
+wwo
+gxg
+bHG
+wJV
+xrW
+xrW
+unX
+xrW
+nAh
+gge
+gge
+dMl
+"}
+(143,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hOe
+mCd
+awl
+xue
+gQx
+hTt
+kQv
+iwc
+iwc
+iwc
+iwc
+iwc
+gkr
+gkr
+uMC
+gkr
+gkr
+gkr
+gkr
+uMC
+gkr
+gkr
+gkr
+gkr
+neU
+qti
+qti
+qti
+qti
+qti
+qti
+qti
+lYH
+eZL
+kQw
+hxd
+jCT
+jCT
+jCT
+jCT
+sKM
+dxL
+kgX
+jCT
+jCT
+jCT
+wDV
+wDV
+xPp
+pXp
+wDV
+pWt
+rji
+trE
+sss
+rji
+rji
+rpO
+bzD
+avK
+kDR
+kDR
+mnb
+cKn
+apA
+uEn
+mjD
+gQG
+jsY
+jsY
+ueG
+lll
+gbH
+qKa
+gbH
+gbH
+gbH
+rQw
+fFp
+rQw
+rQw
+fFp
+eGb
+dre
+wPp
+bne
+wPp
+jOd
+kGs
+frz
+wPp
+xiy
+wPp
+wPp
+wPp
+wPp
+uPU
+uPU
+hGO
+sbF
+sLi
+sLi
+sbF
+uPU
+mfZ
+wPp
+irD
+gge
+gge
+vMH
+fhY
+wPp
+jin
+fhY
+frz
+jOd
+jOd
+mOU
+fuh
+sDq
+kFd
+pnf
+ksY
+xqd
+xqd
+unX
+unX
+unX
+gge
+gge
+dMl
+"}
+(144,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+rcv
+bEx
+vPd
+pdJ
+hTt
+iwc
+omB
+iwc
+iwc
+iwc
+iwc
+iwc
+gkr
+gkr
+gkr
+gkr
+gkr
+gkr
+aHg
+gkr
+gkr
+gkr
+gkr
+oJE
+utr
+utr
+utr
+utr
+qti
+qti
+qti
+wnB
+ann
+eZL
+hIK
+hxd
+kMP
+jCT
+jCT
+jCT
+hgQ
+sKM
+sKM
+jCT
+jCT
+jCT
+wDV
+nBq
+wDV
+wDV
+wDV
+jYU
+cwM
+rji
+rji
+rji
+vhT
+rpO
+ybP
+rpO
+sss
+rji
+rji
+rji
+rji
+jYU
+jsY
+uox
+jsY
+jsY
+jsY
+dre
+dGl
+cgt
+oGG
+rQw
+rQw
+rJB
+rQw
+mam
+bDM
+gbD
+jTy
+dre
+wPp
+wPp
+wPp
+jOd
+frz
+jOd
+irD
+bFq
+irD
+irD
+irD
+irD
+dHv
+pnR
+oGE
+luA
+ohD
+luA
+qpp
+xzD
+brz
+uIM
+vcu
+gge
+mYa
+tQA
+cTy
+wPp
+wPp
+wPp
+frz
+mAe
+jOd
+mOU
+fuh
+mvi
+kFd
+pnf
+oYf
+bOu
+xqd
+unX
+unX
+nnU
+gge
+gge
+dMl
+"}
+(145,1,1) = {"
+dMl
+kMx
+kMx
+hTt
+hTt
+hTt
+wmm
+wmm
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+oQD
+gQx
+gQx
+gQx
+gQx
+gQx
+gQx
+kNm
+hif
+bfk
+iwc
+kNm
+hTt
+iwc
+oRK
+wlq
+wlq
+oRK
+wlq
+wlq
+wJH
+nwO
+nwO
+wJH
+nwO
+nwO
+wJH
+gkr
+gkr
+gkr
+oJE
+oJE
+utr
+utr
+utr
+utr
+qti
+qti
+neU
+sGc
+tMS
+sGc
+hIK
+hxd
+jCT
+jcl
+jcl
+jCT
+jcl
+jCT
+jCT
+jCT
+jCT
+jCT
+wDV
+odW
+wDV
+wDV
+uAM
+bzD
+bzD
+kaw
+yfz
+cvo
+jMS
+rji
+rji
+xtf
+ezO
+gyc
+ezO
+vYg
+bzD
+bzD
+gbs
+uox
+jsY
+oEa
+qwt
+xWs
+fHG
+dre
+dre
+xWs
+xWs
+rQw
+rQw
+xWs
+dre
+dre
+dre
+xWs
+wPp
+kXe
+wPp
+wPp
+wPp
+irD
+irD
+mvh
+irD
+jWZ
+jWZ
+jWZ
+jWZ
+jFe
+ogS
+cMz
+oPu
+jFe
+jFe
+jFe
+hIC
+hIC
+hIC
+hIC
+sjf
+gge
+gge
+gge
+irD
+wPp
+frz
+jOd
+jOd
+mOU
+fuh
+sDq
+kFd
+pnf
+ksY
+xqd
+xqd
+unX
+unX
+nnU
+gge
+gge
+dMl
+"}
+(146,1,1) = {"
+dMl
+kMx
+kko
+kko
+kko
+kko
+kko
+kko
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kNm
+kNm
+kNm
+kNm
+kNm
+kNm
+kNm
+hTt
+stz
+stz
+iwc
+hTt
+hTt
+iwc
+kAC
+stz
+stz
+stz
+stz
+stz
+lLj
+lLj
+lLj
+lLj
+lLj
+lLj
+wHz
+gkr
+uMC
+gkr
+oJE
+oJE
+utr
+utr
+utr
+utr
+utr
+qti
+uYl
+wnB
+tMS
+sGc
+iUs
+hxd
+jCT
+jCT
+jcl
+iNi
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+bEf
+wDV
+lYr
+lYr
+lYr
+ngK
+bzD
+kcY
+waL
+cvo
+cvo
+rji
+rji
+rji
+gyc
+gyc
+ezO
+sYH
+bzD
+jsY
+jsY
+uox
+xXv
+rFd
+mAe
+mAe
+uXx
+wPp
+mnS
+mnS
+xWs
+cKU
+xjf
+sQl
+wPp
+wPp
+wPp
+wPp
+wPp
+uIM
+wPp
+irD
+gge
+gge
+gge
+jWZ
+jWZ
+jWZ
+csO
+fGQ
+gKw
+dzE
+kLq
+jFe
+oIn
+fWa
+vZW
+iyM
+hIC
+nys
+yas
+hIC
+sHh
+hIC
+gge
+gge
+gge
+irD
+xDu
+iQm
+wPp
+one
+fuh
+sDq
+kFd
+one
+nQP
+nQP
+nQP
+one
+unX
+unX
+nnU
+gge
+dMl
+"}
+(147,1,1) = {"
+dMl
+kMx
+kko
+gCP
+pGK
+nyk
+iCT
+kko
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+euM
+oDe
+uus
+euM
+oDe
+bWd
+kNm
+hTt
+sFq
+iCG
+fNB
+hTt
+hTt
+iwc
+kAC
+stz
+hbY
+bCl
+fbk
+bts
+sUA
+lpu
+aHB
+sUA
+sUA
+lLj
+wHz
+gkr
+gkr
+gkr
+gkr
+oJE
+utr
+utr
+utr
+utr
+utr
+utr
+kQw
+wnB
+tMS
+sGc
+kQw
+hxd
+jCT
+jCT
+jCT
+jcl
+jcl
+jcl
+hsw
+jCT
+jCT
+jCT
+jCT
+iwe
+lYr
+cfY
+lrn
+fYn
+jYU
+bpr
+oAo
+yfz
+yfz
+trE
+rji
+sss
+ezO
+ezO
+jRc
+oQb
+jYU
+bMi
+jsY
+pCK
+jsY
+xTA
+mAe
+mAe
+jOd
+wPp
+kXe
+kpb
+vfN
+mOn
+fOJ
+jOd
+irD
+kpb
+wPp
+wPp
+wPp
+uIM
+irD
+uIM
+gge
+gge
+jWZ
+jWZ
+csO
+csO
+fCk
+wVc
+gKw
+gKw
+cgn
+jFe
+efS
+jFe
+rXW
+hIC
+hIC
+aTK
+yas
+yas
+qNc
+hIC
+ctl
+ctl
+gge
+wPp
+wPp
+wPp
+wPp
+mOU
+fuh
+sDq
+hSn
+kFd
+kFd
+kFd
+kFd
+nQP
+unX
+unX
+unX
+gge
+dMl
+"}
+(148,1,1) = {"
+dMl
+kMx
+kko
+lHk
+vBY
+aqi
+kKD
+kko
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+oKM
+uyx
+bAG
+bAG
+nPm
+iWM
+kNm
+hTt
+stz
+dPW
+iwc
+hTt
+hTt
+iwc
+kAC
+hif
+qJY
+stz
+stz
+stz
+lLj
+lrf
+imE
+lLj
+dRG
+ltx
+wHz
+gkr
+gkr
+aBX
+oJE
+qTB
+utr
+utr
+utr
+utr
+utr
+lVO
+kmc
+gJG
+nud
+ibF
+hTV
+aPw
+jCT
+jCT
+jCT
+bEf
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+jKK
+lYr
+lYr
+lYr
+cfY
+iRS
+kCD
+gNC
+dsi
+yfz
+rji
+sss
+rji
+ezO
+trL
+fNu
+bAk
+oYO
+bMi
+jsY
+uox
+jsY
+sHr
+tdE
+mOn
+jOd
+irD
+irD
+irD
+uIM
+skP
+mAe
+frz
+kpb
+irD
+wPp
+pAG
+wPp
+irD
+uIM
+wPp
+tUw
+tUw
+jWZ
+eCj
+hGm
+wVc
+wVc
+lyq
+uYg
+gKw
+iyM
+vZW
+efS
+vZW
+iyM
+hIC
+eqv
+wZl
+wZl
+wZl
+wZl
+hIC
+jUF
+ctl
+bpp
+fhY
+irD
+wPp
+wPp
+mOU
+fuh
+oet
+vOu
+vOu
+gfS
+iwt
+kFd
+nQP
+xrW
+nnU
+gge
+gge
+dMl
+"}
+(149,1,1) = {"
+dMl
+kMx
+kko
+lHk
+jUb
+eVf
+gvN
+kko
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+rJr
+okS
+uIN
+uIN
+fvG
+iWM
+kNm
+kNm
+wmP
+gVX
+iwc
+kNm
+hTt
+iwc
+oRK
+stz
+ewD
+pKj
+pKj
+pKj
+lLj
+aEe
+euh
+lLj
+sUA
+lLj
+wJH
+gkr
+aBX
+gkr
+oJE
+oJE
+utr
+utr
+utr
+utr
+utr
+sDZ
+eav
+xJq
+vxN
+sDZ
+yiz
+jHs
+kJj
+nRY
+jcl
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+fgq
+buK
+vmV
+gRw
+lYr
+bqw
+jYU
+jYU
+jYU
+bzD
+trE
+rji
+lHA
+bzD
+jYU
+jYU
+jYU
+bzD
+bMi
+jsY
+uox
+jsY
+xtO
+irD
+gge
+gge
+wPp
+uIM
+irD
+gge
+jOd
+iWl
+mOn
+irD
+iih
+iQm
+irD
+irD
+vui
+wMw
+peV
+tUw
+kTH
+gKw
+ePY
+rhQ
+rhQ
+rhQ
+xbs
+oiN
+gKw
+vZW
+vZW
+vGz
+vZW
+ean
+hIC
+nPe
+tZW
+pIY
+xRJ
+wZl
+hIC
+itI
+jiS
+ctl
+aGW
+nth
+ctl
+wPp
+mOU
+fuh
+kFd
+kFd
+kFd
+kFd
+sDq
+kFd
+nQP
+xrW
+unX
+gge
+gge
+dMl
+"}
+(150,1,1) = {"
+dMl
+kMx
+kko
+lHk
+aHt
+qXB
+gvN
+kko
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+rZI
+qar
+qar
+qar
+qar
+wTw
+kNm
+stz
+stz
+stz
+iwc
+iwc
+iwc
+omB
+kAC
+stz
+qJY
+pKj
+pKj
+pKj
+bBp
+bBp
+bBp
+lLj
+sUA
+lLj
+wHz
+gkr
+gkr
+gkr
+oJE
+oJE
+utr
+utr
+lTu
+utr
+utr
+sDZ
+eav
+xJq
+vxN
+yiz
+sDZ
+jHs
+jcl
+jcl
+jcl
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+bEf
+wDV
+lYr
+lYr
+dHw
+xOk
+ccm
+buK
+lYr
+lYr
+bzD
+jYU
+kuc
+jYU
+bzD
+nBq
+nBq
+nBq
+wDV
+bMi
+jsY
+oMe
+jsY
+xtO
+wPp
+gge
+uIM
+wPp
+wPp
+gge
+gge
+wPp
+uIM
+cau
+gge
+gge
+irD
+uIM
+wPp
+peV
+hzi
+dUv
+tai
+jvx
+gKw
+ama
+gKw
+gKw
+gKw
+eUy
+lzz
+pEO
+cMz
+mUP
+dqw
+nRm
+vZW
+hIC
+hIC
+hIC
+hIC
+hIC
+pfe
+hIC
+oQt
+tSU
+tQO
+vQi
+vQi
+kIg
+irD
+one
+nQP
+nQP
+nQP
+one
+kFd
+sDq
+kFd
+one
+xrW
+nnU
+gge
+gge
+dMl
+"}
+(151,1,1) = {"
+dMl
+kMx
+kko
+tgQ
+ybq
+sZL
+aTD
+kko
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ssj
+nHr
+nHr
+nHr
+nHr
+uvO
+stz
+stz
+stz
+gVX
+iwc
+omB
+iwc
+iwc
+kAC
+hif
+qJY
+stz
+xUp
+hif
+bBp
+bBp
+bBp
+lLj
+dRG
+lLj
+wHz
+gkr
+uMC
+gkr
+oJE
+oJE
+utr
+utr
+utr
+utr
+lau
+sDZ
+sDZ
+yiz
+vxN
+sDZ
+sDZ
+jHs
+jCT
+jcl
+jCT
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+jCT
+jCT
+wDV
+uuT
+gge
+wMs
+wMs
+ccm
+xwQ
+kaL
+cfY
+ihx
+cfY
+gRw
+wDV
+cPh
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ooJ
+gge
+wPp
+wPp
+uIM
+ihD
+hXd
+kVT
+qpc
+lqJ
+ama
+hzZ
+hbn
+hbn
+vzy
+okC
+wVc
+gKw
+vZW
+tXn
+ymf
+aSs
+vZW
+ndm
+rLu
+jzU
+iyK
+lrl
+lpP
+ndm
+nBx
+pgu
+tsa
+iZF
+ekx
+kIg
+wPp
+wPp
+wPp
+wPp
+xgW
+nQP
+lud
+sDq
+kFd
+nQP
+xrW
+nnU
+gge
+gge
+dMl
+"}
+(152,1,1) = {"
+dMl
+kMx
+kko
+kko
+kko
+lJB
+aXA
+kko
+wmm
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+bfj
+uYk
+uYk
+uYk
+uYk
+dtn
+uYk
+xKs
+uYk
+lxO
+vdv
+vdv
+vdv
+tbD
+dIl
+dIl
+jVv
+dIl
+dIl
+dIl
+dIl
+jsf
+dIl
+njS
+pHj
+njS
+njS
+qCy
+iwc
+iwc
+iwc
+kQv
+kAC
+pKj
+qJY
+stz
+jaw
+iku
+lLj
+lLj
+lLj
+lLj
+sUA
+lLj
+wHz
+gkr
+gkr
+gkr
+oJE
+oJE
+utr
+utr
+utr
+xdD
+sDZ
+yiz
+sDZ
+sDZ
+pZV
+xHP
+mum
+hxd
+jCT
+jCT
+jCT
+jcl
+jcl
+sUC
+jCT
+jCT
+jCT
+jCT
+jCT
+jKK
+gge
+wMs
+wMs
+wMs
+gge
+cfY
+cfY
+lYr
+lYr
+wDV
+wDV
+wDV
+pXp
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jOd
+mOn
+qBs
+tUw
+tUw
+ovs
+wmc
+lFn
+wfL
+ama
+kIX
+hhP
+jlL
+xgA
+lnB
+vEA
+gKw
+nKj
+tXn
+uXo
+aSs
+iyM
+ndm
+vAX
+jNA
+csu
+enP
+hwc
+ndm
+iCL
+nox
+eML
+sdF
+gAW
+ctl
+irD
+irD
+irD
+iih
+iQm
+nQP
+fuh
+sDq
+kFd
+nQP
+unX
+gge
+gge
+gge
+dMl
+"}
+(153,1,1) = {"
+dMl
+kMx
+kko
+kko
+kko
+lEM
+auL
+kko
+gGn
+dEM
+gUl
+hAu
+gGn
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+bIP
+uYk
+uYk
+uYk
+uYk
+xKs
+vdv
+vdv
+lxO
+vdv
+vdv
+wgm
+vdv
+lxO
+vdv
+vdv
+vdv
+lxO
+vdv
+vdv
+iwc
+iwc
+iwc
+oeY
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+oRK
+stz
+qJY
+stz
+qBr
+ets
+lLj
+xtY
+lLj
+lLj
+sUA
+ltx
+wJH
+nwO
+nwO
+wJH
+loN
+gkr
+utr
+utr
+utr
+utr
+sDZ
+sDZ
+sDZ
+yiz
+xua
+aYX
+mum
+nKJ
+uGC
+aBI
+aBI
+toJ
+aTA
+aUA
+hgp
+aBI
+aBI
+rkk
+jPE
+wDV
+cfY
+gge
+gge
+gge
+wMs
+cfY
+cfY
+lYr
+wDV
+wDV
+pXp
+aZe
+jiq
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+vEC
+eFG
+ozZ
+hXd
+rCm
+bjI
+hwv
+xPM
+qwQ
+gKw
+gKw
+ama
+gKw
+gKw
+gKw
+gKw
+gKw
+nhD
+tXn
+uXo
+aSs
+iMx
+ndm
+iWT
+iWT
+iWT
+iWT
+kyw
+ndm
+ctl
+yfX
+ctl
+ctl
+ctl
+ctl
+ctl
+ctl
+irD
+irD
+wPp
+one
+fuh
+sDq
+kFd
+nQP
+nnU
+gge
+gge
+gge
+dMl
+"}
+(154,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+cXk
+nqs
+rDg
+eYi
+oqB
+cZS
+cfF
+fWj
+gGn
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+gDr
+vdv
+vdv
+vdv
+vdv
+vdv
+vdv
+wgm
+vdv
+vdv
+abQ
+vdv
+vdv
+vdv
+iwc
+omB
+iwc
+iwc
+iwc
+oeY
+iwc
+iwc
+omB
+iwc
+omB
+kAC
+stz
+ewD
+stz
+hif
+stz
+lLj
+bHm
+lLj
+lLj
+viE
+lLj
+lLj
+lLj
+bHm
+eiN
+gkr
+gkr
+utr
+sDZ
+utr
+sDZ
+sDZ
+sDZ
+jRs
+ohP
+fAz
+auO
+ghD
+hQy
+ulD
+gmb
+ulD
+dxL
+ulD
+dxL
+ulD
+ulD
+ulD
+rkk
+rxu
+wDV
+wDV
+wDV
+nBq
+wDV
+wDV
+nBq
+nBq
+wDV
+wDV
+jiq
+wDV
+wDV
+tNJ
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jBm
+mOn
+ihD
+mRF
+jvx
+ctS
+jvx
+gPh
+uEe
+lwn
+kcC
+rCz
+lLe
+rCz
+yhB
+myM
+tHm
+auz
+tXn
+uXo
+aSs
+dsm
+ndm
+nim
+vwY
+oGQ
+gwd
+sPU
+ndm
+bKt
+lUy
+gKz
+ctl
+bsG
+onp
+rGG
+ctl
+irD
+lDt
+irD
+nQP
+kFd
+ulw
+kFd
+one
+nnU
+gge
+gge
+gge
+dMl
+"}
+(155,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+pvI
+jdZ
+wSQ
+bYl
+rVL
+vjX
+vjX
+tsK
+gGn
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+uYk
+tIL
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+vdv
+vdv
+vdv
+odn
+vdv
+hTt
+gQx
+odn
+vdv
+hTt
+hTt
+hTt
+iwc
+kIl
+gVX
+iwc
+iwc
+iwc
+oeY
+iwc
+iwc
+iwc
+iwc
+kAC
+hif
+qJY
+bse
+stz
+stz
+lLj
+lLj
+lLj
+lLj
+sUA
+lLj
+lLj
+lLj
+lLj
+eiN
+gkr
+gkr
+kwF
+yiz
+qhC
+yiz
+eav
+eav
+kQw
+wnB
+tMS
+eZL
+qBF
+mSX
+rkk
+wBo
+wBo
+ixp
+qhk
+dxL
+rof
+wBo
+wBo
+rkk
+aQB
+faE
+pXp
+wDV
+wDV
+pXp
+pXp
+pXp
+jiq
+pXp
+pXp
+wDV
+nBq
+cfY
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+irD
+qBs
+tUw
+sOz
+qFx
+iDX
+jvx
+tzH
+ftF
+lwn
+sJq
+mBA
+uzw
+uOR
+uzw
+ahd
+qRI
+mst
+emE
+ymf
+aSs
+vZW
+iWT
+azz
+wFh
+xwS
+bhP
+vDH
+ndm
+tXx
+lUy
+eKv
+ctl
+tNw
+nZt
+fwm
+ctl
+ctl
+irD
+cTy
+nQP
+lud
+sDq
+kFd
+nQP
+unX
+gge
+gge
+gge
+dMl
+"}
+(156,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+qVg
+omo
+uAR
+bYl
+cjD
+vjX
+hXs
+kED
+gGn
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+bIP
+uYk
+uYk
+bIP
+uYk
+hTt
+hTt
+hTt
+vdv
+vdv
+hTt
+hTt
+hTt
+gQx
+vdv
+rNE
+rNE
+rNE
+rNE
+vXh
+stz
+gVX
+iwc
+omB
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+kAC
+stz
+qJY
+stz
+bse
+stz
+lLj
+cjW
+lLj
+lLj
+ccU
+lLj
+lLj
+lLj
+ltx
+alL
+jfO
+oeW
+jmj
+jmj
+jmj
+jmj
+jmj
+jmj
+jmj
+dxf
+pTc
+eZL
+qBF
+mSX
+rkk
+rkk
+lMW
+kzk
+dxL
+dxL
+kQX
+rkk
+rkk
+rhF
+uZt
+wxL
+pXp
+jiq
+xPp
+pXp
+jJp
+pXp
+xPp
+pXp
+jiq
+wDV
+buK
+cSI
+grK
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wPp
+tUw
+lOe
+jvx
+vdo
+wmc
+mDu
+xxo
+eDa
+lwn
+dik
+abt
+cjv
+ybj
+ybj
+xGy
+aTM
+nqG
+dfL
+hhU
+foY
+iyM
+iWT
+edl
+rOc
+uXa
+vQk
+kGb
+ndm
+xhS
+jYc
+hlm
+hmq
+ctl
+ctl
+jdu
+qYH
+ctl
+wPp
+irD
+nQP
+kFd
+sDq
+kFd
+nQP
+xrW
+gge
+gge
+gge
+dMl
+"}
+(157,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+rkw
+pHI
+ixu
+bYl
+qMC
+gxi
+njG
+xET
+gGn
+hTt
+uYk
+uYk
+uYk
+uYk
+xKs
+uYk
+uYk
+bIP
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+vdv
+vdv
+hTt
+hTt
+hTt
+gQx
+rNE
+rNE
+aFI
+tuv
+inm
+gOt
+stz
+gVX
+iwc
+iwc
+iwc
+iwc
+omB
+iwc
+iwc
+omB
+oRK
+stz
+qJY
+pbC
+hif
+stz
+lLj
+bHm
+lLj
+lLj
+bHm
+lLj
+lLj
+lLj
+bHm
+ccU
+lLj
+lLj
+tIH
+uYl
+sGc
+sGc
+tIH
+sGc
+sGc
+sGc
+tDj
+eZL
+qBF
+mSX
+rkk
+wBo
+wBo
+ixp
+qhk
+qhk
+cUA
+wBo
+wBo
+rkk
+gOq
+imr
+jJp
+pXp
+jiq
+sKK
+uGs
+sKK
+nBq
+sKK
+xSq
+nBq
+ngK
+cfY
+grK
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+tUw
+tUw
+lwn
+lwn
+uHH
+wmc
+gZe
+uJU
+ftF
+lwn
+pqk
+dJZ
+abq
+dIy
+abq
+abq
+exZ
+bSg
+mkJ
+fjy
+bSg
+bSg
+iWT
+fTR
+mrG
+cFT
+vQk
+fnT
+ndm
+cED
+lUy
+vOG
+seJ
+rWE
+lxb
+rFu
+lmR
+ctl
+ctl
+wPp
+one
+kFd
+sDq
+kFd
+one
+xrW
+nnU
+gge
+gge
+dMl
+"}
+(158,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+qVg
+pHI
+uAR
+eYi
+vJh
+bmo
+hSH
+lEw
+fWB
+uYk
+uYk
+uYk
+bIP
+uYk
+xKs
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+rNE
+pdE
+uJK
+eIb
+stz
+hif
+iwc
+iwc
+iwc
+omB
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+kAC
+stz
+qJY
+mpn
+stz
+stz
+lLj
+lLj
+lLj
+lLj
+ccU
+lLj
+lLj
+lLj
+lLj
+vJw
+qng
+lcF
+qti
+qti
+uYl
+sGc
+sGc
+sGc
+sGc
+sGc
+tMS
+sGc
+qBF
+ata
+ulD
+ulD
+ulD
+kzk
+dxL
+qhk
+ulD
+ulD
+ulD
+rkk
+blH
+khp
+sKK
+sKK
+uGs
+uGs
+ccm
+cfY
+gge
+gge
+ccm
+keq
+lYr
+grK
+grK
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ihD
+sDG
+qxf
+iHC
+hRr
+rai
+jvx
+xxo
+lHr
+lwn
+lnd
+wzM
+dde
+eTj
+vFe
+vFe
+vFe
+hfU
+hzj
+fjy
+fBE
+ksB
+ndm
+iWT
+ndm
+uZi
+xwS
+akS
+ndm
+ieT
+hQH
+qAq
+iGM
+xLp
+ctl
+iGf
+prP
+fcK
+nth
+wPp
+nQP
+kFd
+sDq
+kFd
+nQP
+xrW
+nnU
+gge
+gge
+dMl
+"}
+(159,1,1) = {"
+dMl
+kMx
+dMl
+dND
+xMz
+wZu
+nsu
+eYi
+jCs
+gGn
+gGn
+fWB
+uYk
+bfj
+uYk
+bIP
+uYk
+uYk
+xKs
+uYk
+uYk
+uYk
+bIP
+bfj
+uYk
+uYk
+uYk
+uYk
+uYk
+bIP
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+vhY
+pVD
+kCi
+wmP
+iwc
+wmP
+stz
+wmP
+iwc
+oeY
+iwc
+thd
+iwc
+iwc
+omB
+oeY
+kAC
+stz
+qJY
+uVQ
+stz
+stz
+gmn
+pFT
+hja
+lLj
+moD
+ltx
+lLj
+lLj
+ltx
+eiN
+gkr
+gkr
+qti
+qti
+qti
+oNG
+sqQ
+oNG
+oNG
+oNG
+fqR
+cEN
+lzV
+rzb
+wkF
+pIU
+pIU
+fMP
+iNi
+aUA
+jCT
+aBI
+kEC
+rkk
+khp
+wDV
+ccm
+ugS
+fYn
+ylC
+gge
+gge
+gge
+gge
+gge
+ccm
+xOk
+gge
+gge
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+ihD
+yiu
+cCk
+rwA
+pYm
+vdo
+bza
+ayU
+acG
+lwn
+uzw
+ahd
+uzw
+ahd
+vFe
+kto
+iGA
+vZW
+hzj
+fjy
+vZW
+vZW
+iGA
+bQO
+iWT
+oYE
+dBF
+hqO
+ndm
+pgm
+pqh
+rrv
+nIp
+wIg
+ctl
+iGf
+nzJ
+fkg
+kIg
+wPp
+nQP
+lud
+sDq
+kFd
+nQP
+unX
+nnU
+gge
+gge
+dMl
+"}
+(160,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+wep
+vPa
+cKe
+uYJ
+nRj
+lIx
+bfj
+uYk
+bfj
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+dJj
+dJj
+uYk
+uYk
+uYk
+uYk
+uYk
+bIP
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+rNE
+usN
+stz
+iqY
+jii
+mMB
+stz
+gVX
+iwc
+iwc
+iwc
+bwX
+ehT
+iwc
+eTL
+iwc
+mLd
+stz
+qJY
+stz
+stz
+stz
+lLj
+lLj
+lLj
+lLj
+moD
+lLj
+lLj
+lLj
+lLj
+eiN
+gkr
+gkr
+qti
+qti
+eQF
+kQw
+wnB
+iKv
+iKv
+tEl
+fYr
+vqu
+iKv
+jcl
+jcl
+jcl
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+jPE
+wDV
+mwt
+ugS
+mnv
+lYr
+lYr
+lYr
+gge
+gge
+gge
+gge
+bkS
+ugS
+gge
+gge
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+tUw
+lwn
+lwn
+lwn
+pYm
+gJU
+lwn
+lwn
+lwn
+lwn
+qRI
+rbs
+qRI
+qRI
+vFe
+wId
+vZW
+iyM
+hzj
+fjy
+vZW
+iyM
+vZW
+jiA
+ndm
+kyw
+iWT
+ndm
+ndm
+ctl
+ctl
+hzT
+oYH
+hzT
+ctl
+fIz
+ctl
+ctl
+ctl
+dHv
+tHm
+kFd
+sDq
+kFd
+one
+unX
+gge
+gge
+gge
+dMl
+"}
+(161,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+dVe
+fNT
+qVI
+dfn
+fYM
+dZs
+uYk
+uYk
+bIP
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+rNE
+ngo
+stz
+wlV
+qJY
+stz
+aHG
+wmP
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+wmP
+hif
+qJY
+stz
+hif
+wJe
+lLj
+lWz
+lLj
+lLj
+moD
+lLj
+wJH
+dPD
+dPD
+wJH
+aHg
+gkr
+qti
+qti
+qti
+qti
+wnB
+iKv
+mgz
+nWi
+fOu
+hpE
+iKv
+jcl
+jcl
+jcl
+jcl
+jcl
+jcl
+hsw
+jCT
+jCT
+jCT
+jPE
+uGs
+ccm
+ccm
+lYr
+wDV
+nBq
+wDV
+sKK
+gge
+gge
+gge
+ccm
+ugS
+ugS
+gge
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+stb
+iyM
+dIf
+ofq
+fjy
+hzj
+iyM
+vZW
+niW
+cFI
+fYI
+vZW
+vZW
+vZW
+vZW
+vZW
+pnZ
+oof
+lSs
+nKr
+jyC
+pnZ
+jyC
+vTn
+vZW
+meU
+hrh
+niW
+fvy
+jdl
+vZW
+vZW
+efS
+vZW
+hJs
+fjy
+hrT
+pQY
+pQY
+sMY
+kFd
+kFd
+sDq
+kFd
+nQP
+unX
+gge
+gge
+gge
+dMl
+"}
+(162,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+sLQ
+pss
+mrA
+dfn
+tuU
+eYi
+hTt
+xKs
+xtz
+xKs
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+bIP
+uYk
+bfj
+uYk
+uYk
+uYk
+bfj
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+vhY
+sfe
+rxX
+stz
+iwc
+wmP
+wmP
+iwc
+iwc
+omB
+iwc
+iwc
+gNP
+fCN
+muo
+oeY
+iwc
+stz
+qJY
+stz
+bse
+iku
+lLj
+lLj
+lLj
+wrb
+qgr
+lLj
+wHz
+uMC
+gkr
+gkr
+gkr
+uMC
+qti
+qti
+qti
+qti
+wnB
+arD
+mgz
+nWi
+cWj
+stJ
+arD
+pZB
+ntS
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+wDV
+wDV
+wDV
+gge
+lYr
+sUx
+wDV
+pXp
+krm
+sKK
+sKK
+gge
+gge
+gge
+ccm
+ccm
+gge
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+dPs
+vZW
+stb
+ean
+iuV
+hzj
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+nZS
+pnZ
+lrq
+xtI
+mOH
+uiB
+tGW
+hzj
+hzj
+hzj
+hzj
+hzj
+hzj
+hzj
+hzj
+hzj
+vGz
+hzj
+hzj
+vGz
+hzj
+bQQ
+oeL
+fiS
+vOu
+vOu
+nJR
+kFd
+nQP
+nnU
+gge
+gge
+gge
+dMl
+"}
+(163,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+lEx
+vre
+xmb
+dfn
+qNN
+eYi
+hTt
+uYk
+uYk
+uYk
+dJj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+bfj
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+gQx
+gQx
+hTt
+hTt
+jyv
+rOz
+dBx
+kqu
+qJY
+hvJ
+wmP
+omB
+gVX
+iwc
+oeY
+gQD
+iwc
+iwc
+iwc
+iwc
+iwc
+iwc
+stz
+qJY
+stz
+stz
+stz
+lLj
+lLj
+sUA
+imE
+sUA
+ltx
+wHz
+gkr
+gkr
+gkr
+gkr
+aBX
+qti
+qti
+qti
+neU
+wnB
+arD
+mgz
+fgl
+sGT
+hAI
+vrg
+pZB
+kUp
+jcl
+jcl
+kMP
+jCT
+jCT
+jCT
+wDV
+wDV
+gge
+gge
+gge
+gge
+lYr
+wDV
+gtP
+pXp
+pXp
+wDV
+lYr
+gge
+ylC
+lYr
+lYr
+ylC
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+mZZ
+vZW
+fWa
+vZW
+dzQ
+hzj
+ygG
+ygG
+ygG
+ygG
+ygG
+ygG
+xRV
+ahw
+cSZ
+ksB
+vZW
+bKn
+cqA
+vFn
+sGg
+vJs
+uIl
+uIl
+ygG
+mob
+ygG
+ygG
+ygG
+xRV
+ygG
+ygG
+tUs
+iyM
+iRi
+fjy
+vZW
+kPQ
+lxW
+reO
+kFd
+lud
+kFd
+kFd
+nQP
+unX
+gge
+gge
+gge
+dMl
+"}
+(164,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+eYi
+bYl
+eYi
+nXe
+tuU
+eYi
+dJj
+uYk
+uYk
+uYk
+dJj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+bIP
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aqr
+ukC
+ohZ
+iRL
+ukC
+ukC
+kTD
+ukC
+ukC
+ukC
+ucR
+ukC
+mcP
+cNJ
+giV
+ohZ
+pSl
+ohZ
+lLj
+lLj
+lLj
+euh
+suh
+lLj
+wHz
+gkr
+gkr
+gkr
+gkr
+gkr
+qti
+qti
+qti
+qti
+wnB
+arD
+qMo
+fgl
+sGT
+hAI
+vrg
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+jCT
+jCT
+wDV
+lYr
+gge
+gge
+gge
+gge
+gge
+lYr
+wDV
+wDV
+wDV
+wDV
+ccm
+ugS
+ccm
+lYr
+nBq
+wDV
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kNB
+cLh
+lwq
+lwq
+fmb
+wdh
+lxE
+xQL
+pyY
+xQL
+wyo
+xQL
+tss
+xuz
+jEr
+pRx
+lwq
+dTw
+lCu
+alw
+seC
+nte
+lwq
+tdl
+ceB
+nPa
+bXr
+xQL
+gXY
+xQL
+vfn
+cbc
+oGr
+qDh
+lwq
+dnM
+wVo
+iXc
+rim
+ipq
+kFd
+kFd
+kFd
+kFd
+one
+xrW
+gge
+gge
+gge
+dMl
+"}
+(165,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+fcM
+vwN
+oRo
+dfn
+aHD
+bYl
+dJj
+uYk
+bIP
+uYk
+dJj
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+uYk
+bIP
+uYk
+rtE
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+tou
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+sTH
+ukC
+ukC
+ukC
+kTD
+sZw
+kTD
+pGZ
+ukC
+sZw
+ukC
+ohZ
+giV
+tBm
+nQj
+ohZ
+lLj
+bHm
+lLj
+ltx
+dRG
+vpA
+wJH
+gkr
+gkr
+gkr
+gkr
+gkr
+dNf
+qti
+qti
+qti
+wnB
+iKv
+fpk
+ind
+sGT
+stJ
+iKv
+jcl
+jcl
+kMP
+jCT
+jCT
+jCT
+jCT
+jCT
+wDV
+lYr
+lYr
+gge
+gge
+gge
+gge
+jKK
+wDV
+jKK
+lYr
+lYr
+ylC
+ccm
+ccm
+cfY
+nBq
+aZe
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+stb
+jFe
+stb
+vZW
+stb
+efS
+hxa
+hxa
+hxa
+hxa
+hxa
+hxa
+haO
+tOF
+lby
+ksB
+qop
+uIl
+wSb
+okb
+oru
+qMS
+vZW
+vZW
+lby
+eaM
+hxa
+hxa
+hxa
+hxa
+hxa
+hxa
+hxa
+vZW
+vZW
+vZW
+vZW
+pQY
+acv
+reO
+kFd
+kFd
+kFd
+kFd
+nQP
+unX
+nnU
+gge
+gge
+dMl
+"}
+(166,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+ozn
+vwN
+fDR
+dfn
+tuU
+bYl
+dJj
+uYk
+uYk
+rtE
+uYk
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+bUe
+hKZ
+xLe
+xLe
+xLe
+xLe
+xLe
+xLe
+xLe
+nnD
+aTU
+iRL
+cGM
+ukC
+bMq
+iRL
+ukC
+iRL
+iRL
+ukC
+ukC
+iRL
+jpW
+ukC
+iRL
+nLu
+jpW
+akQ
+lLj
+ltx
+lLj
+sUA
+lLj
+wHz
+gkr
+gkr
+gkr
+gkr
+gkr
+qti
+qti
+qti
+qti
+wnB
+iKv
+mxq
+gjC
+cWj
+xCq
+iKv
+jcl
+jcl
+jCT
+jCT
+jcl
+jCT
+bEf
+jPE
+wDV
+lYr
+cfY
+gge
+gge
+gge
+gge
+wDV
+jhk
+wDV
+gRw
+lYr
+ccm
+ugS
+ccm
+gRw
+wDV
+wDV
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+stb
+fWa
+stb
+vZW
+vZW
+efS
+hzj
+hzj
+hzj
+hzj
+hzj
+hzj
+oIn
+vZW
+vZW
+vZW
+gpb
+gpb
+qXw
+cdJ
+gld
+jyC
+anw
+vZW
+vZW
+qEm
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+vZW
+fWa
+pQY
+uJG
+sMY
+kFd
+kFd
+kFd
+kFd
+nQP
+unX
+nnU
+gge
+gge
+dMl
+"}
+(167,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+qUJ
+vwN
+gjq
+xeU
+iGD
+eYi
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+wmm
+wmm
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+wmm
+wmm
+wmm
+lpY
+hTt
+bUe
+bUe
+hKZ
+rrC
+klE
+sDu
+jIz
+hff
+jlU
+bUj
+gXL
+udq
+cGM
+ukC
+sZw
+iRL
+ukC
+gJz
+ukC
+iRL
+ukC
+ukC
+iRL
+peD
+qHD
+iRL
+jpW
+iRL
+sUA
+sUA
+lLj
+sUA
+sUA
+lLj
+hav
+uMC
+gkr
+gkr
+gkr
+uMC
+qti
+qti
+qti
+neU
+wnB
+iKv
+nwT
+gjC
+ruP
+nNG
+arD
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+jPE
+wDV
+lYr
+cSI
+lYr
+gge
+jVp
+gge
+gge
+sKK
+uGs
+ccm
+lYr
+gge
+ccm
+ccm
+ccm
+lYr
+jKK
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+mMr
+iyM
+fZH
+vZW
+vZW
+oIn
+vZW
+vZW
+wgu
+sOf
+jdl
+vZW
+efS
+hzj
+hzj
+wRQ
+lSs
+lSs
+lSs
+suc
+pnZ
+pnZ
+pnZ
+vZW
+vZW
+iyM
+hrh
+niW
+dsm
+fYI
+qsn
+vZW
+ean
+iyM
+vZW
+blA
+vZW
+iyM
+pQY
+lUL
+kFd
+lud
+hSn
+kFd
+nQP
+xrW
+gge
+gge
+gge
+dMl
+"}
+(168,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+fwY
+vwN
+vwN
+dfn
+tuU
+eYi
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+wmm
+wmm
+hTt
+uYk
+uYk
+uYk
+dtn
+uYk
+uYk
+hTt
+hTt
+wmm
+wmm
+wmm
+lpY
+hTt
+sTX
+guS
+sTX
+tjS
+hKZ
+fqh
+dwl
+dwl
+dwl
+hff
+hKZ
+cGM
+ukC
+iRL
+ukC
+ran
+ukC
+ukC
+xSj
+sZw
+ukC
+cGM
+mcP
+sZw
+ukC
+jpW
+cGM
+ukC
+eps
+lLj
+lLj
+eps
+ltx
+lLj
+jUf
+gkr
+gkr
+gkr
+gkr
+aBX
+qti
+qti
+qti
+jVj
+wnB
+iKv
+wnI
+gjC
+pTj
+lQG
+arD
+jCT
+jCT
+jCT
+jcl
+jcl
+jCT
+jCT
+jPE
+wDV
+cfY
+lYr
+lYr
+cfY
+gge
+gge
+lYr
+gge
+gge
+ylC
+ylC
+gge
+gge
+gge
+ccm
+lYr
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+wRd
+eUS
+eUS
+eUS
+oxW
+tdi
+eUS
+eUS
+eUS
+bwL
+bwL
+dHe
+dCE
+bwL
+bwL
+wId
+vZW
+iyM
+hzj
+fjy
+vZW
+iyM
+vZW
+jiA
+vTX
+cEs
+xEF
+cEs
+cEs
+cEs
+vTX
+vTX
+vTX
+vTX
+vTX
+vTX
+wOj
+wOj
+acR
+dHv
+nQP
+nQP
+nQP
+nQP
+sez
+nnU
+nnU
+gge
+gge
+dMl
+"}
+(169,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+eze
+vwN
+rAH
+dfn
+aHD
+bYl
+hTt
+uYk
+uYk
+bIP
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+bIP
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+wmm
+wmm
+wmm
+lpY
+hTt
+kNm
+hTt
+hTt
+ktz
+dwl
+uPO
+dwl
+dPk
+hff
+dwl
+dwl
+xTC
+iRL
+ukC
+ukC
+ukC
+ukC
+wXy
+ukC
+ukC
+ukC
+ucR
+ukC
+ukC
+sEq
+iRL
+uOv
+nrG
+gzD
+lZA
+hav
+lcF
+hav
+lZA
+lcF
+gkr
+gkr
+gkr
+aBX
+gkr
+qti
+qti
+qti
+qti
+vIq
+arD
+pXO
+gjC
+eBm
+wJU
+arD
+jCT
+jCT
+vjF
+jcl
+jcl
+jCT
+jCT
+jCT
+wDV
+fYn
+lYr
+cSI
+lYr
+lYr
+gge
+ccm
+gge
+gge
+ccm
+gge
+gge
+gge
+gge
+gge
+ccm
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+cFc
+cNG
+uKm
+hUX
+ujC
+xDq
+oxW
+aGQ
+rOi
+bwL
+ieM
+fVU
+coA
+sha
+bwL
+eCS
+iGA
+vZW
+hzj
+uld
+vZW
+vZW
+lVM
+gxq
+vTX
+mxA
+jml
+nLf
+ydn
+lty
+kzP
+isb
+aqE
+vTX
+uIC
+nhh
+mMp
+kXC
+acR
+gge
+iRM
+ehH
+biM
+xDm
+iRM
+pQf
+gge
+gge
+gge
+dMl
+"}
+(170,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+eYi
+eYi
+eYi
+pVc
+oXZ
+eYi
+hTt
+hTt
+bfj
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+hTt
+hTt
+hTt
+bUe
+aXd
+wid
+klE
+ify
+eXe
+sDu
+duT
+iRL
+ukC
+ukC
+ukC
+iRL
+ukC
+ukC
+sTH
+eWj
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+sEq
+gkr
+uMC
+akQ
+gkr
+gkr
+gkr
+uMC
+gkr
+gkr
+aBX
+gkr
+gkr
+qti
+qti
+qti
+qti
+wnB
+arD
+oDb
+clS
+pWq
+wAb
+arD
+jCT
+jCT
+jCT
+jcl
+jcl
+jCT
+hsw
+jCT
+wDV
+cfY
+ngK
+lYr
+lYr
+lYr
+ccm
+ccm
+ugS
+lrn
+lYr
+lYr
+gge
+gge
+gge
+gge
+gge
+lYr
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+fCZ
+wMZ
+eZg
+oqA
+azA
+qOe
+oxW
+mvN
+ctR
+hTw
+jIT
+mMX
+pgl
+pum
+bwL
+bwL
+bwL
+vZW
+hzj
+fjy
+ksB
+vZW
+aFT
+aFT
+aFT
+bsJ
+dKN
+hku
+hku
+hku
+jLS
+qmW
+tvl
+vTX
+qhS
+mMp
+afJ
+kYa
+acR
+gge
+gge
+iRM
+iRM
+iRM
+hGQ
+otZ
+oxw
+gge
+gge
+dMl
+"}
+(171,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+lCz
+mcq
+mcq
+nOG
+vOd
+eYi
+bIP
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+wmm
+wmm
+hTt
+hTt
+xKs
+xKs
+xKs
+xKs
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+lpY
+wmm
+hTt
+bUe
+bUe
+kxk
+kxk
+kxk
+kxk
+kxk
+aPm
+nnD
+aTU
+cNJ
+iRL
+sZw
+nQj
+iRL
+pGZ
+ukC
+sZw
+kTD
+ukC
+ukC
+sZw
+pGZ
+ukC
+qKv
+ukC
+hqJ
+hRC
+gkr
+gkr
+gkr
+rhr
+rhr
+gkr
+gkr
+rhr
+pYw
+hTt
+hTt
+qti
+qti
+neU
+wnB
+arD
+tpR
+gjC
+pTj
+hpE
+iKv
+jcl
+kMP
+jcl
+jcl
+jCT
+jCT
+jCT
+jCT
+wDV
+fYn
+lYr
+lYr
+lYr
+lYr
+ccm
+ugS
+ccm
+cSI
+lYr
+lYr
+lYr
+gge
+gge
+gge
+gge
+sct
+lYr
+gge
+gge
+ccm
+lYr
+lYr
+hng
+cfY
+lYr
+pTO
+cVE
+aMq
+aMq
+xqB
+lYr
+tov
+ccm
+kaL
+lYr
+tov
+wRd
+wRd
+eUS
+eUS
+oxW
+mdn
+oxW
+rHo
+oXl
+bwL
+eCE
+dDq
+mod
+vEv
+wOy
+pQR
+bwL
+vZW
+uFX
+lkV
+uIh
+vZW
+nqF
+jag
+ydv
+gPi
+jml
+bgk
+cuo
+hku
+gSu
+jLS
+dqN
+vTX
+nJt
+oTC
+kUT
+acR
+acR
+gge
+gge
+pQf
+iRM
+iRM
+otZ
+ipw
+otZ
+gge
+gge
+dMl
+"}
+(172,1,1) = {"
+dMl
+kMx
+dMl
+bYl
+ghA
+kQK
+nEG
+wHg
+uFu
+eYi
+uYk
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+wmm
+wmm
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+lpY
+hTt
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+ukC
+ukC
+ukC
+kTD
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+ukC
+hTt
+hTt
+rhr
+gkr
+rhr
+rhr
+rhr
+rhr
+rhr
+rhr
+pYw
+hTt
+hTt
+qti
+qti
+qti
+wnB
+iKv
+qXg
+uAo
+pTj
+heN
+xbo
+ntS
+jcl
+jcl
+jcl
+yau
+jCT
+jCT
+wDV
+wDV
+cfY
+lYr
+lYr
+cfY
+lYr
+ugS
+ccm
+lYr
+lYr
+lYr
+lYr
+lhO
+lYr
+gge
+gge
+gge
+lYr
+kaL
+ccm
+lYr
+lYr
+lYr
+lYr
+lYr
+cfY
+lYr
+pTO
+aMq
+ghB
+aMq
+pTO
+lYr
+lYr
+xOk
+ccm
+tov
+tov
+tov
+wRd
+lli
+oxW
+rkl
+cbN
+kks
+mvN
+rRZ
+bwL
+mNJ
+rsP
+gFI
+pum
+pum
+hBp
+bwL
+iyM
+tPy
+tku
+nRm
+iyM
+nqF
+bDV
+dPb
+eyJ
+hku
+dKN
+qOW
+cZT
+frt
+hpO
+erE
+gOs
+aya
+lTd
+hnV
+acR
+gge
+gge
+gge
+iRM
+iRM
+iRM
+otZ
+otZ
+otZ
+gge
+gge
+dMl
+"}
+(173,1,1) = {"
+dMl
+kMx
+dMl
+eYi
+dQT
+qhF
+dfn
+kKC
+sHK
+bYl
+hTt
+uYk
+uYk
+uYk
+bIP
+uYk
+hTt
+wmm
+wmm
+hTt
+hTt
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+gQx
+gQx
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+aTU
+cKZ
+cKZ
+lMy
+lMy
+ukC
+ukC
+ukC
+lMy
+lMy
+ukC
+ukC
+ukC
+ukC
+ukC
+hTt
+hTt
+ukC
+sZw
+hTt
+hTt
+hTt
+rhr
+rhr
+rhr
+hTt
+hTt
+hTt
+riJ
+pYw
+pYw
+hTt
+hTt
+qti
+qti
+wnB
+arD
+oBQ
+gjC
+pTj
+awj
+vrg
+ntS
+jcl
+jcl
+jcl
+jCT
+jCT
+jCT
+wDV
+lYr
+xwQ
+fYn
+kaL
+lYr
+ccm
+ugS
+ccm
+lYr
+kaL
+lYr
+wDV
+wDV
+wDV
+wDV
+sKK
+ugS
+vpM
+pSX
+pSX
+vpM
+pSX
+pSX
+pSX
+vpM
+pSX
+pSX
+vpM
+cwJ
+aDx
+aDx
+pSX
+lYr
+lYr
+ccm
+lYr
+tov
+tov
+ccm
+mRv
+wRd
+vHr
+rkl
+juF
+oxW
+cEb
+auH
+bwL
+jIT
+fSh
+uCR
+hBp
+pum
+qqU
+bwL
+oyu
+tXn
+ymf
+aSs
+ean
+tvH
+xGN
+nMb
+cZT
+fxV
+cZT
+tbN
+gtW
+vTX
+vTX
+wOj
+vTX
+qDm
+wOj
+acR
+acR
+gge
+gge
+gge
+iRM
+iRM
+iRM
+iRM
+iRM
+iRM
+pQf
+gge
+dMl
+"}
+(174,1,1) = {"
+dMl
+kMx
+ahA
+bYl
+enZ
+qye
+cga
+xdL
+szS
+bYl
+hTt
+dJj
+uYk
+uYk
+uYk
+uYk
+dJj
+wmm
+wmm
+hTt
+hTt
+uYk
+bIP
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+gQx
+gQx
+gQx
+gQx
+gQx
+hTt
+hTt
+hTt
+hTt
+lMy
+lMy
+lMy
+lMy
+lMy
+lMy
+lMy
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+rhr
+rhr
+rhr
+rhr
+hTt
+hTt
+rhr
+rhr
+pYw
+hTt
+hTt
+qti
+qti
+wnB
+arD
+oBQ
+gjC
+pWq
+stJ
+vrg
+jcl
+bEf
+jCT
+jcl
+kMP
+jCT
+jCT
+wDV
+ngK
+lYr
+kaL
+lYr
+ccm
+lYr
+ccm
+gge
+dlV
+acF
+kaL
+wDV
+aZe
+xPp
+jJp
+gGa
+ccm
+pSX
+ciT
+aDx
+aDx
+aDx
+aDx
+eyG
+aDx
+aDx
+aDx
+ciT
+aDx
+aDx
+eyG
+kib
+vjO
+acF
+lYr
+ccm
+lYr
+ccm
+ccm
+ylC
+fCZ
+hfG
+rkl
+cbN
+oxW
+rHo
+rRZ
+bwL
+jIT
+nVM
+hBm
+kGH
+pum
+uhQ
+bwL
+vZW
+tXn
+pmF
+xyb
+cMz
+ujS
+pCn
+pex
+lty
+wJm
+lXR
+tbm
+bow
+qfE
+svF
+rnn
+xED
+xGN
+xGN
+ayi
+gge
+gge
+gge
+gge
+iRM
+iRM
+ehH
+iRM
+gge
+gge
+gge
+gge
+dMl
+"}
+(175,1,1) = {"
+dMl
+kMx
+ahA
+xVm
+xVm
+bRT
+xVm
+xVm
+xVm
+hTt
+dJj
+dJj
+uYk
+bIP
+uYk
+dJj
+dJj
+hTt
+hTt
+hTt
+hTt
+ewi
+qcW
+ewi
+ewi
+ewi
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+gQx
+hTt
+hTt
+hTt
+qOh
+lMy
+bNO
+lMy
+lMy
+lMy
+hTt
+hTt
+coj
+coj
+coj
+coj
+coj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+pYw
+pYw
+riJ
+rhr
+hTt
+rhr
+rhr
+pYw
+hTt
+hTt
+qti
+neU
+wnB
+arD
+cZz
+kGR
+pTj
+eES
+arD
+jcl
+jCT
+jCT
+jcl
+jCT
+jCT
+jCT
+wDV
+ngK
+kaL
+lYr
+lYr
+ccm
+ccm
+gge
+gge
+gge
+ccm
+lYr
+wDV
+wDV
+jJp
+mKG
+sKK
+ccm
+pSX
+aUU
+ciT
+aUU
+aDx
+aDx
+aDx
+aUU
+aDx
+ciT
+aDx
+aUU
+aDx
+aDx
+uvC
+sKK
+lYr
+lYr
+lYr
+lYr
+ccm
+ccm
+ylC
+mUZ
+hfG
+tZl
+kpR
+erm
+oxW
+wxA
+frO
+jIT
+kGH
+pum
+iEz
+pum
+vxv
+bwL
+gUy
+tXn
+uXo
+aSs
+vZW
+nqF
+xGN
+sAe
+yep
+mdi
+vTX
+vTX
+vTX
+vTX
+dUl
+nFd
+ekB
+gNK
+ayi
+ayi
+gge
+gge
+gge
+gge
+pQf
+fNL
+fNL
+pQf
+gge
+gge
+gge
+gge
+dMl
+"}
+(176,1,1) = {"
+dMl
+kMx
+ahA
+xMb
+ooB
+ekp
+cPQ
+kKK
+sOB
+dJj
+dJj
+uYk
+uYk
+uYk
+bIP
+dJj
+hTt
+hTt
+hTt
+hTt
+hTt
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+gQx
+gQx
+hTt
+lMy
+aYU
+lMy
+lMy
+lMy
+lMy
+hTt
+coj
+coj
+phD
+kkR
+uip
+coj
+coj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+pYw
+pYw
+rhr
+rhr
+rhr
+rhr
+pYw
+hTt
+hTt
+qti
+qti
+wnB
+iKv
+osY
+sEU
+pTj
+bDh
+iKv
+jCT
+jCT
+jcl
+jcl
+jcl
+jCT
+jCT
+wDV
+cfY
+lYr
+xwQ
+cfY
+ccm
+gge
+gge
+gge
+gge
+gge
+lYr
+lYr
+sKK
+oLl
+gGa
+cSI
+lYr
+pSX
+aDx
+aDx
+aDx
+aDx
+aDx
+aDx
+aDx
+aDx
+aDx
+aDx
+lvV
+lvV
+lvV
+pAW
+tov
+tov
+lYr
+ccm
+lYr
+ccm
+ccm
+lYr
+wRd
+uUu
+oxW
+ayz
+tPk
+ygv
+uoZ
+frO
+jIT
+xJw
+pum
+ltM
+pum
+pum
+lZy
+iyM
+tXn
+uXo
+aSs
+iyM
+qSs
+tfv
+onv
+cyq
+pCn
+osF
+pCn
+kxi
+fiV
+svF
+jID
+jID
+ujM
+ayi
+fNL
+iRM
+gge
+gge
+gge
+gge
+fNL
+pQf
+pQf
+gge
+gge
+gge
+gge
+dMl
+"}
+(177,1,1) = {"
+dMl
+kMx
+ahA
+oFb
+oFb
+cPQ
+oFb
+oCW
+xVm
+dJj
+uYk
+bIP
+rtE
+uYk
+uYk
+dJj
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+ewi
+iaX
+ewi
+hET
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+oaq
+ide
+xXJ
+xXJ
+hTt
+hTt
+hTt
+coj
+xJr
+wMv
+pbe
+uip
+xJr
+coj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+pYw
+rhr
+rhr
+wUE
+pYw
+hTt
+hTt
+hTt
+pLB
+pLB
+xaY
+iKv
+iKv
+arD
+rIX
+vqu
+iKv
+kXw
+kXw
+xqZ
+xqZ
+kXw
+kXw
+kXw
+wDV
+wDV
+lma
+acF
+lYr
+ccm
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+ccm
+ugS
+ccm
+lYr
+lrn
+vpM
+aDx
+aDx
+aDx
+aDx
+aDx
+gIc
+gIc
+aDx
+aUU
+lvV
+lvV
+lvV
+ezW
+vpM
+vpM
+tov
+ccm
+lYr
+foU
+pDx
+pDx
+pDx
+wqC
+xQW
+eUS
+eUS
+eUS
+tPk
+mxn
+bwL
+bwL
+bwL
+dCK
+bwL
+bwL
+bwL
+bwL
+vZW
+tXn
+ymf
+aSs
+vZW
+aFT
+aFT
+aFT
+xGN
+iBD
+rnn
+rnn
+rnn
+keI
+uem
+xGN
+esN
+wuo
+pQf
+fNL
+gge
+gge
+gge
+ctE
+oxw
+oxw
+pQf
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(178,1,1) = {"
+dMl
+kMx
+ahA
+teS
+oFb
+cPQ
+aud
+xVm
+xVm
+dJj
+uYk
+uYk
+uYk
+uYk
+uYk
+dJj
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+iaX
+ewi
+hET
+hET
+hTt
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+tpv
+xXJ
+hTt
+xXJ
+xXJ
+oaq
+oaq
+gQx
+hTt
+hTt
+coj
+atA
+mQi
+qLU
+rcT
+atA
+coj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+cZA
+rxN
+cZA
+hTt
+hTt
+hTt
+hTt
+pLB
+mHD
+pLB
+pLB
+tfo
+ssG
+sMI
+eaP
+qEY
+kXw
+pGi
+xqZ
+xqZ
+fMZ
+kXw
+kXw
+kXw
+wDV
+lYr
+fYn
+lYr
+ccm
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+ugS
+ccm
+lYr
+lYr
+lYr
+pSX
+aDx
+aDx
+eyG
+aDx
+gIc
+njZ
+aDx
+aDx
+lvV
+lvV
+lvV
+lvV
+xvO
+lvV
+vpM
+vpM
+tov
+ccm
+pDx
+xQW
+xQW
+xQW
+xQW
+xQW
+bWE
+xQW
+sDR
+kHS
+wqC
+wqC
+ulJ
+ulJ
+hxW
+miv
+wqC
+dLA
+vZW
+vZW
+ePu
+hpy
+foY
+vZW
+vZW
+wsT
+aFT
+lAK
+uuX
+xwk
+guK
+hQT
+keI
+xGN
+hTG
+svF
+hyh
+oRY
+pQf
+pQf
+gge
+iRM
+otZ
+otZ
+gZx
+otZ
+otZ
+gge
+gge
+gge
+gge
+dMl
+"}
+(179,1,1) = {"
+dMl
+kMx
+ahA
+oFb
+pBt
+cPQ
+oFb
+xVm
+dJj
+dJj
+uYk
+uYk
+bfj
+uYk
+dJj
+dJj
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+qcW
+ewi
+hET
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+vCY
+xXJ
+xXJ
+xXJ
+xXJ
+exh
+vCY
+xXJ
+tpv
+xXJ
+hTt
+gQx
+hTt
+coj
+xGV
+pbe
+fEU
+pbe
+xGV
+coj
+hTt
+hTt
+hTt
+hTt
+kyb
+kyb
+kyb
+kyb
+dQk
+dQk
+kyb
+hTt
+hTt
+hTt
+hTt
+pLB
+pLB
+pLB
+pLB
+pLB
+hpk
+sMI
+eaP
+qEY
+kXw
+kXw
+kXw
+xqZ
+xqZ
+kXw
+kXw
+kXw
+wDV
+kaL
+lYr
+lYr
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+lYr
+lYr
+lYr
+cSI
+pSX
+aUU
+aDx
+aUU
+aDx
+gIc
+njZ
+arQ
+lvV
+lvV
+lvV
+lvV
+lvV
+jjG
+lvV
+lvV
+vpM
+vpM
+lYr
+pDx
+byT
+xQW
+bOc
+iwP
+unj
+fCj
+unj
+iwP
+jcV
+xQW
+wqC
+miv
+miv
+miv
+miv
+wqC
+wTu
+vZW
+vZW
+hzj
+fjy
+vZW
+vZW
+vZW
+vZW
+nqF
+xGN
+uVC
+bZi
+rnz
+uuX
+kYS
+ayi
+aRW
+aRW
+cTb
+pQf
+rQH
+pQf
+pQf
+otZ
+otZ
+bXa
+dPB
+dPB
+eoR
+xDm
+gge
+gge
+gge
+dMl
+"}
+(180,1,1) = {"
+dMl
+kMx
+ahA
+oFb
+oFb
+cPQ
+aud
+sOB
+dJj
+uYk
+uYk
+bIP
+uYk
+dJj
+dJj
+hTt
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+ewi
+ewi
+hET
+hTt
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+exh
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+gQx
+coj
+coj
+ieb
+cGR
+aSR
+hbF
+pFz
+coj
+bZD
+ukC
+ukC
+ukC
+dQk
+dQk
+dQk
+dQk
+dQk
+dQk
+dQk
+kyb
+hTt
+hTt
+hTt
+pLB
+pLB
+pLB
+mHD
+pLB
+ssG
+uWE
+gBq
+qEY
+kXw
+kXw
+xqZ
+xqZ
+kXw
+kXw
+kXw
+kXw
+jKK
+lYr
+lYr
+lYr
+lYr
+ijB
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+lYr
+cSI
+wDV
+wDV
+pSX
+aDx
+aDx
+aDx
+njZ
+njZ
+gIc
+aDx
+lvV
+lvV
+oMI
+lvV
+lvV
+tCn
+geh
+lvV
+lvV
+vpM
+lYr
+pDx
+cXT
+xQW
+kkq
+jvJ
+hJX
+dQg
+xMP
+sLz
+pAh
+byT
+tPi
+bBy
+sxj
+nHC
+dPE
+hhq
+dDM
+vZW
+ean
+wRQ
+sgb
+vZW
+ean
+vZW
+iyM
+gWR
+xGN
+dXZ
+qEw
+ejc
+ejc
+ayi
+ayi
+iRM
+iRM
+iRM
+pQf
+iRM
+pQf
+gge
+otZ
+dPB
+dPB
+dPB
+dPB
+otZ
+gge
+gge
+gge
+gge
+dMl
+"}
+(181,1,1) = {"
+dMl
+kMx
+ahA
+teS
+oFb
+cPQ
+xVm
+xVm
+dJj
+uYk
+uYk
+uYk
+uYk
+dJj
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+ewi
+ewi
+ewi
+hET
+hTt
+oQD
+hTt
+hTt
+dDo
+iCe
+dDo
+hTt
+hTt
+oQD
+hTt
+hTt
+xXJ
+xXJ
+tpv
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+gQx
+coj
+aPr
+aof
+twn
+twn
+vnI
+yju
+xJr
+bZD
+ukC
+ukC
+hTt
+dQk
+wTO
+qHn
+dQk
+wTO
+qHn
+dQk
+dQk
+kyb
+kyb
+cZA
+pLB
+pLB
+eWH
+pLB
+pLB
+ssG
+sMI
+sgT
+bxg
+vKE
+kXw
+xqZ
+xqZ
+xqZ
+kXw
+kXw
+kXw
+wDV
+lYr
+wDV
+wDV
+lYr
+acF
+wMs
+gge
+gge
+gge
+gge
+gge
+lYr
+kaL
+lYr
+wDV
+krm
+vpM
+aDx
+aDx
+aDx
+gIc
+gIc
+arQ
+aDx
+lvV
+ezW
+lvV
+lvV
+ezW
+cCd
+lvV
+lvV
+ezW
+vpM
+wqC
+wqC
+bOc
+unj
+lPi
+tDP
+tDP
+bBH
+kQB
+wbd
+wQo
+fMQ
+sTo
+roO
+hQI
+hQI
+vwz
+ssf
+xLU
+qDI
+swj
+swj
+xWg
+vcW
+rMU
+rMU
+rMU
+nqF
+sDU
+uDM
+kPG
+qRR
+qRR
+qRR
+uyH
+uyH
+tWH
+iRM
+dxe
+gge
+gge
+gge
+oxw
+dPB
+dPB
+qob
+dPB
+oxw
+gge
+gge
+gge
+gge
+dMl
+"}
+(182,1,1) = {"
+dMl
+kMx
+ahA
+oFb
+oFb
+igU
+xVm
+dJj
+dJj
+uYk
+uYk
+uYk
+uYk
+uYk
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+ewi
+qcW
+ewi
+hET
+hTt
+oQD
+hTt
+dDo
+kpn
+kpn
+kpn
+dDo
+hTt
+oQD
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+gQx
+coj
+rKs
+yju
+twn
+rwg
+sco
+anu
+dYs
+bZD
+ukC
+ukC
+ukC
+dQk
+dQk
+dQk
+kyb
+kyb
+wTO
+dQk
+dQk
+dQk
+dQk
+cZA
+mHD
+pLB
+cDZ
+pLB
+pLB
+ssG
+bhH
+rRA
+leQ
+jkt
+kXw
+xqZ
+xqZ
+kXw
+kXw
+kXw
+kXw
+wDV
+lYr
+wDV
+wDV
+nBq
+ccm
+ccm
+gge
+gge
+gge
+gge
+gge
+lYr
+lYr
+gRw
+wDV
+nBq
+pSX
+aDx
+ciT
+aDx
+njZ
+aDx
+aUU
+aDx
+lvV
+byM
+lvV
+lvV
+lvV
+byM
+lvV
+eBn
+lvV
+lvV
+wqC
+pEj
+kkq
+ghY
+dQg
+bBL
+aYn
+hdk
+ajP
+qhz
+wno
+rwx
+wqC
+miT
+pBS
+eBx
+eBx
+pBS
+kju
+iMG
+vZW
+vZW
+hzj
+vZW
+vZW
+kju
+coK
+otB
+nOy
+ayi
+bwg
+oTG
+oTG
+oTG
+vbI
+oTG
+qME
+iRM
+gge
+gge
+gge
+gge
+oxw
+dPB
+dPB
+dPB
+dPB
+oxw
+gge
+gge
+gge
+gge
+dMl
+"}
+(183,1,1) = {"
+dMl
+kMx
+ahA
+oFb
+oFb
+cPQ
+xVm
+hET
+qcW
+ewi
+ewi
+qcW
+ewi
+ewi
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+ewi
+ewi
+ewi
+hET
+hTt
+oQD
+dDo
+kpn
+wbv
+kpn
+jmN
+kpn
+dDo
+oQD
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+gQx
+coj
+aPr
+yju
+twn
+twn
+twn
+yju
+eRu
+eqK
+ukC
+sZw
+beH
+urI
+urI
+kyb
+hTt
+hTt
+kyb
+kyb
+dQk
+dQk
+dQk
+cZA
+pLB
+pLB
+pLB
+pLB
+pLB
+ssG
+tuZ
+vzF
+qjh
+kXw
+kXw
+kXw
+xqZ
+xqZ
+kXw
+kXw
+kXw
+wDV
+lYr
+wDV
+pXp
+wDV
+cSI
+ccm
+gge
+gge
+gge
+gge
+gge
+gge
+lYr
+lYr
+lYr
+lYr
+pSX
+dPi
+aDx
+aUU
+geh
+lvV
+oMI
+lvV
+lvV
+siz
+lvV
+lvV
+lvV
+rQY
+byM
+lvV
+lvV
+lvV
+tPi
+xQW
+kkq
+iPf
+dQg
+oRL
+gTL
+hdk
+jHz
+kPF
+wno
+xQW
+hTS
+aVc
+tPi
+jlX
+wHd
+pBS
+dHv
+dAl
+jJk
+jJk
+jFU
+jJk
+jJk
+mhb
+dHv
+ayi
+tbO
+oTG
+lOl
+gPQ
+lOl
+lOl
+lOl
+oTG
+qME
+pQf
+gge
+gge
+gge
+gge
+otZ
+dPB
+dPB
+dPB
+otZ
+oxw
+pQf
+gge
+gge
+gge
+dMl
+"}
+(184,1,1) = {"
+dMl
+kMx
+ahA
+teS
+oFb
+mco
+xVm
+hET
+ewi
+ewi
+ewi
+ewi
+ewi
+qcW
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+hET
+ewi
+ewi
+ewi
+hET
+hTt
+oQD
+dDo
+kpn
+kpn
+qCb
+kpn
+kpn
+kpn
+cpO
+vCY
+xXJ
+xXJ
+xXJ
+xXJ
+vCY
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+fuQ
+xXJ
+xXJ
+hTt
+gQx
+hTt
+coj
+rKs
+yju
+twn
+twn
+twn
+yju
+eCP
+bZD
+ukC
+beH
+beH
+beH
+urI
+dQk
+aCY
+hTt
+hTt
+hTt
+kyb
+kyb
+kyb
+hTt
+hTt
+pLB
+cDZ
+pLB
+pLB
+ssG
+sMI
+pLB
+pLB
+kXw
+kXw
+kXw
+xqZ
+tPa
+xqZ
+kXw
+kXw
+jKK
+gtP
+wDV
+pXp
+wDV
+lYr
+lYr
+ccm
+gge
+gge
+gge
+gge
+gge
+ccm
+lYr
+cfY
+lYr
+pSX
+sur
+sur
+sur
+ubp
+ezW
+lvV
+lvV
+lvV
+lvV
+lvV
+lvV
+lvV
+cua
+lvV
+byM
+lvV
+lvV
+tPi
+xQW
+xwL
+iPf
+dQg
+rCB
+hVV
+hdk
+wmW
+gtC
+oaO
+byT
+xQW
+aVc
+rRU
+bNn
+rXT
+vfS
+dHv
+hhg
+nxj
+luA
+hpd
+luA
+hhg
+nxj
+dHv
+opw
+iZm
+fhU
+oqn
+oqn
+oqn
+oqn
+uRH
+oTG
+oiq
+gge
+gge
+gge
+gge
+gge
+otZ
+otZ
+eij
+lnH
+otZ
+gge
+iRM
+gge
+gge
+gge
+dMl
+"}
+(185,1,1) = {"
+dMl
+kMx
+ahA
+oFb
+cPQ
+sPZ
+xVm
+hET
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+ewi
+ewi
+ewi
+ewi
+ewi
+qcW
+hET
+hTt
+oQD
+dDo
+kpn
+kpn
+wbv
+kpn
+kpn
+dDo
+wxD
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+tpv
+hTt
+gQx
+hTt
+coj
+aPr
+yju
+vnI
+twn
+twn
+mmj
+aPr
+bZD
+ukC
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kwM
+xqZ
+tPa
+kXw
+xqZ
+kXw
+kXw
+wDV
+wDV
+pXp
+pXp
+wDV
+lYr
+lYr
+lYr
+ccm
+gge
+gge
+gge
+lYr
+wDV
+wDV
+wDV
+lYr
+vpM
+aHH
+aHH
+aHH
+vpM
+vpM
+nNO
+lvV
+lvV
+ezW
+lvV
+ezW
+lvV
+vyT
+ezW
+lvV
+ezW
+lvV
+wqC
+pEj
+kkq
+nwn
+dQg
+wRA
+cwp
+hdk
+jHz
+kQj
+pAh
+xQW
+aVc
+cGE
+qrw
+bNn
+kzs
+lvL
+kEk
+ric
+ric
+ric
+nXy
+vpF
+knw
+vpF
+nRA
+bNn
+kzs
+bRY
+kzs
+kzs
+kzs
+kzs
+jHu
+oTG
+oiq
+gge
+gge
+gge
+gge
+gge
+iRM
+otZ
+otZ
+otZ
+otZ
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(186,1,1) = {"
+dMl
+kMx
+ahA
+xVm
+tpC
+xVm
+xVm
+ewi
+ewi
+ewi
+qcW
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+ewi
+qcW
+ewi
+ewi
+qcW
+ewi
+ewi
+hTt
+hTt
+oQD
+gaA
+dDo
+kpn
+iCe
+kpn
+dDo
+luk
+wxD
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+gQx
+hTt
+hTt
+pJF
+eCP
+yju
+twn
+twn
+twn
+yju
+rKs
+bZD
+ukC
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+xqZ
+xqZ
+kXw
+kXw
+kXw
+kXw
+wDV
+wDV
+wDV
+wDV
+wDV
+lYr
+fFv
+lYr
+lYr
+gge
+lYr
+lYr
+wDV
+wDV
+jiq
+wDV
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+vpM
+nrT
+byM
+lvV
+byM
+lvV
+lvV
+eBn
+lvV
+lvV
+wrO
+wrO
+vpM
+wqC
+wqC
+qaw
+uhf
+lLh
+tDP
+tDP
+xXp
+tDP
+iaE
+cpd
+bOR
+gTo
+pBS
+pBS
+bNn
+kzs
+kzs
+kzs
+kzs
+kzs
+kzs
+kzs
+kzs
+mDe
+kzs
+kzs
+bNn
+kzs
+dcq
+bRY
+kzs
+kzs
+kzs
+xFP
+oTG
+abW
+otZ
+jkg
+gge
+gge
+gge
+fNL
+pQf
+dsX
+riz
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(187,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+wgH
+tmw
+wbS
+ewi
+qcW
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+oQD
+gaA
+gaA
+dDo
+kpn
+dDo
+luk
+luk
+wDe
+xXJ
+tpv
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+hxM
+hTt
+gQx
+hTt
+joB
+joB
+rte
+wpT
+lcA
+lcA
+lcA
+wpT
+rte
+joB
+gAc
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+xqZ
+xqZ
+kXw
+kXw
+kXw
+kXw
+wDV
+lYr
+wDV
+wDV
+lYr
+lYr
+fYn
+fYn
+lYr
+ccm
+lYr
+lYr
+wDV
+fIn
+wDV
+wDV
+ccm
+lYr
+lYr
+lYr
+cfY
+lYr
+vpM
+uIX
+eBn
+wrO
+lvV
+lvV
+lvV
+lvV
+lvV
+kzB
+wrO
+vpM
+vpM
+lYr
+pDx
+pmg
+xQW
+kkq
+qCc
+qCc
+tYF
+gGT
+jQY
+pAh
+cXT
+oXw
+pne
+jlX
+kgd
+bRY
+kzs
+kzs
+kzs
+bRY
+kzs
+uIj
+kzs
+bRY
+kzs
+kzs
+bNn
+kzs
+kzs
+nhy
+kzs
+kRn
+rcV
+wbk
+oTG
+dts
+sFv
+iRM
+pQf
+eSJ
+oxw
+oxw
+wtF
+fNL
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(188,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+wgH
+tmw
+wbS
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+qcW
+ewi
+qcW
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+oQD
+wxD
+wxD
+wxD
+jOC
+wxD
+wxD
+wDe
+wDe
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+gQx
+hTt
+bsY
+fSg
+aqk
+snx
+twc
+twc
+twc
+gqu
+sBZ
+hcg
+fyp
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+xqZ
+xqZ
+fMZ
+kXw
+kXw
+kXw
+wDV
+lYr
+lYr
+lYr
+wDV
+nBq
+wDV
+wDV
+lYr
+lYr
+lYr
+lYr
+wDV
+wDV
+jKK
+cfY
+ylC
+ccm
+lYr
+fFC
+lYr
+cfY
+lvV
+ezW
+byM
+wrO
+lvV
+lvV
+lvV
+lvV
+wrO
+wrO
+vpM
+vpM
+tov
+ccm
+pDx
+cXT
+xQW
+kkq
+heg
+qCc
+hdk
+jQY
+vSq
+pAh
+xQW
+wTG
+pne
+jbf
+hfJ
+hfJ
+hfJ
+wuT
+ykR
+cMa
+cMa
+cMa
+cMa
+cMa
+ykR
+kzs
+bNn
+gsi
+ykw
+rcV
+kzs
+fbR
+rcV
+jHu
+oTG
+rSV
+otZ
+iRM
+eSJ
+pQf
+otZ
+lnH
+oxw
+oxw
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(189,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+wgH
+pgL
+wbS
+sRp
+ewi
+ewi
+ewi
+ewi
+iaX
+ewi
+ewi
+ewi
+ewi
+iaX
+qcW
+xmK
+ewi
+ewi
+iaX
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+vCY
+xXJ
+tpv
+xXJ
+xXJ
+vCY
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+tpv
+gPI
+vCY
+dVg
+hTt
+gQx
+hTt
+qyx
+atv
+rWM
+eFV
+eFV
+eFV
+eFV
+eFV
+rWM
+pdA
+aAq
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+xqZ
+kXw
+kXw
+kXw
+kXw
+oay
+jKK
+lYr
+lYr
+lYr
+wDV
+aZe
+pXp
+wDV
+kaL
+lYr
+lma
+acF
+lYr
+kaL
+lYr
+ylC
+ylC
+gge
+lYr
+lYr
+lYr
+lYr
+geh
+geh
+vpM
+vpM
+lvV
+lvV
+ezW
+lvV
+vpM
+vpM
+vpM
+pSX
+ccm
+lYr
+pDx
+xQW
+xQW
+vzV
+cuV
+uhf
+keg
+grH
+grH
+ptv
+cGE
+cGE
+pne
+lOl
+lOl
+lOl
+nun
+bNn
+ykR
+kzs
+ykR
+kzs
+ykR
+kzs
+ykR
+kzs
+bNn
+yjS
+fqI
+rcV
+kzs
+css
+swU
+wbk
+oTG
+abW
+otZ
+oxw
+eSJ
+pQf
+otZ
+otZ
+eij
+otZ
+gge
+gge
+pQf
+iRM
+pQf
+gge
+gge
+dMl
+"}
+(190,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+aXE
+tmw
+bNU
+bNU
+bNU
+ewi
+ewi
+iaX
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+hTt
+hTt
+ewi
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+hAO
+aoi
+kLr
+fTO
+gQx
+qyx
+qyx
+atv
+rcE
+eFV
+owb
+bJb
+eFV
+eFV
+rcE
+atv
+qyx
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+kXw
+kXw
+kXw
+wDV
+wDV
+lYr
+lYr
+cSI
+wDV
+wDV
+jiq
+wDV
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+cfY
+lYr
+gge
+gge
+gge
+lYr
+lYr
+lrn
+lYr
+lYr
+cfY
+aHH
+byM
+ubp
+lvV
+ubp
+vpM
+aDx
+aDx
+pSX
+tov
+lYr
+wqC
+pDx
+pDx
+pDx
+wqC
+xQW
+sZr
+aVc
+pBS
+pne
+pne
+pne
+pBS
+lOl
+qyd
+qyd
+pSr
+bNn
+ykR
+kzs
+ykR
+kzs
+ykR
+kzs
+ykR
+kzs
+bNn
+rmg
+hRm
+kzs
+oBC
+xcc
+qCv
+wbk
+oTG
+abW
+hGQ
+jcQ
+pQf
+iRM
+iRM
+otZ
+hYq
+otZ
+iRM
+pQf
+fNL
+pQf
+iRM
+iRM
+gge
+dMl
+"}
+(191,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+wgH
+tmw
+bNU
+bNU
+bNU
+bNU
+qcW
+ewi
+ewi
+qcW
+ewi
+ewi
+ewi
+ewi
+ekc
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+ewi
+ewi
+ewi
+xXJ
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+oii
+rWM
+eFV
+wUV
+joB
+qyx
+atv
+atv
+rWM
+eFV
+eFV
+iiA
+eFV
+owb
+rWM
+atv
+tqA
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+fUy
+oay
+kXw
+kXw
+wDV
+lYr
+lYr
+lYr
+lYr
+lYr
+wDV
+wDV
+nBq
+lYr
+lYr
+ccm
+ylC
+ccm
+lYr
+lYr
+gge
+gge
+gge
+gge
+gge
+lYr
+lYr
+lYr
+cSI
+lYr
+aHH
+sur
+ciT
+aDx
+aDx
+aDx
+dgF
+aDx
+pSX
+lYr
+lYr
+lYr
+wDV
+wDV
+wDV
+wqC
+sNd
+jLr
+kqn
+pBS
+lOl
+lOl
+lOl
+vnX
+lOl
+qyd
+qyd
+lOl
+bNn
+ykR
+kzs
+ykR
+kzs
+ykR
+kzs
+ykR
+kzs
+bNn
+kzs
+kzs
+kzs
+bcv
+kzs
+mfT
+jHu
+oTG
+qME
+rQH
+pQf
+eSJ
+pQf
+iRM
+otZ
+otZ
+otZ
+iRM
+pQf
+fNL
+gge
+iRM
+gge
+gge
+dMl
+"}
+(192,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+asf
+kfB
+bai
+oCS
+hNI
+bNU
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+hTt
+ewi
+ewi
+ewi
+qcW
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+tpv
+xXJ
+xXJ
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+xXJ
+tpv
+xXJ
+hxM
+iAn
+rWM
+qtq
+rIm
+vzu
+joB
+eFV
+rWM
+rWM
+eFV
+nlC
+cTI
+nnd
+atv
+rYf
+cOQ
+tqA
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+oay
+kXw
+kXw
+kXw
+wDV
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
+ylC
+ccm
+ylC
+ccm
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+lYr
+lYr
+lYr
+lYr
+aHH
+sur
+aUU
+aDx
+twQ
+hnX
+ukn
+hnX
+twQ
+lYr
+lYr
+lYr
+wDV
+krm
+wDV
+pSX
+aDx
+oDm
+tCg
+kTE
+lOl
+lOl
+lOl
+lOl
+pIa
+bLd
+eZM
+lOl
+sVB
+ykR
+kzs
+pnS
+kzs
+ykR
+kzs
+sFN
+kzs
+bNn
+kzs
+kzs
+kzs
+uqG
+uui
+fkG
+tKI
+oTG
+qME
+xDm
+ctE
+gge
+gge
+pQf
+iRM
+iRM
+iRM
+iRM
+pQf
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(193,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+aXE
+wgH
+uiE
+hNf
+dVl
+bNU
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+hTt
+hTt
+ewi
+ewi
+iaX
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+iaX
+xXJ
+xXJ
+xXJ
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vCY
+xXJ
+xXJ
+xXJ
+xXJ
+oii
+iiA
+owb
+wUV
+eFV
+taJ
+rWM
+rWM
+bJb
+iiA
+iAn
+sPe
+aVG
+qyx
+tqA
+iWp
+rWM
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+kXw
+kXw
+kXw
+wDV
+lYr
+lYr
+lYr
+lYr
+lYr
+gge
+ccm
+ccm
+ccm
+ccm
+lYr
+lYr
+lYr
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+sKK
+wDV
+wDV
+twQ
+oSb
+oSb
+oSb
+twQ
+xsZ
+xsZ
+xsZ
+twQ
+oSb
+oSb
+oSb
+twQ
+wDV
+wDV
+pSX
+aDx
+oDm
+uQU
+kTE
+lKG
+ric
+ric
+ric
+ric
+ric
+ric
+ric
+tbg
+kzs
+bRY
+kzs
+kzs
+kzs
+bRY
+kzs
+kzs
+ric
+ric
+ric
+ric
+ric
+ric
+ric
+uke
+oTG
+oiq
+oxw
+gge
+gge
+gge
+gge
+fNL
+fNL
+ehH
+fAi
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(194,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+dgA
+wgH
+bNU
+qFl
+sUI
+bNU
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+ewi
+ewi
+ewi
+ekc
+ewi
+qcW
+ewi
+hTt
+ewi
+ewi
+vCY
+xXJ
+xXJ
+vCY
+xXJ
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+iAn
+qyn
+rWM
+rIm
+dwB
+joB
+rWM
+eFV
+owb
+eFV
+fOV
+twc
+blE
+atv
+vKF
+iWp
+iWp
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+kXw
+kXw
+kXw
+wDV
+lYr
+cfY
+tov
+cfY
+gge
+gge
+gge
+sKK
+sKK
+sKK
+wDV
+fFv
+ccm
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+sKK
+pjl
+wDV
+oSb
+xsZ
+dMj
+jDk
+jDk
+jDk
+iFM
+jDk
+sJV
+jDk
+dDW
+oOI
+oSb
+lYr
+lYr
+vpM
+aDx
+oDm
+uQU
+kTE
+bNn
+ivu
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+pGQ
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+wme
+ivu
+wbk
+hqa
+wYe
+otZ
+pQf
+gge
+gge
+gge
+pQf
+fNL
+dxe
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(195,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+dgA
+mTR
+bNU
+liE
+cis
+bNU
+bNU
+ewi
+qcW
+ewi
+ewi
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+hTt
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+xXJ
+tpv
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+hxM
+oii
+rWM
+qtq
+qQe
+joB
+bsY
+owb
+eFV
+eFV
+eFV
+rWM
+rWM
+rWM
+eFV
+dTG
+atv
+tqA
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+kXw
+wDV
+wDV
+wDV
+kaL
+tov
+gge
+lYr
+gge
+gge
+gge
+wDV
+wkd
+jJp
+sKK
+ccm
+ylC
+ccm
+lYr
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+wDV
+wDV
+wDV
+oSb
+xsZ
+cIb
+kKi
+kKi
+vyk
+uJz
+jqe
+bkK
+kKi
+hlK
+xsZ
+oSb
+lYr
+lYr
+pSX
+aDx
+kTj
+uQU
+kTE
+bNn
+mFE
+ofE
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+fcS
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+sNu
+xnj
+vmD
+wbk
+hqa
+bmv
+otZ
+jkg
+gge
+gge
+pQf
+iRM
+pQf
+fNL
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(196,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+iKH
+wgH
+bNU
+pzf
+bBm
+naG
+bNU
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+hTt
+ewi
+ewi
+ewi
+ewi
+ewi
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vCY
+xXJ
+vCY
+tpv
+xXJ
+xXJ
+xXJ
+xXJ
+hxM
+xXJ
+xXJ
+aqk
+dnD
+dnD
+dnD
+gQx
+bsY
+bsY
+eFV
+rcE
+rWM
+atv
+atv
+rWM
+qyn
+rcE
+vhK
+qyx
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+kXw
+odW
+lYr
+lYr
+lYr
+gge
+gge
+gge
+gge
+gge
+ccm
+wDV
+xPp
+aZe
+jKK
+wDV
+lYr
+lYr
+fYn
+qMI
+gge
+gge
+gge
+gge
+lYr
+wDV
+wDV
+wDV
+wDV
+oSb
+sYv
+cIb
+lES
+kKi
+flO
+uJz
+sjS
+kKi
+reR
+hlK
+sYv
+oSb
+lYr
+lYr
+pSX
+aDx
+oDm
+tCg
+kTE
+bNn
+mFE
+mZF
+coi
+hZY
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+hZY
+coi
+une
+vmD
+wbk
+hqa
+wiy
+gge
+iRM
+pQf
+pQf
+iRM
+otZ
+otZ
+oxw
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(197,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+dgA
+wgH
+bNU
+hjO
+aIy
+rcm
+bNU
+kAx
+lyi
+kAx
+irb
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+kAx
+kAx
+hET
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xXJ
+xXJ
+vCY
+xXJ
+xXJ
+xXJ
+xXJ
+tpv
+xXJ
+xXJ
+xXJ
+vCY
+xXJ
+ghs
+gQx
+hTt
+bsY
+rWM
+rWM
+rWM
+atv
+atv
+rWM
+rWM
+atv
+atv
+dZt
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+fbU
+wDV
+lYr
+lYr
+gRw
+gge
+gge
+gge
+gge
+gge
+lYr
+wDV
+wDV
+jiq
+pXp
+jKK
+lYr
+cfY
+lYr
+ccm
+ccm
+cfY
+ccm
+lYr
+lYr
+wDV
+cox
+vxU
+twQ
+twQ
+xsZ
+pxU
+mBC
+mBC
+apO
+nut
+mBC
+mBC
+mBC
+igA
+wka
+twQ
+twQ
+pSX
+vpM
+aDx
+oDm
+ejn
+kTE
+bNn
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+gge
+gge
+dsX
+pQf
+otZ
+otZ
+sad
+otZ
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(198,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+dgA
+wgH
+bNU
+vyx
+bBm
+fEW
+bNU
+iaX
+ewi
+ewi
+iaX
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+hET
+iaX
+ewi
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+hTt
+xXJ
+xXJ
+xXJ
+vCY
+xXJ
+fuQ
+xXJ
+xXJ
+xXJ
+hxM
+xXJ
+xXJ
+xXJ
+hTt
+gQx
+hTt
+bsY
+rWM
+avy
+qyn
+rWM
+wdQ
+eFV
+eFV
+rWM
+atv
+aAq
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+kXw
+tmr
+tmr
+tmr
+tmr
+vEW
+vEW
+vEW
+gge
+gge
+gge
+gge
+vEW
+tmr
+hJr
+qPI
+mwW
+szz
+fOd
+rUd
+gLa
+jrI
+rUd
+jrI
+rUd
+rUd
+rUd
+sjE
+rgc
+mkX
+xsZ
+mWU
+oGf
+cDe
+cDe
+cDe
+cDe
+cDe
+cDe
+cDe
+poM
+xsZ
+xsZ
+hnX
+aDx
+aDx
+aDx
+oDm
+ejn
+kTE
+apI
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+gge
+gge
+pQf
+pQf
+otZ
+eij
+otZ
+eoR
+xDm
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(199,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+ktl
+wgH
+bNU
+sPn
+gOQ
+kXM
+bNU
+ewi
+ewi
+ewi
+ewi
+hET
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+qcW
+ewi
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+wmm
+wmm
+wmm
+hTt
+gaA
+gaA
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+gaA
+hTt
+gQx
+hTt
+bsY
+lmd
+xqm
+twc
+twc
+twc
+twc
+twc
+twc
+oIc
+aAq
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+tmr
+tmr
+tmr
+tmr
+tmr
+tmr
+tmr
+mwW
+gge
+gge
+gge
+gge
+gge
+tmr
+tmr
+tmr
+tmr
+vEW
+gjO
+rUd
+pTw
+pTw
+rzp
+aBz
+tig
+edc
+pGD
+pGD
+iET
+asc
+hUE
+wcR
+qWR
+aBo
+xBx
+gzS
+vJU
+oJB
+sNP
+kKi
+iqq
+aiv
+hUE
+asc
+vsQ
+sfg
+clh
+nvx
+cqT
+kTE
+nsp
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+gge
+gge
+pQf
+pQf
+otZ
+otZ
+otZ
+iRM
+ehH
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(200,1,1) = {"
+dMl
+kMx
+kMx
+wbS
+kfB
+wgH
+bNU
+wvf
+pIJ
+bNU
+bNU
+ewi
+ewi
+ewi
+qcW
+hET
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+ewi
+ewi
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+tpv
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+tpv
+xXJ
+xXJ
+hTt
+hTt
+gQx
+hTt
+hTt
+bsY
+ahO
+eFV
+eFV
+eFV
+eFV
+owb
+nYN
+joB
+mJe
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+kXw
+tmr
+cGC
+oRB
+oRB
+bfu
+bfu
+oRB
+tmr
+mwW
+gge
+gge
+gge
+gge
+gge
+gge
+vEW
+uxi
+vEW
+aXf
+pTw
+jrI
+eeF
+jrI
+rUd
+nPp
+iGq
+awe
+sjE
+rgc
+mkX
+xsZ
+xsZ
+jjs
+iXS
+iXS
+iXS
+egc
+hLd
+hLd
+hLd
+llN
+xsZ
+xsZ
+hnX
+aDx
+aDx
+aDx
+ciT
+jDy
+hqa
+bNn
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+bvK
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+gge
+pQf
+iRM
+pQf
+pQf
+iRM
+rQH
+ehH
+dsX
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(201,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+jEy
+xAV
+bNU
+bNU
+bNU
+bNU
+ewi
+iaX
+ewi
+ewi
+ewi
+hET
+hTt
+wmm
+wmm
+hTt
+hET
+ewi
+ewi
+hET
+ewi
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+oQD
+wjA
+wmm
+wmm
+wmm
+hTt
+xXJ
+vCY
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+vCY
+gaA
+hTt
+gQx
+hTt
+joB
+bsY
+iiA
+eFV
+owb
+iiA
+eFV
+bJb
+eFV
+bsY
+joB
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+mke
+tmr
+tmr
+oRB
+hMH
+lJN
+nHJ
+oRB
+hJr
+tmr
+tmr
+vEW
+gge
+gge
+gge
+vEW
+vEW
+vEW
+hnG
+aXf
+jrI
+jrI
+ohS
+fOd
+kFy
+sdm
+rUd
+rUd
+sfL
+vMK
+twQ
+twQ
+jHk
+dMj
+jDk
+jDk
+jDk
+tfy
+jDk
+jDk
+jDk
+xXZ
+lys
+twQ
+twQ
+pSX
+pSX
+vpM
+pSX
+jDy
+hqa
+bNn
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+sFv
+iRM
+gge
+gge
+gge
+gge
+gge
+iRM
+pQf
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(202,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+cRA
+urX
+bfr
+qYk
+hTt
+ewi
+iaX
+qcW
+ewi
+ewi
+hET
+hET
+hTt
+hTt
+hTt
+hTt
+hET
+ewi
+ewi
+ewi
+kkg
+rRT
+rRT
+rRT
+rRT
+rRT
+rRT
+hTt
+wmm
+wjA
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+xly
+xly
+xly
+xly
+xly
+sxB
+gQx
+hTt
+hTt
+bsY
+iWp
+iWp
+eFV
+eFV
+qyx
+iiA
+eFV
+iiA
+iWp
+joB
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+tmr
+gge
+tmr
+oRB
+wol
+tgB
+hbz
+tHc
+hJr
+igo
+tmr
+vEW
+mke
+xuF
+mwW
+tmr
+vEW
+tmr
+tmr
+rUd
+kEl
+cbW
+ohS
+igi
+fOd
+fOd
+jhe
+rUd
+rUd
+rUd
+rUd
+oSb
+xsZ
+cIb
+lES
+pKQ
+sdj
+ryp
+sIp
+kOv
+mzH
+hlK
+xsZ
+oSb
+fOd
+fOd
+cbW
+rUd
+rUd
+fpj
+hqa
+bNn
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+otZ
+gge
+gge
+gge
+gge
+gge
+gge
+pQf
+iRM
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(203,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+pUb
+nSR
+ePp
+qYk
+hlL
+ewi
+ewi
+ewi
+hET
+hET
+hET
+hTt
+hTt
+hTt
+hTt
+hTt
+ewi
+ewi
+qcW
+ewi
+kkg
+hET
+ewi
+ewi
+ewi
+iaX
+rRT
+hTt
+wmm
+wmm
+wjA
+wmm
+hTt
+wmm
+wmm
+wmm
+wmm
+gQx
+hTt
+xXJ
+xXJ
+xXJ
+xXJ
+gaA
+gaA
+hTt
+bsY
+bsY
+hby
+iWp
+bJb
+qyx
+qyx
+eFV
+eFV
+rWM
+tqA
+qyx
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+gge
+gge
+mke
+oRB
+uMw
+dfd
+oqC
+oRB
+kJY
+hJr
+mwW
+mke
+xuF
+iel
+hJr
+mwW
+szz
+tmr
+aII
+rUd
+kEl
+gge
+gge
+gge
+owK
+fOd
+xuX
+fOd
+rUd
+rUd
+rUd
+oSb
+xsZ
+cIb
+kKi
+lES
+dlr
+ryp
+crc
+aly
+nRd
+hlK
+xsZ
+oSb
+jhe
+fOd
+fOd
+rUd
+fBt
+fpj
+hqa
+bNn
+mFE
+mZF
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+une
+vmD
+wbk
+hqa
+wiy
+hGQ
+pQf
+gge
+gge
+gge
+gge
+gge
+pQf
+iRM
+eSJ
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(204,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+xkk
+gtO
+vnB
+qYk
+ewi
+qcW
+ewi
+hET
+hET
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+hTt
+qcW
+ewi
+ewi
+hET
+kkg
+hET
+ewi
+qcW
+ewi
+xXJ
+rRT
+rRT
+hTt
+hTt
+oQD
+hTt
+hTt
+wmm
+wmm
+wmm
+lpY
+hTt
+gaA
+xXJ
+tpv
+xXJ
+xXJ
+tpv
+gaA
+hTt
+joB
+qyx
+atv
+rWM
+frf
+eFV
+xHT
+owb
+frf
+rWM
+atv
+atv
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+gge
+gge
+gge
+tTD
+wkI
+emU
+bwx
+oRB
+hJr
+cFG
+tmr
+mke
+wFr
+mke
+tmr
+tmr
+jyK
+tmr
+tmr
+jrI
+gge
+gge
+gge
+gge
+gge
+gge
+fOd
+fOd
+rUd
+fBt
+rUd
+oSb
+oOI
+pxU
+mBC
+mBC
+mBC
+rkg
+mBC
+qhc
+mBC
+igA
+xsZ
+oSb
+fOd
+fOd
+fOd
+rUd
+rUd
+fpj
+hqa
+bNn
+mFE
+mZF
+coi
+hZY
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+coi
+hZY
+coi
+une
+vmD
+wbk
+hqa
+wiy
+iRM
+pQf
+eSJ
+gge
+gge
+gge
+gge
+gge
+vNt
+iRM
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(205,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+sPp
+bVT
+sDX
+lCy
+ewi
+ewi
+ewi
+hET
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+hTt
+ewi
+ewi
+ewi
+ewi
+kkg
+hET
+ewi
+ewi
+xXJ
+xXJ
+xXJ
+rRT
+hTt
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+hTt
+gQx
+hTt
+gaA
+gaA
+xXJ
+xXJ
+xXJ
+xXJ
+gaA
+hTt
+bsY
+qyx
+tmx
+rWM
+jtS
+jtS
+wKM
+gDC
+jtS
+eFV
+rWM
+rWM
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+gge
+gge
+gge
+tTD
+lLU
+csQ
+jib
+oRB
+xuF
+sRg
+xuF
+xuF
+mke
+mke
+gge
+oLw
+jgG
+oLw
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+kEl
+fOd
+rUd
+rUd
+rUd
+twQ
+mkX
+oSb
+oSb
+twQ
+xsZ
+eJI
+xsZ
+twQ
+oSb
+oSb
+oSb
+ttl
+kEl
+kEl
+kEl
+kEl
+fOd
+fpj
+hqa
+bNn
+mFE
+miP
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+wsY
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qLS
+qsy
+vmD
+wbk
+hqa
+wiy
+dsX
+eSJ
+iRM
+rQH
+gge
+gge
+gge
+gge
+gge
+dsX
+pQf
+gge
+gge
+gge
+gge
+dMl
+"}
+(206,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+wdi
+nrd
+oDp
+jEy
+iaX
+ewi
+ewi
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+wmm
+wmm
+hTt
+ewi
+ewi
+ewi
+ewi
+kkg
+tIu
+ewi
+ewi
+ewi
+xXJ
+tpv
+rRT
+rRT
+hTt
+hTt
+wjA
+wmm
+wmm
+wmm
+gQx
+hTt
+gaA
+vCY
+exh
+xXJ
+xXJ
+vCY
+xXJ
+xXJ
+dom
+bsY
+atv
+atv
+njg
+jtS
+yfb
+qyx
+yfb
+jtS
+eFV
+eFV
+eFV
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+hou
+jgG
+gge
+gge
+tTD
+kLu
+qFs
+qsz
+qdW
+ctX
+jie
+qdW
+qdW
+gge
+gge
+gge
+jgG
+oLw
+oLw
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+kEl
+fOd
+fOd
+fOd
+fOd
+fOd
+fOd
+fOd
+twQ
+hnX
+fyW
+hnX
+twQ
+fOd
+fOd
+fOd
+kEl
+fOd
+gge
+gge
+kEl
+fOd
+fpj
+hqa
+bNn
+ivu
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+cim
+oHj
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+rSh
+ivu
+wbk
+hqa
+wiy
+pQf
+eSJ
+iRM
+pQf
+pQf
+gge
+gge
+gge
+gge
+gge
+rQH
+iRM
+gge
+gge
+gge
+dMl
+"}
+(207,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+uIf
+eRZ
+bOC
+qYk
+ewi
+ewi
+iaX
+hTt
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+ewi
+hET
+ewi
+iaX
+ewi
+kkg
+kAx
+ewi
+ewi
+ewi
+xXJ
+xXJ
+xXJ
+rRT
+rRT
+hTt
+wjA
+wmm
+wmm
+wmm
+gQx
+hTt
+gaA
+gaA
+gaA
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+dom
+buZ
+rWM
+qyn
+rWM
+aSA
+iWp
+urw
+kvH
+rWM
+eFV
+bJb
+owb
+jtS
+joB
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+kmg
+kXw
+kXw
+kXw
+kXw
+kXw
+kXw
+kXw
+kXw
+kXw
+kmg
+qVG
+oLw
+vsJ
+gge
+jgG
+gge
+gge
+gge
+jgG
+jgG
+sXL
+qdW
+bzN
+sOP
+tMU
+qdW
+gge
+gge
+gge
+oLw
+vEW
+jgG
+oLw
+gge
+gge
+gge
+gge
+kEl
+fOd
+gge
+gge
+gge
+kEl
+fOd
+kEl
+gge
+gge
+fOd
+fOd
+fOd
+fOd
+gGQ
+fOd
+fOd
+fOd
+fOd
+fOd
+kEl
+gge
+gge
+gge
+gge
+fpl
+fpj
+hqa
+ucq
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+xYT
+hfJ
+omV
+vNj
+kBs
+vNj
+vNj
+ngu
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+hfJ
+nsT
+hqa
+wiy
+gge
+gge
+pQf
+pQf
+pQf
+pQf
+gge
+gge
+gge
+gge
+iRM
+iRM
+gge
+gge
+gge
+dMl
+"}
+(208,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+yje
+xGG
+gUe
+qYk
+qcW
+ewi
+qcW
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hET
+ewi
+qcW
+ewi
+ewi
+sRp
+kkg
+kAx
+ewi
+ewi
+xXJ
+xXJ
+tpv
+xXJ
+xXJ
+rRT
+rRT
+vbU
+rRT
+rRT
+wmm
+gQx
+hTt
+gaA
+tUn
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+dom
+gZc
+etp
+eFV
+iiA
+rWM
+tqA
+tqA
+atv
+atv
+wdQ
+eFV
+eFV
+qyC
+joB
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wMs
+kXw
+kXw
+kXw
+fMZ
+kXw
+kXw
+kXw
+kXw
+kXw
+kmg
+kmg
+gge
+jgG
+oLw
+gge
+gge
+gge
+gge
+gge
+oLw
+vEW
+qdW
+lnI
+lYM
+ozv
+yke
+khL
+gge
+gge
+gge
+vEW
+vEW
+vEW
+oLw
+gge
+gge
+kEl
+fOd
+fOd
+kEl
+gge
+gge
+gge
+gge
+ohS
+jhI
+kEl
+gge
+gge
+fOd
+gge
+kEl
+nlS
+kEl
+gge
+gge
+gge
+fOd
+kEl
+kEl
+gge
+gge
+gge
+gge
+fpj
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+ukV
+ahB
+rLV
+kld
+hfJ
+bMz
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+hqa
+wiy
+gge
+gge
+pQf
+pQf
+pQf
+iRM
+pQf
+gge
+gge
+pQf
+pQf
+iRM
+gge
+gge
+gge
+dMl
+"}
+(209,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+gtM
+oDp
+goP
+qYk
+ewi
+hET
+ewi
+hTt
+hTt
+hTt
+hTt
+hTt
+qcW
+ewi
+ewi
+ewi
+ewi
+ewi
+hET
+ewi
+uzr
+kAx
+ewi
+ewi
+mGj
+vCY
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+wDe
+vCY
+rRT
+hTt
+hTt
+sxB
+gaA
+gaA
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+dom
+gZc
+cUn
+eFV
+rWM
+atv
+tqA
+qyx
+qyx
+atv
+rWM
+iiA
+eFV
+hDY
+joB
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+kmg
+kXw
+kXw
+kXw
+kXw
+kXw
+kmg
+kmg
+kmg
+kmg
+gge
+gge
+jgG
+jgG
+gge
+gge
+qdW
+sXL
+sXL
+sXL
+qdW
+qdW
+ocY
+lzx
+mDt
+oOp
+sXL
+gge
+gge
+jgG
+vEW
+vEW
+tmr
+spi
+rUd
+kEl
+jhI
+kEl
+fOd
+gge
+gge
+gge
+gge
+gge
+cxn
+kEl
+fOd
+kEl
+gge
+gge
+gge
+jhI
+seQ
+jhI
+gge
+gge
+kEl
+vYt
+eQf
+vrX
+gge
+gge
+gge
+gge
+fpj
+cTR
+cTR
+cTR
+cTR
+cTR
+cTR
+cTR
+cTR
+cTR
+rgw
+hqa
+hqa
+hqa
+oTG
+tUF
+cZb
+oTG
+gge
+gge
+qyy
+xvf
+xvf
+xvf
+xvf
+xvf
+xvf
+xvf
+xvf
+gge
+gge
+gge
+dsX
+iRM
+iRM
+rQH
+iRM
+iRM
+pQf
+dsX
+gge
+gge
+gge
+gge
+dMl
+"}
+(210,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+rpr
+woy
+bPT
+qYk
+ewi
+iaX
+ewi
+ewi
+hTt
+hTt
+hTt
+ewi
+ewi
+iaX
+ewi
+ewi
+ewi
+ewi
+ewi
+iaX
+kkg
+hET
+ewi
+qcW
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+xXJ
+wDe
+tpv
+xXJ
+vCY
+xXJ
+hTt
+oaq
+xXJ
+exh
+xXJ
+xXJ
+xXJ
+tpv
+xXJ
+xXJ
+xXJ
+rWM
+wdQ
+qyn
+rWM
+tqA
+qyx
+qyx
+tLc
+atv
+rWM
+eFV
+eFV
+sGt
+joB
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+gge
+kXw
+kmg
+kmg
+kmg
+kmg
+tRe
+kmg
+hSi
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+qdW
+wKT
+iLz
+gso
+qgR
+pvU
+ocY
+rgj
+mDt
+oOp
+qdW
+khL
+bgh
+sXL
+jgG
+mQV
+mwW
+hJr
+ohE
+rUd
+kEl
+gge
+gge
+gge
+gge
+gge
+gge
+fOd
+cbW
+uQl
+fOd
+kEl
+psi
+cbW
+kEl
+kEl
+nlS
+kEl
+kEl
+uVg
+ceo
+yky
+rgc
+tVg
+cbW
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+fpj
+cTR
+cTR
+fpj
+xEQ
+tDu
+gIT
+xEQ
+qyy
+xvf
+wiy
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+pQf
+pQf
+iRM
+iRM
+iRM
+iRM
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(211,1,1) = {"
+dMl
+kMx
+kMx
+qYk
+dnK
+dmu
+jxq
+qYk
+nvN
+qcW
+iaX
+ewi
+qcW
+hlL
+ewi
+ewi
+iaX
+ewi
+ewi
+qcW
+ewi
+hET
+hTt
+ewi
+kkg
+hET
+ewi
+ewi
+ewi
+xXJ
+xXJ
+xXJ
+tpv
+xXJ
+wDe
+xXJ
+xXJ
+tpv
+vCY
+exh
+oaq
+xXJ
+exh
+xXJ
+xXJ
+xXJ
+vCY
+xXJ
+xXJ
+xXJ
+eFV
+rWM
+wdQ
+rWM
+tqA
+tqA
+tqA
+atv
+rWM
+eFV
+bJb
+eFV
+kYY
+joB
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+gge
+kmg
+kmg
+kmg
+kmg
+kmg
+tRe
+kmg
+kmg
+gge
+gge
+qdW
+qdW
+qdW
+sXL
+sXL
+qdW
+avP
+bep
+fNo
+qsB
+sXL
+uwF
+nbG
+nYh
+eQp
+vcL
+ukc
+ily
+kuL
+jgG
+szz
+tmr
+hJr
+aPA
+aXf
+fOd
+gge
+gge
+gge
+gge
+gge
+gge
+fey
+cbW
+hrH
+kEl
+kEl
+psi
+cbW
+vYt
+bjB
+iUV
+nUt
+cbW
+vyP
+fRs
+pTw
+pTw
+hgP
+vrX
+fOd
+fOd
+gge
+gge
+vYt
+nUt
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+cTR
+aXY
+eVG
+lKu
+aXY
+xvf
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+pQf
+pQf
+pQf
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(212,1,1) = {"
+dMl
+kMx
+dMl
+qYk
+qYk
+qYk
+qYk
+qYk
+hlL
+ewi
+ewi
+iaX
+ewi
+ewi
+qcW
+hET
+hET
+ewi
+ewi
+ewi
+ewi
+hET
+hTt
+hTt
+kkg
+hET
+ewi
+ewi
+ewi
+tpv
+xXJ
+xXJ
+xXJ
+xXJ
+wDe
+xXJ
+xXJ
+xXJ
+xXJ
+exh
+oaq
+tpv
+exh
+xXJ
+xXJ
+xXJ
+xXJ
+gaA
+xXJ
+dom
+iwO
+rWM
+eFV
+eFV
+rWM
+iWp
+wdQ
+rWM
+eFV
+owb
+iiA
+eFV
+suE
+joB
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+gge
+kmg
+kmg
+tRe
+tRe
+tRe
+tRe
+kmg
+kmg
+kmg
+gge
+qdW
+hdq
+eTg
+nEU
+uOU
+qdW
+kEx
+vRk
+kFf
+uln
+atC
+nlq
+wsZ
+xzH
+tnJ
+tir
+ozv
+oOp
+qdW
+jgG
+vEW
+mwW
+igo
+rgc
+rUd
+fOd
+jhI
+gge
+iLJ
+gge
+gge
+gge
+fOd
+cbW
+uQl
+kEl
+xcY
+eta
+fOd
+vyP
+pFH
+kUX
+xxi
+cbW
+pGe
+gVI
+kjh
+gvf
+kmK
+hgP
+bjB
+bjB
+bjB
+bjB
+yky
+hgP
+bjB
+nUt
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+vYt
+tJt
+jpS
+wtg
+nUt
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(213,1,1) = {"
+dMl
+kMx
+dMl
+uTK
+uTK
+biI
+biI
+uTK
+uTK
+ewi
+ewi
+lBe
+ewi
+ewi
+ewi
+hET
+hET
+qcW
+ewi
+ewi
+qcW
+hET
+hTt
+hTt
+vbU
+hET
+ewi
+ewi
+ewi
+dSg
+xXJ
+xXJ
+xXJ
+rRT
+vbU
+rRT
+gaA
+gaA
+gaA
+gaA
+oaq
+gaA
+gaA
+gaA
+gaA
+gaA
+gaA
+gaA
+gaA
+joB
+joB
+joB
+jYT
+joB
+joB
+coj
+bRh
+joB
+joB
+bsY
+qyu
+bsY
+joB
+joB
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+grK
+gge
+gge
+tRe
+tRe
+jhB
+opc
+kmg
+tRe
+tRe
+tRe
+gge
+sXL
+qBW
+lqT
+rgi
+dsQ
+qdW
+dRN
+vRk
+qUD
+sXL
+sXL
+xKx
+cmL
+eoa
+imz
+tmi
+osO
+enO
+khL
+gge
+jgG
+vEW
+tmr
+rUd
+rUd
+uFK
+jhI
+gge
+fOd
+rUd
+ohE
+pYp
+pYp
+kEl
+jhI
+jhI
+gge
+gge
+gge
+fya
+kmK
+gVI
+kDM
+fOd
+fya
+snX
+iyg
+gge
+uBl
+snX
+snX
+snX
+snX
+snX
+snX
+kmK
+mlz
+hgP
+gge
+gge
+gge
+gge
+gge
+sJm
+bjB
+bjB
+yky
+nGy
+snX
+rVW
+hgP
+vbO
+wxM
+fvM
+aLb
+aLb
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(214,1,1) = {"
+dMl
+kMx
+dMl
+uTK
+fds
+rXK
+hXR
+rXK
+rXK
+nYf
+hTt
+qcW
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+ewi
+hET
+hET
+hTt
+oQD
+hTt
+hET
+qcW
+ewi
+xXJ
+xXJ
+xXJ
+xXJ
+rRT
+rRT
+oQD
+hTt
+hTt
+hTt
+hTt
+sxB
+gaA
+gaA
+hTt
+hTt
+hTt
+hTt
+hET
+hTt
+hTt
+joB
+icW
+rWM
+owb
+iFV
+joB
+jXg
+opE
+jXg
+bsY
+fKa
+qJV
+esE
+weT
+joB
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+gge
+gge
+kmg
+jhB
+tRe
+tRe
+oUl
+tRe
+tRe
+iNP
+gge
+sXL
+pze
+jTp
+hza
+kGB
+qdW
+rft
+ebf
+bDR
+qdW
+sXL
+sXL
+tCs
+qdW
+qdW
+sXL
+sXL
+qdW
+qdW
+qdW
+qdW
+oLw
+oLw
+fOd
+fOd
+jhI
+psi
+rUd
+rUd
+rUd
+ncs
+rgc
+pYp
+jhI
+fOd
+gge
+gge
+gge
+gge
+kEl
+fya
+snX
+inb
+kEl
+kEl
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+fya
+aKp
+kmK
+hgP
+bjB
+bjB
+bjB
+bjB
+klw
+nGy
+snX
+snX
+inb
+gge
+fya
+snX
+vEV
+hqu
+lEu
+vbO
+fvM
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(215,1,1) = {"
+dMl
+kMx
+dMl
+pZb
+rXK
+avR
+vGx
+avR
+rXK
+hXR
+hTt
+iaX
+ewi
+ewi
+qcW
+ewi
+ewi
+hlL
+hET
+hET
+hET
+hTt
+hTt
+oQD
+hTt
+hET
+ewi
+ewi
+ewi
+xXJ
+xXJ
+rRT
+rRT
+hTt
+hTt
+oQD
+hTt
+hTt
+hTt
+gQx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+joB
+hOm
+gbT
+qyn
+avC
+joB
+jXg
+hSe
+jXg
+bsY
+lVU
+qan
+ply
+teC
+joB
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+gge
+gge
+gge
+tRe
+tRe
+tRe
+tRe
+kmg
+tRe
+gge
+qdW
+qdW
+qdW
+qdW
+hba
+lJp
+qdW
+qdW
+qdW
+qdW
+qdW
+dFU
+jGO
+jox
+fzD
+dyZ
+sXL
+bpk
+iIU
+dfg
+nTT
+qdW
+bDK
+oLw
+fey
+jhI
+psi
+fOd
+jzn
+pjo
+gVI
+rgc
+rUd
+gjO
+fOd
+jhI
+gge
+gge
+gge
+gge
+gge
+kEl
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+vyP
+gVI
+rgc
+rgc
+nGy
+snX
+snX
+inb
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+lko
+vEV
+vEV
+swX
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(216,1,1) = {"
+dMl
+kMx
+dMl
+cuE
+yid
+avR
+vGx
+avR
+hXR
+rXK
+hTt
+hTt
+hTt
+hET
+hET
+hET
+hET
+hET
+hET
+hTt
+hTt
+hTt
+hTt
+oQD
+hTt
+hET
+ewi
+qcW
+ewi
+ewi
+ewi
+rRT
+rRT
+hTt
+hTt
+wjA
+wmm
+wmm
+wmm
+gQx
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+vEw
+rWM
+rdY
+avC
+joB
+vga
+hXa
+jXg
+bsY
+weT
+teC
+teC
+qyx
+qyx
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+gge
+gge
+gge
+gge
+oUl
+kmg
+kmg
+tRe
+tRe
+tRe
+gge
+qdW
+dFt
+wNN
+qdW
+iUX
+vLP
+vLP
+wIa
+vLP
+quW
+vLP
+rrx
+orJ
+nGO
+azY
+wRi
+bsa
+mLn
+lwi
+lwi
+eqL
+qdW
+gge
+gge
+gge
+gge
+kEl
+qzd
+rUd
+rUd
+rUd
+rUd
+jrI
+kEl
+kEl
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+fya
+snX
+snX
+snX
+inb
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(217,1,1) = {"
+dMl
+kMx
+dMl
+lqp
+fcg
+avR
+aWa
+avR
+rXK
+rXK
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+oQD
+hET
+ewi
+ewi
+ewi
+iaX
+rRT
+rRT
+hTt
+hTt
+hTt
+wjA
+wmm
+wmm
+wmm
+gQx
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+dmA
+rWM
+hTt
+hTt
+hTt
+uIo
+cKt
+bsY
+atv
+ofw
+qyx
+qyx
+qyx
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+gge
+gge
+gge
+eQo
+oUl
+gge
+tRe
+oUl
+gge
+gge
+qdW
+tXV
+vrU
+nls
+gPm
+tOY
+lYi
+lYi
+lYi
+lYi
+lYi
+hhz
+azY
+qRw
+wcw
+fMb
+vdn
+eYN
+eZC
+vSs
+eDc
+qdW
+gge
+gge
+gge
+jjz
+gge
+gge
+gge
+gge
+iLJ
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+kEl
+fOd
+kEl
+bLv
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(218,1,1) = {"
+dMl
+kMx
+dMl
+pZb
+mEY
+rXK
+hXR
+rXK
+rXK
+biI
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+vbU
+vbU
+vbU
+vbU
+vbU
+vbU
+vbU
+wjA
+wjA
+oQD
+wmm
+wmm
+wmm
+wmm
+gQx
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+joB
+joB
+hTt
+hTt
+hTt
+joB
+weT
+joB
+bsY
+atv
+qyx
+qyx
+qyx
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+gge
+gge
+gge
+gge
+grK
+gge
+gge
+gge
+grK
+gge
+gge
+qdW
+gRf
+fAc
+sXL
+foD
+ciz
+qqf
+ikx
+kXc
+tdu
+xfx
+hqG
+pWs
+hZJ
+wsk
+ktY
+qdW
+qiF
+tRR
+iDi
+lwi
+qdW
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(219,1,1) = {"
+dMl
+kMx
+dMl
+kTt
+sAh
+fux
+rXK
+xpu
+oxd
+uTK
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+gQx
+wmm
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+hTt
+joB
+joB
+joB
+joB
+bsY
+qyx
+qyx
+hTt
+hTt
+hTt
+hTt
+wmm
+wmm
+wmm
+wmm
+hTt
+hTt
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+qdW
+qdW
+qdW
+sXL
+sXL
+qdW
+qdW
+qdW
+qdW
+qdW
+sXL
+sXL
+sXL
+qdW
+qdW
+qdW
+qdW
+qdW
+qdW
+qdW
+qdW
+qdW
+gge
+gge
+gge
+gge
+jjz
+gge
+gge
+gge
+gge
+gge
+jjz
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+gge
+dMl
+"}
+(220,1,1) = {"
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+dMl
+"}

--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,8 +13,11 @@ Format:
 endmap
 
 map lv624
-        default
 	minplayers 1
+endmap
+
+map lv624small
+    default
 endmap
 
 map bigred_v2


### PR DESCRIPTION

## About The Pull Request
Adds lv624small, a copy of lv624 without the huge marine base taking up the bottom half of the map and making the minimap too big for the screen.  Also some minor mapping fixes to lv624.
## Why It's Good For The Game
Should be more fun to play on.
## Changelog
:cl:
add: New map: LV624Small, a copy of LV624 without the huge marine base taking up the bottom half of the map.
/:cl: