### PR TITLE
Disables most corpse spawners

### DIFF
--- a/code/game/objects/effects/landmarks/corpsespawner.dm
+++ b/code/game/objects/effects/landmarks/corpsespawner.dm
@@ -48,6 +48,9 @@
 
 /// Create the mob and delete the corpse spawner
 /obj/effect/landmark/corpsespawner/proc/create_mob()
+	if(death_type != REGULAR_DEATH)
+		qdel(src)
+		return
 	var/mob/living/carbon/human/victim = new(loc)
 	SSmobs.stop_processing(victim)
 	GLOB.round_statistics.total_humans_created[victim.faction]-- //corpses don't count
@@ -81,6 +84,8 @@
 
 
 /obj/effect/landmark/corpsespawner/proc/equip_items_to_mob(mob/living/carbon/human/corpse)
+	if(!corpse)
+		return FALSE
 	if(corpseuniform)
 		corpse.equip_to_slot_or_del(new corpseuniform(corpse), SLOT_W_UNIFORM)
 	if(corpsesuit)


### PR DESCRIPTION

## About The Pull Request
Makes corpses spawners that spawn corpses that are obviously killed by xenos (chestbursted, cocooned or headbitten) instead spawn nothing.
## Why It's Good For The Game
They make xenos seem a lot more genocidal than they actually are in our lore.  And they're not used for much, even though they can be useful in theory most people don't bother collecting them.
## Changelog
:cl:
del: Removed most roundstart corpses.
/:cl:
