### PR TITLE
SH-23 Overall Buffs

### DIFF
--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -183,7 +183,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 50
+	damage = 55
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -196,9 +196,9 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	shell_speed = 4
 	max_range = 15
-	damage = 125
+	damage = 130
 	penetration = 50
-	sundering = 15
+	sundering = 20
 
 /datum/ammo/bullet/shotgun/barrikada/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 2 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
@@ -210,7 +210,7 @@
 	accuracy_var_high = 9
 	accurate_range = 3
 	max_range = 10
-	damage = 50
+	damage = 60
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/heavy_flechette
@@ -225,15 +225,15 @@
 	accuracy_var_low = 8
 	accuracy_var_high = 8
 	max_range = 15
-	damage = 60
+	damage = 65
 	damage_falloff = 0.5
-	penetration = 20
-	sundering = 10
+	penetration = 25
+	sundering = 15
 
 /datum/ammo/bullet/shotgun/flechette/heavy_flechette_spread
 	name = "additional flechette"
-	damage = 45
-	sundering = 7
+	damage = 50
+	sundering = 10
 
 /datum/ammo/bullet/shotgun/sx16_flechette
 	name = "shotgun flechette shell"


### PR DESCRIPTION
## About The Pull Request

Initial testing before addition of the SH-23 did point to it being potentially weaker than expected due to the lack of attachments and very slow rechamber speed, more akin to a sniper without the advantages of aimmode as opposed to a traditional shotgun.  Think martini henry. This seems to have been correct given my current experiences ingame.

As such I have buffed every ammunition type slightly, with emphasis on the flechettes and buckshot ammotypes. This is due to the fact that flechettes and buckshot travel very slowly across the screen, lacking the raw speed found from the SH-35 with barrel charger or extended barrel. Flechettes in particular are slow enough that I have witnessed people stepping out of the way of the bullets before they land with ease.

Slugs: 5 more damage and sunder, AP unchanged.

Buckshot: 5 more damage per projectile (25 more total) AP and sunder unchanged. My rationale for this, is that it's incredibly difficult to hit a target with every single projectile unless you're directly adjacent to them, and this round has no armour penetration or sunder.

Flechettes: 5 more damage, sunder and AP for main projectile, 5 more damage and 3 more sunder for secondary projectiles (15 more damage and 11 more sunder total)

It should be of note that this also effects the ML-101 as they use the same ammotype. However I have yet to see the ICC's ML-101 in game and so this shouldn't be too major of a concern.

## Why It's Good For The Game

Gives more reason for the SH-23 to be used rather than being simply a slower SH-35, without compromising it's lack of attachments, punishing slowdown and very slow rechamber speed. Gives more reason to use flechettes, currently slugs feel like the only viable option given the glacial speed of flechettes.

From my experience given that the SH-23 has 2.75 seconds between shots, no attachment support, five round tube, massively increased slowdown and necessity to be two hand wielded before firing, despite it's impressive damage stats on paper it ends up feeling like a direct downgrade from the SH-35.

## Changelog

:cl:
balance: buffs six gauge ammunition across the board.
/:cl:
