### PR TITLE
floortile type fix

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -12,10 +12,18 @@
 	///The turf type this tile creates
 	var/turf/open/floor/turf_type
 
-/obj/item/stack/tile/Initialize(mapload)
+/obj/item/stack/tile/Initialize(mapload, amount, new_turf_type)
 	. = ..()
 	pixel_x = rand(1, 14)
 	pixel_y = rand(1, 14)
+	if(new_turf_type)
+		set_turf_type(new_turf_type)
+
+/obj/item/stack/tile/proc/set_turf_type(new_turf_type)
+	var/turf/open/floor/floor_type = new_turf_type
+	name = "[initial(floor_type.name)] tile"
+	singular_name = name
+	turf_type = new_turf_type
 
 /obj/item/stack/tile/attack_turf(turf/T, mob/living/user)
 	if(!turf_type)

--- a/code/game/turfs/floor.dm
+++ b/code/game/turfs/floor.dm
@@ -164,7 +164,7 @@
 /turf/open/floor/proc/spawn_tile()
 	if(!has_tile())
 		return null
-	return new floor_tile(src)
+	return new floor_tile(src, 1, type)
 
 //todo: maybe redo this wet/dry stuff
 /turf/open/floor/wet_floor(wet_level = FLOOR_WET_WATER)


### PR DESCRIPTION

## About The Pull Request

Currently in-game when you crowbar a tile and place it back down, you get the default turf type instead of what it used to be.

This fixes/changes it so that when a tile is crowbarred, that its floor type (i.e. what it looks like) is preserved - the way this is implemented, you can mix metal floor tiles of different styles to make more of them (i.e. the same way it functions on CM).

I considered adding a tile painter but am unsure if there's any actual demand for this or need.

## Why It's Good For The Game

it's a fix; lets you keep the look of a room after crowbarring tiles up and putting them back down; lets you change how rooms look

## Changelog
:cl:
fix: crowbarred floor tiles now preserve their look
/:cl:
