### PR TITLE
fixes improper, changes description and name of SOM weapon rack

### DIFF
--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -1,7 +1,7 @@
 /obj/machinery/vending/weapon/som
-	name = "/improper SOC weapon rack"
+	name = "\improper SOM weapon rack"
 	faction = FACTION_SOM
-	desc = "Syndicate Official Contraband weapon rack, here you get your guns."
+	desc = "An automated weapon rack hooked up to a colossal storage of standard-issue weapons."
 	icon_state = "marinearmory"
 	icon_vend = "marinearmory-vend"
 	icon_deny = "marinearmory"

--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -1,5 +1,5 @@
 /obj/machinery/vending/weapon/som
-	name = "\improper SOM weapon rack"
+	name = "\improper SOM automated weapons rack"
 	faction = FACTION_SOM
 	desc = "An automated weapon rack hooked up to a colossal storage of standard-issue weapons."
 	icon_state = "marinearmory"


### PR DESCRIPTION

## About The Pull Request

Changes the /improper to be \improper in the SOM weapon rack - as well as changing its name from "SOC weapon rack" to "SOM automated weapons rack" and changing its description to match the marine weapons rack

## Why It's Good For The Game

fixes formatting, changes name and description to be consistent

## Changelog

:cl:
fix: fixed SOM weapons rack formatting, name and description
/:cl:
