### PR TITLE
Adds end round votes

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -223,6 +223,8 @@ Voting
 */
 /datum/config_entry/flag/allow_vote_restart
 
+/datum/config_entry/flag/allow_vote_endround
+
 /datum/config_entry/flag/allow_vote_mode
 
 /datum/config_entry/flag/allow_vote_groundmap

--- a/config/config.txt
+++ b/config/config.txt
@@ -250,6 +250,7 @@ log_emote
 log_looc
 log_say
 allow_vote_restart
+allow_vote_endround
 allow_vote_groundmap
 allow_vote_shipmap
 allow_vote_mode

--- a/tgui/packages/tgui/interfaces/Vote.jsx
+++ b/tgui/packages/tgui/interfaces/Vote.jsx
@@ -48,6 +48,7 @@ const StartVoteOptions = (props) => {
   const {
     allow_vote_mode,
     allow_vote_restart,
+    allow_vote_endround,
     allow_vote_groundmap,
     allow_vote_shipmap,
     vote_happening,
@@ -79,7 +80,15 @@ const StartVoteOptions = (props) => {
                   disabled={vote_happening || !allow_vote_restart}
                   onClick={() => act('restart')}
                 >
-                  Restart
+                  Restart (immediately)
+                </Button>
+              </Stack.Item>
+              <Stack.Item>
+                <Button
+                  disabled={vote_happening || !allow_vote_endround}
+                  onClick={() => act('endround')}
+                >
+                  End Round and Restart
                 </Button>
               </Stack.Item>
               <Stack.Item>
@@ -104,6 +113,7 @@ const VoteOptions = (props) => {
   const {
     allow_vote_mode,
     allow_vote_restart,
+    allow_vote_endround,
     allow_vote_groundmap,
     allow_vote_shipmap,
     upper_admin,
@@ -149,6 +159,18 @@ const VoteOptions = (props) => {
                     onClick={() => act('toggle_restart')}
                   >
                     Restart vote {allow_vote_restart ? 'Enabled' : 'Disabled'}
+                  </Button.Checkbox>
+                )}
+              </Stack.Item>
+              <Stack.Item>
+                {!!upper_admin && (
+                  <Button.Checkbox
+                    mr={!allow_vote_endround ? 1 : 1.6}
+                    color="red"
+                    checked={!!allow_vote_endround}
+                    onClick={() => act('toggle_endround')}
+                  >
+                    End Round vote {allow_vote_endround ? 'Enabled' : 'Disabled'}
                   </Button.Checkbox>
                 )}
               </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Adds end round votes, which when passed end the round and restart.  Unlike restart votes, they do not skip EORD or mode/map votes.
## Why It's Good For The Game
Comments in restart vote code indicate it's meant for when things are lagging severely so the server needs to be restarted as soon as possible.  But it's also useful to have a way to restart the server by vote when people just want a new mode or map.
## Changelog
:cl:
add: End round votes now exist, like restart votes but they do not skip mode/map votes.
/:cl:
