### PR TITLE
fix v-35 loadout, add marine helmet to som

### DIFF
--- a/code/game/objects/machinery/vending/quick_vendor.dm
+++ b/code/game/objects/machinery/vending/quick_vendor.dm
@@ -47,6 +47,7 @@ GLOBAL_LIST_INIT(quick_loadouts, init_quick_loadouts())
 		/datum/outfit/quick/som/marine/shotgunner,
 		/datum/outfit/quick/som/marine/pyro,
 		/datum/outfit/quick/som/marine/breacher,
+		/datum/outfit/quick/som/marine/v35breacher,
 		/datum/outfit/quick/som/marine/breacher_melee,
 		/datum/outfit/quick/som/marine/machine_gunner,
 		/datum/outfit/quick/som/marine/charger,

--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -479,6 +479,7 @@
 			/obj/item/clothing/head/helmet/marine/icc = -1,
 			/obj/item/clothing/head/helmet/marine/icc/guard = -1,
 			/obj/item/clothing/head/helmet/marine/icc/guard/heavy = -1,
+			/obj/item/clothing/head/helmet/marine/stolen = -1,
 		),
 		"Combat Drone" = list(
 			/obj/item/clothing/suit/modular/robot/light = -1,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -209,6 +209,11 @@
 		M = mutable_appearance('icons/mob/modular/modular_helmet_storage.dmi', M.icon_state)
 		standing.overlays += M
 
+/obj/item/clothing/head/helmet/marine/stolen
+	name = "\improper stolen M10 pattern helmet"
+	desc = "A stolen M10 pattern marine helmet, likely from fallen colony-based marines or old battles. It has been painted black & repurposed for use by the Sons of Mars."
+	icon_state = "k_helmet"
+
 /obj/item/clothing/head/helmet/marine/specialist
 	name = "\improper B18 helmet"
 	desc = "The B18 Helmet that goes along with the B18 Defensive Armor. It's heavy, reinforced, and protects more of the face."


### PR DESCRIPTION
what does this do?
adds the v-35 loadout from my previous pr to vendors, one of the maintainers changed it before it was merged but forgot to do that part,
adds the m10 marine helmet to som vendors

why?
the v-35 loadout will function as intended now,
the m10 helmet is there so som can actually use some of the helmet attachments from req such as the cheaper, battery powered night vision goggles that none of their helmets can accomodate 