### PR TITLE
gives tweezers to medical roles

### DIFF
--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -231,7 +231,7 @@ Your primary goal is to serve the hive, and ultimate goal is to liberate the col
 	. = ..()
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/stick, SLOT_IN_SUIT)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/stick, SLOT_IN_SUIT)
-
+	H.equip_to_slot_or_del(new /obj/item/tweezers, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/defibrillator, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/roller, SLOT_IN_BACKPACK)
 	H.equip_to_slot_or_del(new /obj/item/storage/box/MRE, SLOT_IN_BACKPACK)

--- a/code/datums/jobs/job/icc_squad.dm
+++ b/code/datums/jobs/job/icc_squad.dm
@@ -54,12 +54,22 @@
 
 	id = /obj/item/card/id/dogtag
 	ears = /obj/item/radio/headset/mainship/marine/icc
-	w_uniform = /obj/item/clothing/under/icc
+	w_uniform = /obj/item/clothing/under/icc/medic
+	r_hand = /obj/item/medevac_beacon
 	gloves = /obj/item/clothing/gloves/marine/icc
 	shoes = /obj/item/clothing/shoes/marine/icc/knife
 	back = /obj/item/storage/backpack/lightpack/icc
 	belt = /obj/item/storage/belt/lifesaver/icc/ert
 	glasses = /obj/item/clothing/glasses/hud/health
+
+/datum/outfit/job/icc_squad/medic/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	. = ..()
+	H.equip_to_slot_or_del(new /obj/item/roller, SLOT_IN_ACCESSORY)
+	H.equip_to_slot_or_del(new /obj/item/bodybag/cryobag, SLOT_IN_ACCESSORY)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/oxycodone, SLOT_IN_ACCESSORY)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/advanced/nanoblood, SLOT_IN_ACCESSORY)
+	H.equip_to_slot_or_del(new /obj/item/roller/medevac, SLOT_IN_ACCESSORY)
+	H.equip_to_slot_or_del(new /obj/item/tweezers, SLOT_IN_ACCESSORY)
 
 //VSD Spec
 /datum/job/icc_squad/spec

--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -637,8 +637,8 @@ Make sure that the doctors and nurses are doing their jobs and keeping the SOM h
 
 /datum/outfit/job/som/medical/professor/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.equip_to_slot_or_del(new /obj/item/tweezers_advanced, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/lemoline/doctor, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/tweezers_advanced, SLOT_IN_L_POUCH)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/lemoline/doctor, SLOT_S_STORE)
 
 //Medical Officer
 /datum/job/som/medical/medicalofficer
@@ -697,11 +697,13 @@ You are also an expert when it comes to medication and treatment. If you do not 
 	glasses = /obj/item/clothing/glasses/hud/health
 	mask = /obj/item/clothing/mask/surgical
 	head = /obj/item/clothing/head/surgery/purple
+	r_store = /obj/item/storage/pouch/surgery
+	l_store = /obj/item/storage/pouch/medkit/doctor
 
 /datum/outfit/job/som/medical/medicalofficer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
-	H.equip_to_slot_or_del(new /obj/item/tweezers_advanced, SLOT_IN_BACKPACK)
-	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/lemoline/doctor, SLOT_IN_BACKPACK)
+	H.equip_to_slot_or_del(new /obj/item/tweezers_advanced, SLOT_IN_R_POUCH)
+	H.equip_to_slot_or_del(new /obj/item/reagent_containers/glass/bottle/lemoline/doctor, SLOT_S_STORE)
 
 
 /datum/job/som/civilian

--- a/code/modules/clothing/under/marine_uniform.dm
+++ b/code/modules/clothing/under/marine_uniform.dm
@@ -634,6 +634,9 @@
 /obj/item/clothing/under/icc/webbing
 	starting_attachments = list(/obj/item/armor_module/storage/uniform/brown_vest)
 
+/obj/item/clothing/under/icc/medic
+	starting_attachments = list(/obj/item/armor_module/storage/uniform/white_vest)
+
 /obj/item/clothing/under/sectoid
 	name = "psionic field"
 	desc = "A field of invisible energy, it protects the wearer but prevents any clothing from being worn."


### PR DESCRIPTION
## About The Pull Request

Adds medical tweezers to the CLF medic, ICC medic and shuffles around the lemoline + advanced tweezer spawns for the SOM CMO and MD (SOM MD now gets a surgery pouch and medkit pouch roundstart). ICC medic also gets a white webbing roundstart containing a medevac stretcher, roller bed, stasis bag, nanoblood hypo, oxy hypo and a medevac beacon in-hand.

Please notify me if there are any other medical roles that don't get tweezers.

## Why It's Good For The Game

Medical tweezers are a fairly important item for medic roles to have.

## Changelog

:cl:
add: ICC and CLF medics now spawn with tweezers
add: ICC medics now spawn with a white webbing, medevac and misc medical equipment
add: SOM MDs now spawn with appropriate pouches
/:cl:
