### PR TITLE
Fixes squad marine quick-equip loadouts

### DIFF
--- a/code/datums/quick_load_beginners.dm
+++ b/code/datums/quick_load_beginners.dm
@@ -7,7 +7,7 @@
 /datum/outfit/quick/beginner
 	name = "Beginner loadout base"
 	desc = "The base loadout for beginners. You shouldn't be able to see this"
-	jobtype = "Squad Marine"
+	jobtype = SQUAD_MARINE
 
 	w_uniform = /obj/item/clothing/under/marine
 	shoes = /obj/item/clothing/shoes/marine/full

--- a/code/datums/quick_load_outfits.dm
+++ b/code/datums/quick_load_outfits.dm
@@ -1136,7 +1136,7 @@
 //Base SOM marine outfit
 /datum/outfit/quick/som/marine
 	name = "SOM Squad Marine"
-	jobtype = "SOM Squad Standard"
+	jobtype = SOM_SQUAD_MARINE
 
 	ears = /obj/item/radio/headset/mainship/som
 	w_uniform = /obj/item/clothing/under/som/webbing

--- a/code/datums/quick_load_robots.dm
+++ b/code/datums/quick_load_robots.dm
@@ -36,7 +36,7 @@
 
 //---- Squad Marine loadouts
 /datum/outfit/quick/beginner_robot/marine
-	jobtype = "Squad Marine"
+	jobtype = SQUAD_MARINE
 
 /datum/outfit/quick/beginner_robot/marine/rifleman
 	name = "Rifleman"

--- a/code/game/objects/machinery/vending/beginner_vendor.dm
+++ b/code/game/objects/machinery/vending/beginner_vendor.dm
@@ -54,10 +54,10 @@ GLOBAL_LIST_INIT(robot_loadouts, init_robot_loadouts())
 /obj/machinery/quick_vendor/beginner //Loadout vendor that shits out basic pre-made loadouts so new players can get something usable
 	icon_state = "loadoutvendor"
 	categories = list(
-		"Squad Marine",
-		"Squad Engineer",
-		"Squad Corpsman",
-		"Squad Smartgunner",
+		SQUAD_MARINE,
+		SQUAD_ENGINEER,
+		SQUAD_CORPSMAN,
+		SQUAD_SMARTGUNNER,
 	)
 	drop_worn_items = TRUE
 


### PR DESCRIPTION

## About The Pull Request
Fixes squad marine quick-equip loadouts being unusable
## Why It's Good For The Game
They're useful and should be usable
## Changelog
:cl:
/:cl:
