### PR TITLE
burst scream pref

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -132,6 +132,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/xenoprofile_pic = ""
 	var/xenogender = 1
 	var/harmful_sex_allowed = TRUE
+	var/burst_screams_enabled = TRUE
 
 	var/list/exp = list()
 	var/list/menuoptions = list()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -496,7 +496,8 @@
 	READ_FILE(S["genitalia_boobs"], genitalia_boobs)
 	READ_FILE(S["genitalia_cock"], genitalia_cock)
 	READ_FILE(S["harmful_sex_allowed"], harmful_sex_allowed)
-	
+	READ_FILE(S["burst_screams_enabled"], burst_screams_enabled)
+
 	READ_FILE(S["metadata"], metadata)
 	READ_FILE(S["metadata_likes"], metadata_likes)
 	READ_FILE(S["metadata_dislikes"], metadata_dislikes)
@@ -576,7 +577,8 @@
 	genitalia_boobs = sanitize_text(genitalia_boobs, initial(genitalia_boobs))
 	genitalia_cock = sanitize_text(genitalia_cock, initial(genitalia_cock))
 	harmful_sex_allowed = sanitize_text(harmful_sex_allowed, initial(harmful_sex_allowed))
-	
+	burst_screams_enabled = sanitize_text(burst_screams_enabled, initial(burst_screams_enabled))
+
 	metadata = sanitize_text(metadata, initial(metadata))
 	metadata_likes = sanitize_text(metadata_likes, initial(metadata_likes))
 	metadata_dislikes = sanitize_text(metadata_dislikes, initial(metadata_dislikes))
@@ -688,6 +690,7 @@
 	genitalia_boobs = sanitize_text(genitalia_boobs, initial(genitalia_boobs))
 	genitalia_cock = sanitize_text(genitalia_cock, initial(genitalia_cock))
 	harmful_sex_allowed = sanitize_text(harmful_sex_allowed, initial(harmful_sex_allowed))
+	burst_screams_enabled = sanitize_text(burst_screams_enabled, initial(burst_screams_enabled))
 
 	metadata = sanitize_text(metadata, initial(metadata))
 	metadata_likes = sanitize_text(metadata_likes, initial(metadata_likes))
@@ -761,7 +764,8 @@
 	WRITE_FILE(S["genitalia_boobs"], genitalia_boobs)
 	WRITE_FILE(S["genitalia_cock"], genitalia_cock)
 	WRITE_FILE(S["harmful_sex_allowed"], harmful_sex_allowed)
-	
+	WRITE_FILE(S["burst_screams_enabled"], burst_screams_enabled)
+
 	WRITE_FILE(S["metadata"], metadata)
 	WRITE_FILE(S["metadata_likes"], metadata_likes)
 	WRITE_FILE(S["metadata_dislikes"], metadata_dislikes)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -557,6 +557,8 @@
 /datum/emote/living/carbon/human/burstscream/get_sound(mob/living/carbon/human/user)
 	if(!user.species)
 		return
+	if(!user.client.prefs.burst_screams_enabled)
+		return
 	if(user.species.burstscreams[user.gender])
 		return user.species.burstscreams[user.gender]
 	if(user.species.burstscreams[NEUTER])

--- a/code/modules/mob/living/carbon/xenomorph/embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/embryo.dm
@@ -181,7 +181,8 @@
 	if(birth_owner.emerge_target == 1)
 		playsound(victim, 'modular_skyrat/sound/weapons/gagging.ogg', 15, TRUE)
 	else
-		victim.emote_burstscream()
+		if(victim.client.prefs.burst_screams_enabled)
+			victim.emote_burstscream()
 	victim.Paralyze(15 SECONDS)
 	victim.visible_message("<span class='danger'>\The [victim] starts shaking uncontrollably!</span>", \
 								"<span class='danger'>You feel something wiggling in your [birth_owner.emerge_target_flavor]!</span>")

--- a/code/modules/mob/mob_verbs.dm
+++ b/code/modules/mob/mob_verbs.dm
@@ -293,3 +293,11 @@
 
 	client.prefs.harmful_sex_allowed = !client.prefs.harmful_sex_allowed
 	to_chat(src, span_notice("Harmful sex is now [client.prefs.harmful_sex_allowed ? "Allowed" : "Disallowed"]"))
+
+/mob/living/carbon/verb/toggle_burst_scream()
+	set name = "Toggle Burst Screams"
+	set desc = "Toggle screaming from bursts."
+	set category = "IC"
+
+	client.prefs.burst_screams_enabled = !client.prefs.burst_screams_enabled
+	to_chat(src, span_notice("Screams from larva bursting are now [client.prefs.burst_screams_enabled ? "enabled" : "disabled"]"))


### PR DESCRIPTION
## About The Pull Request

adds a pref "Toggle Burst Screams" using the same implementation as "toggle sex harm" that lets you enable or disable burst screams (however not gagging)

## Why It's Good For The Game

i've seen more than a few people request this and adding a toggle for it seems innocuous enough, makes sense in the context of CLF or otherwise just people who don't want to hear it

## Changelog

:cl: dottymint
add: added a preference for toggling your own burst screams
/:cl:
