### PR TITLE
fixes brain death message mentioning an MMI

### DIFF
--- a/code/modules/mob/living/brain/death.dm
+++ b/code/modules/mob/living/brain/death.dm
@@ -1,8 +1,9 @@
-/mob/living/brain/death(gibbing, deathmessage = "beeps shrilly as the MMI flatlines!", silent)
+/mob/living/brain/death(gibbing, deathmessage = "", silent)
 	if(stat == DEAD)
 		return ..()
 	if(!gibbing && istype(container, /obj/item/mmi)) //If not gibbing but in a container.
 		container.icon_state = "mmi_dead"
+		deathmessage = "beeps shrilly as the MMI flatlines!"
 	return ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this fixes it so that you no longer get a message like "John Doe beeps shrilly as the MMI flatlines!" when somebody is decapitated

## Why It's Good For The Game

fixes death message mentioning non-existent MMI

## Changelog

:cl: dottymint
fix: decap death message no longer mentions MMIs
/:cl:
