### PR TITLE
Adjusts CAS controls to reduce accidents.

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -174,7 +174,8 @@
 /obj/effect/overlay/temp/Initialize(mapload, effect_duration)
 	. = ..()
 	flick(icon_state, src)
-	QDEL_IN(src, effect_duration ? effect_duration : src.effect_duration)
+	if(!(effect_duration < 0))
+		QDEL_IN(src, effect_duration ? effect_duration : src.effect_duration)
 
 /obj/effect/overlay/temp/point
 	name = "arrow"

--- a/code/game/objects/items/explosives/grenades/flares.dm
+++ b/code/game/objects/items/explosives/grenades/flares.dm
@@ -152,7 +152,7 @@
 	. = ..()
 	var/turf/TU = get_turf(src)
 	if(is_ground_level(TU.z))
-		if(!target && active)
+		if((!target || QDELING(target)) && active)
 			target = new(src, null, name, user_squad)
 
 /obj/item/explosive/grenade/flare/cas/turn_off()

--- a/code/modules/condor/cas_shuttle.dm
+++ b/code/modules/condor/cas_shuttle.dm
@@ -248,7 +248,18 @@
 	user.unset_interaction()
 
 ///Handles clicking on a target while in CAS mode
-/obj/docking_port/mobile/marine_dropship/casplane/proc/fire_weapons_at(datum/source, atom/target, turf/location, control, params)
+/obj/docking_port/mobile/marine_dropship/casplane/proc/fire_weapons_at(datum/source, atom/target, params)
+	SIGNAL_HANDLER
+	var/list/modifiers = params2list(params)
+	if	(	(	modifiers["right"] \
+			) \
+			|| \
+			(	(modifiers["left"]) \
+				&& \
+				(modifiers["shift"] || modifiers["alt"]) \
+			) \
+		)
+		return
 	if(state != PLANE_STATE_FLYING || is_mainship_level(z))
 		end_cas_mission(source)
 		return


### PR DESCRIPTION

## About The Pull Request
CAS weapons no longer fire on right-click, shift-left click, or alt-left click.  Middle click and unmodified left-click continue to work. Also fixes cas flares breaking when varedited to last longer.
## Why It's Good For The Game
Reduces accidental discharges when trying to examine things
## Changelog
:cl:
add: CAS weapons no longer fire on right-click, shift-left click, or alt-left click.  Middle click and unmodified left-click continue to work.
/:cl:
