### PR TITLE
fix looc chat tab sorting

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.ts
+++ b/tgui/packages/tgui-panel/chat/constants.ts
@@ -89,7 +89,7 @@ export const MESSAGE_TYPES = [
     name: 'OOC',
     description: 'OOC messages, admin announcements and round announcements',
     selector:
-      '.ooc, .colorooc, .looc, .adminooc, .hostooc, .projleadooc, .headcoderooc, .headminooc, .headmentorooc, .trialminooc, .candiminooc, .mentorooc, .maintainerooc, .contributorooc, .otherooc, .ooc_alert_ooc, .ooc_alert_game',
+      '.ooc, .colorooc, .adminooc, .hostooc, .projleadooc, .headcoderooc, .headminooc, .headmentorooc, .trialminooc, .candiminooc, .mentorooc, .maintainerooc, .contributorooc, .otherooc, .ooc_alert_ooc, .ooc_alert_game',
   },
   {
     type: MESSAGE_TYPE_LOOC,


### PR DESCRIPTION

## About The Pull Request
Fix looc messages being sorted into chat tabs with ooc enabled rather than ones with looc enabled.
## Why It's Good For The Game
Makes the looc checkbox actually do something.
## Changelog
:cl:
fix: Fix looc messages being sorted into chat tabs with ooc enabled rather than ones with looc enabled.
/:cl:
