### PR TITLE
Fix NTC field commander spawning in SOM ship

### DIFF
--- a/_maps/map_files/antagmap/antagmap.dmm
+++ b/_maps/map_files/antagmap/antagmap.dmm
@@ -6199,7 +6199,7 @@
 /turf/open/floor/plating,
 /area/antag_ship/som/office/commander/field)
 "HE" = (
-/obj/effect/landmark/start/job/fieldcommander,
+/obj/effect/landmark/start/job/som/fieldcommander,
 /turf/open/floor/carpet/side{
 	dir = 10
 	},


### PR DESCRIPTION

## About The Pull Request
Fix NTC field commander spawning in SOM field commander's room on their ship.
## Why It's Good For The Game
It's a bit awkward when the NTC field commander spawns in the the middle of the opposing side's ship.
## Changelog
:cl:
fix: Fixed NTC field commander spawning in SOM ship
/:cl:
