### PR TITLE
stolen m10x for SOM

### DIFF
--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -484,6 +484,7 @@
 			/obj/item/clothing/head/helmet/marine/icc/guard = -1,
 			/obj/item/clothing/head/helmet/marine/icc/guard/heavy = -1,
 			/obj/item/clothing/head/helmet/marine/stolen = -1,
+			/obj/item/clothing/head/modular/m10x/stolen = -1,
 		),
 		"Combat Drone" = list(
 			/obj/item/clothing/suit/modular/robot/light = -1,

--- a/code/modules/clothing/modular_armor/xenonauten.dm
+++ b/code/modules/clothing/modular_armor/xenonauten.dm
@@ -484,6 +484,10 @@
 		/obj/item/armor_module/armor/visor/marine/xenonaut,
 	)
 
+/obj/item/clothing/head/modular/m10x/stolen
+	name = "\improper Stolen M10X pattern helmet"
+	desc = "A stolen modular M10X pattern marine helmet, adapted for use by the Sons of Mars."
+
 /obj/item/clothing/head/modular/m10x/leader
 	name = "\improper M11X pattern leader helmet"
 	desc = "A slightly fancier helmet for marine leaders. This one has cushioning to project your fragile brain."


### PR DESCRIPTION
pretty much the same as my last pr but this gives the SOM the m10x version of the helmet aswell as the m10 so they can fit all the different armor modules & make use of the dynamic sprites (such as goggles appearing & so on)

the SOM already gets a couple of these in their lockers at roundstart, this way you don't lose out if someone else grabs it as there is a severe lack of decent looking, open faced helmets