### PR TITLE
Gives both sides spare IDs

### DIFF
--- a/_maps/map_files/NTC_Nine_Tailed_Fox/NTC_Nine_Tailed_Fox.dmm
+++ b/_maps/map_files/NTC_Nine_Tailed_Fox/NTC_Nine_Tailed_Fox.dmm
@@ -7144,6 +7144,7 @@
 "gwf" = (
 /obj/structure/table/mainship,
 /obj/machinery/recharger,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/mainship/mono,
 /area/mainship/command/cic)
 "gwS" = (

--- a/_maps/map_files/antagmap/antagmap.dmm
+++ b/_maps/map_files/antagmap/antagmap.dmm
@@ -7110,6 +7110,13 @@
 	},
 /turf/open/shuttle/dropship/three,
 /area/shuttle/transport)
+"MG" = (
+/obj/effect/turf_decal/warning_stripes/thin{
+	dir = 4
+	},
+/obj/item/card/id/captains_spare/som,
+/turf/open/floor/mainship/mono,
+/area/antag_ship/som/hangar)
 "MI" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -11235,7 +11242,7 @@ nm
 RK
 RK
 RK
-RK
+MG
 RK
 RK
 RK

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -218,14 +218,24 @@
 	iff_signal = SOM_IFF
 
 /obj/item/card/id/captains_spare
-	name = "captain's spare ID"
-	desc = "The spare ID of the High Lord himself."
+	name = CAPTAIN + "'s spare ID"
+	desc = "The spare ID of the "+CAPTAIN+" himself."
 	icon_state = "gold"
 	worn_icon_state = "gold_id"
 	registered_name = CAPTAIN
 	assignment = CAPTAIN
 	access = ALL_MARINE_ACCESS
 	iff_signal = TGMC_LOYALIST_IFF
+
+/obj/item/card/id/captains_spare/som
+	name = SOM_COMMANDER + "'s spare ID"
+	desc = "The spare ID of the "+SOM_COMMANDER+" himself."
+	icon_state = "gold"
+	worn_icon_state = "gold_id"
+	registered_name = SOM_COMMANDER
+	assignment = SOM_COMMANDER
+	access = ALL_SOM_ACCESS
+	iff_signal = SOM_IFF
 
 /obj/item/card/id/captains_spare/survival
 	name = "identification card"


### PR DESCRIPTION

## About The Pull Request
Maps in a spare NTC commander's ID on the NTC ship and a spare SOM commander's ID on the SOM ship
## Why It's Good For The Game
Lets people operate req and the tadpole without officers available.
## Changelog
:cl:
add: Added a spare NTC commander's ID on the NTC ship and a spare SOM commander's ID on the SOM ship
/:cl:
