### PR TITLE
Makes some xeno slash effects work with disarms

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -68,6 +68,7 @@
 					X.visible_message("<span class='danger'>[X] slams [src] to the ground!</span>",
 					"<span class='danger'>We slam [src] to the ground!</span>", null, 5)
 					Paralyze(10 SECONDS)
+		SEND_SIGNAL(X, COMSIG_XENOMORPH_DISARM_HUMAN, src, damage_to_deal)
 	else if(!ishuman(src))
 		if(randn <= 40)
 			if(!IsParalyzed())

--- a/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defiler/abilities_defiler.dm
@@ -462,6 +462,7 @@
 	var/mob/living/carbon/xenomorph/X = owner
 
 	RegisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(reagent_slash))
+	RegisterSignal(X, COMSIG_XENOMORPH_DISARM_HUMAN, PROC_REF(reagent_slash))
 
 	reagent_slash_count = DEFILER_REAGENT_SLASH_COUNT //Set the number of slashes
 	reagent_slash_duration_timer_id = addtimer(CALLBACK(src, PROC_REF(reagent_slash_deactivate), X), DEFILER_REAGENT_SLASH_DURATION, TIMER_STOPPABLE) //Initiate the timer and set the timer ID for reference
@@ -477,6 +478,7 @@
 ///Called when the duration of reagent slash lapses
 /datum/action/ability/xeno_action/reagent_slash/proc/reagent_slash_deactivate(mob/living/carbon/xenomorph/X)
 	UnregisterSignal(X, COMSIG_XENOMORPH_ATTACK_LIVING) //unregister the signals; party's over
+	UnregisterSignal(X, COMSIG_XENOMORPH_DISARM_HUMAN)
 
 	reagent_slash_count = 0 //Zero out vars
 	deltimer(reagent_slash_duration_timer_id) //delete the timer so we don't have mismatch issues, and so we don't potentially try to deactivate the ability twice

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -63,6 +63,7 @@
 	remaining_slashes = SENTINEL_TOXIC_SLASH_COUNT
 	ability_duration = addtimer(CALLBACK(src, PROC_REF(toxic_slash_deactivate), xeno_owner), SENTINEL_TOXIC_SLASH_DURATION, TIMER_STOPPABLE) //Initiate the timer and set the timer ID for reference
 	RegisterSignal(xeno_owner, COMSIG_XENOMORPH_ATTACK_LIVING, PROC_REF(toxic_slash))
+	RegisterSignal(xeno_owner, COMSIG_XENOMORPH_DISARM_HUAMN, PROC_REF(toxic_slash))
 	xeno_owner.balloon_alert(xeno_owner, "Toxic Slash active")
 	xeno_owner.playsound_local(xeno_owner, 'sound/voice/alien/drool2.ogg', 25)
 	action_icon_state = "neuroclaws_on"
@@ -92,6 +93,7 @@
 ///Called when Toxic Slash expires.
 /datum/action/ability/xeno_action/toxic_slash/proc/toxic_slash_deactivate(mob/living/carbon/xenomorph/xeno_owner)
 	UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_ATTACK_LIVING)
+	UnregisterSignal(xeno_owner, COMSIG_XENOMORPH_DISARM_HUAMN)
 	remaining_slashes = 0
 	deltimer(ability_duration) // Delete the timer so we don't have mismatch issues, and so we don't potentially try to deactivate the ability twice
 	ability_duration = null


### PR DESCRIPTION

## About The Pull Request
Makes Defiler's Reagent Slash, Sentinel's Toxic Slash, and Hunter's Sneak Attack work on disarms too.  (The last was already mostly coded in, just the signal wasn't being sent.)
## Why It's Good For The Game
Gives xenos better nonlethal options to promote captures.
## Changelog
:cl:
add: Defiler's Reagent Slash, Sentinel's Toxic Slash, and Hunter's Sneak Attack now work on disarms too.
/:cl:
