### PR TITLE
locator disabling

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -1348,6 +1348,9 @@
 	ADD_TRAIT(victim, TRAIT_STASIS, TRAIT_STASIS)
 	victim.forceMove(owner_xeno)
 	owner_xeno.eaten_mob = victim
+	var/obj/item/radio/headset/mainship/headset = victim.wear_ear
+	if(istype(headset))
+		headset.disable_locator(40 SECONDS)
 	add_cooldown()
 
 /datum/action/ability/activable/xeno/devour/ai_should_use(atom/target)

--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -48,6 +48,9 @@
 			X.visible_message(null, "<span class='info'>We keep holding [src] down.</span>", null)
 			apply_damage(damage_to_deal, STAMINA, BODY_ZONE_CHEST, MELEE)
 			sound = 'sound/weapons/thudswoosh.ogg'
+			var/obj/item/radio/headset/mainship/headset = wear_ear
+			if(istype(headset))
+				headset.disable_locator(40 SECONDS)
 		else
 			X.do_attack_animation(src, ATTACK_EFFECT_DISARM2)
 			if(pulling)
@@ -69,6 +72,9 @@
 					X.visible_message("<span class='danger'>[X] slams [src] to the ground!</span>",
 					"<span class='danger'>We slam [src] to the ground!</span>", null, 5)
 					Paralyze(10 SECONDS)
+					var/obj/item/radio/headset/mainship/headset = wear_ear
+					if(istype(headset))
+						headset.disable_locator(40 SECONDS)
 		SEND_SIGNAL(X, COMSIG_XENOMORPH_DISARM_HUMAN, src, damage_to_deal)
 	else if(!ishuman(src))
 		if(randn <= 40)

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -547,8 +547,9 @@
 			else
 				visible_message("<span class='warning'>[src] latches onto [H]'s pelvis!</span>")
 			H.equip_to_slot(src, SLOT_WEAR_SUIT)
-			H.dropItemToGround(H.wear_ear)
-			H.wear_ear = null
+			var/obj/item/radio/headset/mainship/headset = H.wear_ear
+			if(istype(headset))
+				headset.disable_locator(40 SECONDS)
 			return TRUE
 
 		if(!H.has_limb(HEAD))
@@ -587,8 +588,9 @@
 
 				if(ishuman(hugged))
 					var/mob/living/carbon/human/H = hugged
-					H.dropItemToGround(H.wear_ear)
-					H.wear_ear = null
+					var/obj/item/radio/headset/mainship/headset = H.wear_ear
+					if(istype(headset))
+						headset.disable_locator(40 SECONDS)
 	if(blocked)
 		hugged.visible_message(span_danger("[src] smashes against [hugged]'s [blocked]!"))
 		return FALSE


### PR DESCRIPTION

## About The Pull Request
Stops facehuggers removing headsets.  Instead, facehuggers, devouring, and xeno disarm knockdowns all disable a headset's location marker for 40 seconds.
## Why It's Good For The Game
Facehuggers removing headsets made it too easy for headsets and bodies to get lost.  This avoids that while still helping xenos get away with kidnappings.
## Changelog
:cl:
del: Facehuggers no longer remove headsets
add: Facehuggers, devouring, and xeno disarm knockdowns all disable a headset's location marker for 40 seconds.
/:cl:
