### PR TITLE
Survivor minimap changes

### DIFF
--- a/code/controllers/subsystem/minimaps.dm
+++ b/code/controllers/subsystem/minimaps.dm
@@ -651,8 +651,8 @@ SUBSYSTEM_DEF(minimaps)
 
 
 /datum/action/minimap/survivor
-	minimap_flags = MINIMAP_FLAG_MARINE
-	marker_flags = MINIMAP_FLAG_SURVIVOR
+	minimap_flags = MINIMAP_FLAG_SURVIVOR
+	marker_flags = MINIMAP_FLAG_XENO
 
 /datum/action/minimap/researcher
 	minimap_flags = MINIMAP_FLAG_MARINE|MINIMAP_FLAG_EXCAVATION_ZONE|MINIMAP_FLAG_SURVIVOR

--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -11,8 +11,8 @@
 
 /datum/job/survivor/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
 	. = ..()
-	SSminimaps.add_marker(C, MINIMAP_FLAG_SURVIVOR, image('icons/UI_icons/map_blips.dmi', null, "survivor"))
 	var/datum/action/minimap/survivor/mini = new
+	SSminimaps.add_marker(C, mini.marker_flags, image('icons/UI_icons/map_blips.dmi', null, "survivor"))
 	mini.give_action(C)
 
 	if(SSmapping.configs[GROUND_MAP].environment_traits[MAP_COLD])


### PR DESCRIPTION

## About The Pull Request
Removes survivors from marine and survivor minimaps, removes marines from survivor minimaps, adds survivors to clf and xeno minimaps.
## Why It's Good For The Game
Makes it less trivial to avoid xenos and gang up as survivor.
## Changelog
:cl:
balance: Removed survivors from marine and survivor minimaps, removed marines from survivor minimaps, added survivors to clf and xeno minimaps.
/:cl:
