### PR TITLE
food processor fix

### DIFF
--- a/code/modules/food/recipes_processor.dm
+++ b/code/modules/food/recipes_processor.dm
@@ -1,0 +1,23 @@
+/datum/food_processor_process/potato
+	input = /obj/item/reagent_containers/food/snacks/grown/potato
+	output = /obj/item/reagent_containers/food/snacks/rawsticks
+
+/datum/food_processor_process/carrot
+	input = /obj/item/reagent_containers/food/snacks/grown/carrot
+	output = /obj/item/reagent_containers/food/snacks/carrotfries
+
+/datum/food_processor_process/soybeans
+	input = /obj/item/reagent_containers/food/snacks/grown/soybeans
+	output = /obj/item/reagent_containers/food/snacks/soydope
+
+/datum/food_processor_process/wheat
+	input = /obj/item/reagent_containers/food/snacks/grown/wheat
+	output = /obj/item/reagent_containers/food/snacks/flour
+
+/datum/food_processor_process/spaghetti
+	input = /obj/item/reagent_containers/food/snacks/flour
+	output = /obj/item/reagent_containers/food/snacks/pizzapasta/spagetti
+
+/datum/food_processor_process/chocolatebar
+	input = /obj/item/reagent_containers/food/snacks/grown/cocoapod
+	output = /obj/item/reagent_containers/food/snacks/chocolatebar

--- a/code/modules/food/recipes_processor.dm
+++ b/code/modules/food/recipes_processor.dm
@@ -21,3 +21,7 @@
 /datum/food_processor_process/chocolatebar
 	input = /obj/item/reagent_containers/food/snacks/grown/cocoapod
 	output = /obj/item/reagent_containers/food/snacks/chocolatebar
+
+/datum/food_processor_process/meat
+	input = /obj/item/reagent_containers/food/snacks/meat
+	output = /obj/item/reagent_containers/food/snacks/rawmeatball

--- a/code/modules/food/recipes_processor.dm
+++ b/code/modules/food/recipes_processor.dm
@@ -25,3 +25,7 @@
 /datum/food_processor_process/meat
 	input = /obj/item/reagent_containers/food/snacks/meat
 	output = /obj/item/reagent_containers/food/snacks/rawmeatball
+
+/datum/food_processor_process/tortilla
+	input = /obj/item/reagent_containers/food/snacks/grown/corn
+	output = /obj/item/reagent_containers/food/snacks/tortilla

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -1591,6 +1591,7 @@ F// DM Environment file for baystation12.dme.
 #include "code\modules\flufftext\Dreaming.dm"
 #include "code\modules\flufftext\Hallucination.dm"
 #include "code\modules\food\recipes_microwave.dm"
+#include "code\modules\food\recipes_processor.dm"
 #include "code\modules\food_and_drinks\kitchen_machinery\griddle.dm"
 #include "code\modules\food_and_drinks\kitchen_machinery\grill.dm"
 #include "code\modules\food_and_drinks\recipes\recipes_drink.dm"


### PR DESCRIPTION
## About The Pull Request

the food processor had zero recipes for it; this adds raw potato sticks, tortillas, carrot fries, soydope, flour, spaghetti, chocolate bars and raw meatballs

## Why It's Good For The Game

as it stands the food processor doesn't do anything, which is a bit sad

## Changelog

:cl: dottymint
add: some recipes for the food processor (raw potato sticks, tortillas, carrot fries, soydope, flour, spaghetti, chocolate bars and raw meatballs)
/:cl:
