### PR TITLE
fixes cross-z-level loocs

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -432,8 +432,10 @@
 			to_chat(M, message)
 	else
 		message = span_looc("[span_prefix("LOOC:")] [mob.name]: [span_message("[msg]")]")
+		var/turf/mobturf = get_turf(mob)
 		for(var/mob/M in GLOB.player_list)
-			if(get_dist(M,mob) <= world.view)
+			var/turf/Mturf = get_turf(M)
+			if(mobturf.z == Mturf.z && get_dist(Mturf,mobturf) <= world.view)
 				to_chat(M, message)
 
 	for(var/client/C AS in GLOB.admins)


### PR DESCRIPTION

## About The Pull Request
Stops people seeing loocs from other z levels
## Why It's Good For The Game
Seeing loocs from unrelated z-levels is weird and confusing.
## Changelog
:cl:
fix: LOOCs are now only visible on the same z-level, instead of being limited by x and y coordinates only.
/:cl: