### PR TITLE
Removes pop requirement from riptide

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -89,7 +89,7 @@ map daedalusprison
 endmap
 
 map riptide
-	minplayers 40
+	minplayers 1
 endmap
 
 map kutjevo


### PR DESCRIPTION

## About The Pull Request
Low pop, not likely to get 30 players so this map will almost never even show up
(Might need to be changed on the hostbox as well, forgot how this works with the config)
## Why It's Good For The Game
The xenos demand a beach episode smh
## Changelog
:cl:
code: decreased minplayers from 40 to 1 on riptide
/:cl:
