### PR TITLE
SH-23 Slug Fix

### DIFF
--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -189,6 +189,8 @@
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
+
+
 /datum/ammo/bullet/shotgun/barrikada_slug
 	name = "heavy metal slug"
 	handful_icon_state = "heavy_shotgun_barrikada"
@@ -200,7 +202,7 @@
 	penetration = 50
 	sundering = 15
 
-/datum/ammo/bullet/shotgun/barrikada/on_hit_mob(mob/target_mob, obj/projectile/proj)
+/datum/ammo/bullet/shotgun/barrikada_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 2 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
 
 /datum/ammo/bullet/shotgun/heavy_spread


### PR DESCRIPTION
## About The Pull Request

Fixes six gauge "barrikada" slugs to make sure they actually apply the intended knockback, stagger and stun effects. The code read as "/datum/ammo/bullet/shotgun/barrikada/on_hit_mob(mob/target_mob, obj/projectile/proj)" as opposed to the expected "/datum/ammo/bullet/shotgun/barrikada_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)" and as such didn't apply the expected stagger effect. My experiences in game effect this.

Unfortunately I could not fully test this locally however, as spawning any xenos in a local game causes a code error and valhalla is not enabled. If this fix works, it should be apparent and testable in the live game.

This fix _also_ effects the ML-101 shotgun due to them sharing the same ammo type.

## Why It's Good For The Game

Restores intended effects.

## Changelog

:cl:
fix: Fixed 6 gauge slugs not applying stagger, knockback and weakness.
/:cl:
