### PR TITLE
melee changes/magni buffs

### DIFF
--- a/code/game/objects/items/implants/implant_items.dm
+++ b/code/game/objects/items/implants/implant_items.dm
@@ -67,8 +67,8 @@
 	desc = "A wicked-looking folding blade capable of being concealed within a human's arm."
 	icon_state = "armblade"
 	worn_icon_state = "armblade"
-	force = 50
+	force = 75
 	attack_speed = 8
 	equip_slot_flags = NONE
 	w_class = WEIGHT_CLASS_BULKY //not needed but just in case why not
-	hitsound = 'sound/weapons/slash.ogg'
+	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/weapons/misc.dm
+++ b/code/game/objects/items/weapons/misc.dm
@@ -107,13 +107,13 @@
 				span_userdanger("[user] punches you!"))
 		return ..()
 	if(M == user)
-		user.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE)
+		user.apply_damage(force * setting + (user.skills.getRating(SKILL_UNARMED) * UNARMED_SKILL_DAMAGE_MOD), BRUTE, user.zone_selected, MELEE)
 		to_chat(user, span_userdanger("You punch yourself!"))
 		playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)
 		playsound(loc, 'sound/weapons/genhit2.ogg', 50, TRUE)
 		cell.charge -= powerused
 		return ..()
-	M.apply_damage(force * setting, BRUTE, user.zone_selected, MELEE)
+	M.apply_damage(force * setting + (user.skills.getRating(SKILL_UNARMED) * UNARMED_SKILL_DAMAGE_MOD), BRUTE, user.zone_selected, MELEE)
 	M.visible_message(span_danger("[user]'s powerfist shudders as they punch [M.name], flinging them away!"), \
 		span_userdanger("[user]'s punch flings you backwards!"))
 	playsound(loc, 'sound/weapons/energy_blast.ogg', 50, TRUE)

--- a/code/game/objects/items/weapons/swords.dm
+++ b/code/game/objects/items/weapons/swords.dm
@@ -53,6 +53,8 @@
 
 /datum/action/ability/activable/weapon_skill/sword_lunge/use_ability(atom/A)
 	var/mob/living/carbon/carbon_owner = owner
+	var/dash_distance = round(6 - owner.cached_multiplicative_slowdown)
+	var/dash_speed = ROUND_UP(4 - owner.cached_multiplicative_slowdown)
 
 	RegisterSignal(carbon_owner, COMSIG_MOVABLE_MOVED, PROC_REF(movement_fx))
 	RegisterSignal(carbon_owner, COMSIG_MOVABLE_BUMP, PROC_REF(lunge_impact))
@@ -60,7 +62,7 @@
 
 	carbon_owner.visible_message(span_danger("[carbon_owner] charges towards \the [A]!"))
 	playsound(owner, 'sound/effects/alien/tail_swipe2.ogg', 50, 0, 4)
-	carbon_owner.throw_at(A, 2, 1, carbon_owner)
+	carbon_owner.throw_at(A, dash_distance, dash_speed, carbon_owner)
 	succeed_activate()
 	add_cooldown()
 
@@ -89,7 +91,7 @@
 		obj_victim.knockback(carbon_owner, 1, 2, knockback_force = MOVE_FORCE_VERY_STRONG)
 	else
 		var/mob/living/carbon/human/human_victim = target
-		human_victim.apply_damage(damage, BRUTE, BODY_ZONE_CHEST, MELEE, TRUE, TRUE, TRUE, penetration)
+		human_victim.apply_damage(damage, BRUTE, carbon_owner.zone_selected, MELEE, TRUE, TRUE, TRUE, penetration)
 		human_victim.adjust_stagger(1 SECONDS)
 		playsound(human_victim, "sound/weapons/wristblades_hit.ogg", 25, 0, 5)
 		shake_camera(human_victim, 2, 1)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -48,6 +48,10 @@
 		ADD_TRAIT(human_user, TRAIT_KNIGHT, src)
 		ADD_TRAIT(human_user, TRAIT_SWORD_EXPERT, src)
 		ADD_TRAIT(human_user, TRAIT_AXE_EXPERT, src)
+		human_user.set_skills(human_user.skills.modifyRating(unarmed=1))
+		human_user.set_skills(human_user.skills.modifyRating(melee_weapons=1))
+		human_user.set_skills(human_user.skills.modifyRating(stamina=1))
+
 
 /obj/item/clothing/unequipped(mob/unequipper, slot)
 	if(!(equip_slot_flags & slotdefine2slotbit(slot)))
@@ -63,6 +67,9 @@
 		REMOVE_TRAIT(human_unequipper, TRAIT_KNIGHT, src)
 		REMOVE_TRAIT(human_unequipper, TRAIT_AXE_EXPERT, src)
 		REMOVE_TRAIT(human_unequipper, TRAIT_SWORD_EXPERT, src)
+		human_unequipper.set_skills(human_unequipper.skills.modifyRating(unarmed=-1))
+		human_unequipper.set_skills(human_unequipper.skills.modifyRating(melee_weapons=-1))
+		human_unequipper.set_skills(human_unequipper.skills.modifyRating(stamina=-1))
 	return ..()
 
 /obj/item/clothing/vendor_equip(mob/user)

--- a/code/modules/clothing/modular_armor/modular.dm
+++ b/code/modules/clothing/modular_armor/modular.dm
@@ -251,6 +251,7 @@
 		/obj/item/armor_module/module/ballistic_armor,
 		/obj/item/armor_module/module/chemsystem,
 		/obj/item/armor_module/module/eshield,
+		/obj/item/armor_module/module/knight,
 
 		/obj/item/armor_module/storage/general,
 		/obj/item/armor_module/storage/ammo_mag,


### PR DESCRIPTION
## About The Pull Request

buffs the knight modules
also buffs a few melee weapons that aren't too used right now

## Why It's Good For The Game

variety. magni's kinda lame right now, you give up guns and grenades for 15 armor and some really gimmicky melee skills.

## Changelog
:cl:
- armblade implant moved up to 75 force (it's just machete tier)
- powerfist now scales with unarmed damage
- rownin can now slot magni
- magni now gives a +1 to melee related stats + stam
- sword's dash range and speed now scale off of your actual movespeed. if sprinting with heavy armor, you'll move 3 tiles. if using rownin and sprinting, 4 tiles. if using sandev, sprinting, and rownin, you'll probably hit like 6-7 tiles idk
/:cl:
