### PR TITLE
Xeno Ability Fixes

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -102,6 +102,7 @@
 		/datum/action/ability/activable/xeno/impregnate,
 		/datum/action/ability/xeno_action/watch_xeno,
 		/datum/action/ability/activable/xeno/psydrain,
+		/datum/action/ability/activable/xeno/devour,
 		/datum/action/ability/activable/xeno/cocoon,
 		/datum/action/ability/activable/xeno/plant_weeds,
 		/datum/action/ability/activable/xeno/healing_infusion,

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -5,9 +5,9 @@
 	ability_cost = 100
 	buildable_structures = list(
 		/turf/closed/wall/resin/regenerating/thick,
+		/turf/closed/wall/resin/membrane,
 		/obj/alien/resin/sticky,
 		/obj/structure/mineral_door/resin/thick,
-		/turf/closed/wall/resin/membrane,
 		/obj/structure/bed/nest,
 		/obj/structure/bed/nest/wall,
 		/obj/structure/xeno/lighttower,

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
@@ -74,10 +74,6 @@
 		/datum/action/ability/xeno_action/attach_spiderlings,
 		/datum/action/ability/activable/xeno/cannibalise,
 		/datum/action/ability/activable/xeno/spiderling_mark,
-		/datum/action/ability/xeno_action/pheromones,
-		/datum/action/ability/xeno_action/pheromones/emit_recovery,
-		/datum/action/ability/xeno_action/pheromones/emit_warding,
-		/datum/action/ability/xeno_action/pheromones/emit_frenzy,
 	)
 
 /datum/xeno_caste/widow/on_caste_applied(mob/xenomorph)
@@ -128,8 +124,4 @@
 		/datum/action/ability/activable/xeno/spiderling_mark,
 		/datum/action/ability/xeno_action/sow,
 		/datum/action/ability/activable/xeno/web_hook,
-		/datum/action/ability/xeno_action/pheromones,
-		/datum/action/ability/xeno_action/pheromones/emit_recovery,
-		/datum/action/ability/xeno_action/pheromones/emit_warding,
-		/datum/action/ability/xeno_action/pheromones/emit_frenzy,
 	)


### PR DESCRIPTION
## About The Pull Request
Fixes Primordial Hivelord not being able to devour. 
Fixes Widow Secrete Resin menu having wrong icons.
Fixes Widows having two copies of the button to change pheromones.
## Why It's Good For The Game
Convenience
## Changelog
:cl:
fix: Fixed Primordial Hivelord not being able to devour. 
fix: Fixed Widow Secrete Resin menu having wrong icons.
fix: Fixed Widows having two copies of the button to change pheromones.
/:cl:
