### PR TITLE
Make neurotoxin stun instead of killing

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin.dm
@@ -468,7 +468,8 @@
 			power = (15*effect_str)
 			L.reagent_pain_modifier -= PAIN_REDUCTION_VERY_HEAVY
 			L.jitter(8) //Shows that things are *really* bad
-
+	L.adjustStaminaLoss(power)
+	/*
 	//Apply stamina damage, then apply any 'excess' stamina damage beyond our maximum as tox and oxy damage
 	var/stamina_loss_limit = L.maxHealth * 2
 	var/applied_damage = clamp(power, 0, (stamina_loss_limit - L.getStaminaLoss()))
@@ -478,7 +479,7 @@
 		L.adjustToxLoss(damage_overflow * 0.5)
 		L.adjustOxyLoss(damage_overflow * 0.5)
 		L.Losebreath(2) //So the oxy loss actually means something.
-
+	*/
 	L.set_timed_status_effect(2 SECONDS, /datum/status_effect/speech/stutter, only_if_higher = TRUE)
 
 	if(current_cycle < 21) //Additional effects at higher cycles


### PR DESCRIPTION

## About The Pull Request
Make neurotoxin stun instead of killing.
## Why It's Good For The Game
Gives xenos more of a chance to get caps.  Makes it less redundant with acid spit.
## Changelog
:cl:
balance: Neurotoxin now stuns people instead of killing them.
/:cl:
