### PR TITLE
[WIP/DNM] Multi-hive improvements

### DIFF
--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -222,6 +222,8 @@ GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 #define ERROR_NO_SUPPORT 7
 /// Failed to other blockers such as egg, power plant , coocon , traps
 #define ERROR_CONSTRUCT 8
+/// Failed due to enemy weeds
+#define ERROR_ENEMY_WEED 9
 
 #define PUPPET_WITHER_RANGE 15
 

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -13,7 +13,7 @@
 
 
 /// Checks all conditions if a spot is valid for construction , will return TRUE
-/proc/is_valid_for_resin_structure(turf/target, needs_support = FALSE, planned_building)
+/proc/is_valid_for_resin_structure(turf/target, needs_support = FALSE, planned_building, hivenumber)
 
 	if(!target || !istype(target))
 		return ERROR_JUST_NO
@@ -22,6 +22,8 @@
 		return ERROR_NOT_ALLOWED
 	if(!alien_weeds)
 		return ERROR_NO_WEED
+	if(alien_weeds.hivenumber != hivenumber)
+		return ERROR_ENEMY_WEED
 	if(!target.is_weedable())
 		return ERROR_CANT_WEED
 	for(var/obj/effect/forcefield/fog/F in range(1, target))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -81,6 +81,9 @@
 /obj/item/proc/attack_obj(obj/O, mob/living/user)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_OBJ, O, user) & COMPONENT_NO_ATTACK_OBJ)
 		return
+	if(isxeno(user))
+		to_chat(user, span_warning("We stare at \the [src] cluelessly."))
+		return FALSE
 	if(item_flags & NOBLUDGEON)
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -195,6 +198,10 @@
 
 	if(M.can_be_operated_on() && do_surgery(M, user, src)) //Checks if mob is lying down on table for surgery
 		return TRUE
+
+	if(isxeno(user))
+		to_chat(user, span_warning("We stare at \the [src] cluelessly."))
+		return FALSE
 
 	if(item_flags & NOBLUDGEON)
 		return FALSE
@@ -331,6 +338,10 @@
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_ALTERNATE, M, user) & COMPONENT_ITEM_NO_ATTACK)
 		return FALSE
 	if(SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK_ALTERNATE, M, src) & COMPONENT_ITEM_NO_ATTACK)
+		return FALSE
+
+	if(isxeno(user))
+		to_chat(user, span_warning("We stare at \the [src] cluelessly."))
 		return FALSE
 
 	if(item_flags & NOBLUDGEON)

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -92,7 +92,7 @@ SUBSYSTEM_DEF(weeds)
 			if(istype(O, /obj/alien/weeds/node))
 				return
 			var/obj/alien/weeds/weed = O
-			if(weed.parent_node && weed.parent_node != node && get_dist_euclidean_square(node, weed) >= get_dist_euclidean_square(weed.parent_node, weed))
+			if(weed.parent_node && weed.parent_node != node && (!(node.issamexenohive(weed)) || (get_dist_euclidean_square(node, weed) >= get_dist_euclidean_square(weed.parent_node, weed))))
 				return
 			if((weed.type == weed_to_spawn) && (weed.color_variant == node.color_variant))
 				weed.set_parent_node(node)
@@ -100,4 +100,4 @@ SUBSYSTEM_DEF(weeds)
 			weed.swapped = TRUE
 			swapped = TRUE
 			qdel(O)
-	new weed_to_spawn(T, node, swapped)
+	new weed_to_spawn(T, node.hivenumber, node, swapped)

--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -8,6 +8,7 @@
 
 /datum/job/clf/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
 	. = ..()
+	C.hivenumber = XENO_HIVE_NORMAL
 	SSminimaps.add_marker(C, MINIMAP_FLAG_MARINE_CLF, image('ntf_modular/icons/UI_icons/map_blips.dmi', null, comm_title))
 	var/datum/action/minimap/clf/mini = new
 	mini.give_action(C)

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -154,18 +154,20 @@
 		vehicle.last_move_time += WEED_SLOWDOWN
 		return
 
-	if(isxeno(crosser))
+	if(issamexenohive(crosser))
+		if(!isxeno(crosser))
+			return
 		var/mob/living/carbon/xenomorph/X = crosser
 		X.next_move_slowdown += X.xeno_caste.weeds_speed_mod
 		return
 
-	if(!ishuman(crosser))
+	if(!isliving(crosser))
 		return
 
 	if(CHECK_MULTIPLE_BITFIELDS(crosser.pass_flags, HOVERING))
 		return
 
-	var/mob/living/carbon/human/victim = crosser
+	var/mob/living/victim = crosser
 
 	if(victim.lying_angle)
 		return
@@ -329,13 +331,16 @@
 		vehicle.last_move_time += WEED_SLOWDOWN
 		return
 
-	if(!ishuman(crosser))
+	if(!isliving(crosser))
+		return
+
+	if(!issamexenohive(crosser))
 		return
 
 	if(CHECK_MULTIPLE_BITFIELDS(crosser.pass_flags, HOVERING))
 		return
 
-	var/mob/living/carbon/human/victim = crosser
+	var/mob/living/victim = crosser
 
 	if(victim.lying_angle)
 		return

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -19,6 +19,7 @@
 	plane = FLOOR_PLANE
 	max_integrity = 25
 	ignore_weed_destruction = TRUE
+	resistance_flags = UNACIDABLE | XENO_DAMAGEABLE
 
 	var/obj/alien/weeds/node/parent_node
 	///The color variant of the sprite
@@ -36,7 +37,7 @@
 /obj/alien/weeds/plasmacutter_act(mob/living/user, obj/item/I)
 	return FALSE // Just attack normally.
 
-/obj/alien/weeds/Initialize(mapload, obj/alien/weeds/node/node, swapped = FALSE)
+/obj/alien/weeds/Initialize(mapload, _hivenumber, obj/alien/weeds/node/node, swapped = FALSE)
 	. = ..()
 	var/static/list/connections = list(
 		COMSIG_FIND_FOOTSTEP_SOUND = TYPE_PROC_REF(/atom/movable, footstep_override)
@@ -257,7 +258,7 @@
 	///The plasma cost multiplier for this node
 	var/ability_cost_mult = 1
 
-/obj/alien/weeds/node/Initialize(mapload, obj/alien/weeds/node/node)
+/obj/alien/weeds/node/Initialize(mapload, _hivenumber, obj/alien/weeds/node/node)
 	var/swapped = FALSE
 	for(var/obj/alien/weeds/W in loc)
 		if(W != src)
@@ -265,7 +266,7 @@
 			swapped = TRUE
 			qdel(W) //replaces the previous weed
 			break
-	. = ..(mapload, node, swapped)
+	. = ..(mapload, _hivenumber, node, swapped)
 
 	// Generate our full graph before adding to SSweeds
 	node_turfs = filled_turfs(src, node_range, "square")

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -27,6 +27,9 @@
 	if(!_hivenumber)
 		return
 	hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 	victim = _victim
 	victim.forceMove(src)
 	START_PROCESSING(SSslowprocess, src)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -134,6 +134,9 @@
 	if(!(resistance_flags & XENO_DAMAGEABLE))
 		to_chat(xeno_attacker, span_warning("We stare at \the [src] cluelessly."))
 		return FALSE
+	if(issamexenohive(xeno_attacker))
+		to_chat(xeno_attacker, span_warning("We stare at \the [src] cluelessly."))
+		return FALSE
 	if(effects)
 		xeno_attacker.visible_message(span_danger("[xeno_attacker] has slashed [src]!"),
 		span_danger("We slash [src]!"))

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -14,11 +14,24 @@
 	var/on_fire = FALSE
 	///Set this to true if this object isn't destroyed when the weeds under it is.
 	var/ignore_weed_destruction = FALSE
+	///Which hive it belongs to
+	var/hivenumber = XENO_HIVE_NORMAL
 
-/obj/alien/Initialize(mapload)
+/obj/alien/Initialize(mapload,_hivenumber)
 	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 	if(!ignore_weed_destruction)
 		RegisterSignal(loc, COMSIG_TURF_WEED_REMOVED, PROC_REF(weed_removed))
+
+/obj/alien/update_icon_state()
+	.=..()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	if(istype(hive))
+		color = hive.color
 
 /// Destroy the alien effect when the weed it was on is destroyed
 /obj/alien/proc/weed_removed()
@@ -170,20 +183,26 @@
 	var/close_delay = 10 SECONDS
 	///The timer that tracks the delay above
 	var/closetimer
+	var/hivenumber = XENO_HIVE_NORMAL
 
 /obj/structure/mineral_door/resin/smooth_icon()
 	. = ..()
 	update_icon()
 
-/obj/structure/mineral_door/resin/Initialize(mapload)
+/obj/structure/mineral_door/resin/Initialize(mapload, _hivenumber)
 	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 	if(!locate(/obj/alien/weeds) in loc)
 		new /obj/alien/weeds(loc)
 
 
 /obj/structure/mineral_door/resin/Cross(atom/movable/mover, turf/target)
 	. = ..()
-	if(!. && isxeno(mover) && !open)
+	if(!. && issamexenohive(mover) && !open)
 		toggle_state()
 		return TRUE
 	if(ishuman(mover))
@@ -204,6 +223,9 @@
 	var/turf/cur_loc = xeno_attacker.loc
 	if(!istype(cur_loc))
 		return FALSE //Some basic logic here
+	if(!issamexenohive(xeno_attacker))
+		return ..()
+
 	if(xeno_attacker.a_intent != INTENT_HARM)
 		try_toggle_state(xeno_attacker)
 		return TRUE
@@ -233,7 +255,7 @@
 			take_damage(30, BRUTE, BOMB)
 
 /obj/structure/mineral_door/resin/try_toggle_state(atom/user)
-	if(isxeno(user))
+	if(issamexenohive(user))
 		return ..()
 
 /obj/structure/mineral_door/resin/toggle_state()
@@ -293,6 +315,16 @@
 	///Holder to ensure only one user per resin jelly.
 	var/current_user
 
+	var/hivenumber = XENO_HIVE_NORMAL
+	
+/obj/item/resin_jelly/Initialize(mapload, _hivenumber)
+	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
+	
 /obj/item/resin_jelly/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -261,7 +261,7 @@
 	//We do this here so anything that doesn't want to persist can clear itself
 	var/list/old__listen_lookup = _listen_lookup?.Copy()
 	var/list/old_signal_procs = _signal_procs?.Copy()
-	var/turf/W = new path(src)
+	var/turf/W = new path(src, usr?.get_xeno_hivenumber())
 
 	// WARNING WARNING
 	// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -17,16 +17,24 @@
 	canSmoothWith = list(SMOOTH_GROUP_XENO_STRUCTURES)
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 75, ENERGY = 75, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hard_armor = list(MELEE = 0, BULLET = 15, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-	resistance_flags = UNACIDABLE
+	resistance_flags = UNACIDABLE | XENO_DAMAGEABLE
 
 	//Used for quickbuild refunding.
 	var/is_normal_resin_wall = TRUE
+	///Which hive it belongs to
+	var/hivenumber = XENO_HIVE_NORMAL
 
 /turf/closed/wall/resin/add_debris_element()
 	AddElement(/datum/element/debris, null, -15, 8, 0.7)
 
-/turf/closed/wall/resin/Initialize(mapload)
+/turf/closed/wall/resin/Initialize(mapload, _hivenumber)
 	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	if(!color)
+		color = hive.color
 	return INITIALIZE_HINT_LATELOAD
 
 
@@ -113,6 +121,22 @@
 /turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return
+	if(!issamexenohive(xeno_attacker))
+		SEND_SIGNAL(xeno_attacker, COMSIG_XENOMORPH_ATTACK_OBJ, src)
+		if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, xeno_attacker) & COMPONENT_NO_ATTACK_ALIEN)
+			return FALSE
+		if(!(resistance_flags & XENO_DAMAGEABLE))
+			to_chat(xeno_attacker, span_warning("We stare at \the [src] cluelessly."))
+			return FALSE
+		if(effects)
+			xeno_attacker.visible_message(span_danger("[xeno_attacker] has slashed [src]!"),
+			span_danger("We slash [src]!"))
+			xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+			playsound(loc, SFX_ALIEN_CLAW_METAL, 25)
+		xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_SMASH)
+		xeno_attacker.changeNext_move(CLICK_CD_MELEE)
+		take_damage(damage_amount, damage_type, armor_type, effects, get_dir(src, xeno_attacker), armor_penetration, xeno_attacker)
+		return TRUE
 	if(CHECK_BITFIELD(SSticker.mode?.round_type_flags, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.active)
 		if(is_normal_resin_wall)
 			SSresinshaping.quickbuild_points_by_hive[xeno_attacker.hivenumber]++

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -52,6 +52,7 @@
 	rally_zombie.give_action(H)
 	var/datum/action/set_agressivity/set_zombie_behaviour = new
 	set_zombie_behaviour.give_action(H)
+	H.hivenumber = FACTION_ZOMBIE
 
 /datum/species/zombie/post_species_loss(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -76,8 +76,11 @@
 	if(!T.is_weedable())
 		to_chat(owner, span_warning("Bad place for a garden!"))
 		return fail_activate()
-
-	if(locate(weed_type) in T)
+	var/obj/alien/weeds/existing_weed = locate() in T
+	if(existing_weed && (!existing_weed.issamexenohive(xeno_owner)))
+		to_chat(owner, span_warning("You cannot build on another hive's weeds!"))
+		return fail_activate()
+	if(existing_weed && existing_weed.type == weed_type)
 		to_chat(owner, span_warning("There's a pod here already!"))
 		return fail_activate()
 
@@ -338,12 +341,15 @@
 		return
 
 	var/mob/living/carbon/xenomorph/X = owner
-	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin))
+	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin, X.hivenumber))
 		if(ERROR_CANT_WEED)
 			owner.balloon_alert(owner, span_notice("This spot cannot support a garden!"))
 			return
 		if(ERROR_NO_WEED)
 			owner.balloon_alert(owner, span_notice("This spot has no weeds to serve as support!"))
+			return
+		if(ERROR_ENEMY_WEED)
+			owner.balloon_alert(owner, span_notice("You cannot build on another hive's weeds!"))
 			return
 		if(ERROR_NO_SUPPORT)
 			owner.balloon_alert(owner, span_notice("This spot has no adjaecent support for the structure!"))
@@ -381,12 +387,15 @@
 
 /datum/action/ability/activable/xeno/secrete_resin/proc/build_resin(turf/T)
 	var/mob/living/carbon/xenomorph/X = owner
-	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin))
+	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin, X.hivenumber))
 		if(ERROR_CANT_WEED)
 			owner.balloon_alert(owner, span_notice("This spot cannot support a garden!"))
 			return
 		if(ERROR_NO_WEED)
 			owner.balloon_alert(owner, span_notice("This spot has no weeds to serve as support!"))
+			return
+		if(ERROR_ENEMY_WEED)
+			owner.balloon_alert(owner, span_notice("You cannot build on another hive's weeds!"))
 			return
 		if(ERROR_NO_SUPPORT)
 			owner.balloon_alert(owner, span_notice("This spot has no adjaecent support for the structure!"))
@@ -410,12 +419,15 @@
 		return fail_activate()
 	if(!do_after(X, get_wait(), NONE, T, BUSY_ICON_BUILD))
 		return fail_activate()
-	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin))
+	switch(is_valid_for_resin_structure(T, X.selected_resin == /obj/structure/mineral_door/resin, X.selected_resin, X.hivenumber))
 		if(ERROR_CANT_WEED)
 			owner.balloon_alert(owner, span_notice("This spot cannot support a garden!"))
 			return
 		if(ERROR_NO_WEED)
 			owner.balloon_alert(owner, span_notice("This spot has no weeds to serve as support!"))
+			return
+		if(ERROR_ENEMY_WEED)
+			owner.balloon_alert(owner, span_notice("You cannot build on another hive's weeds!"))
 			return
 		if(ERROR_NO_SUPPORT)
 			owner.balloon_alert(owner, span_notice("This spot has no adjaecent support for the structure!"))
@@ -546,12 +558,15 @@
 	if(GLOB.hive_datums[owner.get_xeno_hivenumber()].special_build_points <= 0)
 		owner.balloon_alert(owner, span_notice("There is not enough special build points to build this structure!"))
 		return
-	switch(is_valid_for_resin_structure(T, X.selected_special_resin == /obj/structure/mineral_door/resin, X.selected_special_resin))
+	switch(is_valid_for_resin_structure(T, X.selected_special_resin == /obj/structure/mineral_door/resin, X.selected_special_resin, X.hivenumber))
 		if(ERROR_CANT_WEED)
 			owner.balloon_alert(owner, span_notice("This spot cannot support a garden!"))
 			return
 		if(ERROR_NO_WEED)
 			owner.balloon_alert(owner, span_notice("This spot has no weeds to serve as support!"))
+			return
+		if(ERROR_ENEMY_WEED)
+			owner.balloon_alert(owner, span_notice("You cannot build on another hive's weeds!"))
 			return
 		if(ERROR_NO_SUPPORT)
 			owner.balloon_alert(owner, span_notice("This spot has no adjaecent support for the structure!"))
@@ -577,12 +592,15 @@
 	if(GLOB.hive_datums[owner.get_xeno_hivenumber()].special_build_points <= 0)
 		owner.balloon_alert(owner, span_notice("There is not enough special build points to build this structure!"))
 		return
-	switch(is_valid_for_resin_structure(T, X.selected_special_resin == /obj/structure/mineral_door/resin, X.selected_special_resin))
+	switch(is_valid_for_resin_structure(T, X.selected_special_resin == /obj/structure/mineral_door/resin, X.selected_special_resin, X.hivenumber))
 		if(ERROR_CANT_WEED)
 			owner.balloon_alert(owner, span_notice("This spot cannot support a garden!"))
 			return
 		if(ERROR_NO_WEED)
 			owner.balloon_alert(owner, span_notice("This spot has no weeds to serve as support!"))
+			return		
+		if(ERROR_ENEMY_WEED)
+			owner.balloon_alert(owner, span_notice("You cannot build on another hive's weeds!"))
 			return
 		if(ERROR_NO_SUPPORT)
 			owner.balloon_alert(owner, span_notice("This spot has no adjaecent support for the structure!"))

--- a/code/modules/mob/living/carbon/xenomorph/abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities.dm
@@ -83,7 +83,7 @@
 
 	owner.visible_message(span_xenonotice("\The [owner] regurgitates a pulsating node and plants it on the ground!"), \
 		span_xenonotice("We regurgitate a pulsating node and plant it on the ground!"), null, 5)
-	new weed_type(T)
+	new weed_type(T, xeno_owner.hivenumber)
 	last_weeded_turf = T
 	playsound(T, SFX_ALIEN_RESIN_BUILD, 25)
 	GLOB.round_statistics.weeds_planted++
@@ -369,7 +369,7 @@
 		T.ChangeTurf(X.selected_resin, baseturfs)
 		new_resin = T
 	else
-		new_resin = new X.selected_resin(T)
+		new_resin = new X.selected_resin(T, xeno_owner.hivenumber)
 	if(new_resin)
 		SSresinshaping.quickbuild_points_by_hive[owner.get_xeno_hivenumber()]--
 
@@ -445,7 +445,7 @@
 		T.ChangeTurf(X.selected_resin, baseturfs)
 		new_resin = T
 	else
-		new_resin = new X.selected_resin(T)
+		new_resin = new X.selected_resin(T, xeno_owner.hivenumber)
 	switch(X.selected_resin)
 		if(/obj/alien/resin/sticky)
 			ability_cost = initial(ability_cost) / 3
@@ -611,7 +611,7 @@
 		T.ChangeTurf(X.selected_special_resin, baseturfs)
 		new_resin = T
 	else
-		new_resin = new X.selected_special_resin(T)
+		new_resin = new X.selected_special_resin(T, xeno_owner.hivenumber)
 	if(new_resin)
 		add_cooldown(SSmonitor.gamestate == SHUTTERS_CLOSED ? get_cooldown()/2 : get_cooldown())
 		succeed_activate(SSmonitor.gamestate == SHUTTERS_CLOSED ? ability_cost/2 : ability_cost)

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -351,7 +351,7 @@
 	succeed_activate()
 
 	playsound(T, SFX_ALIEN_RESIN_BUILD, 25)
-	new /obj/structure/xeno/acidwell(T, owner)
+	new /obj/structure/xeno/acidwell(T, xeno_owner.hivenumber, owner)
 
 	to_chat(owner, span_xenonotice("We place an acid well; it can be filled with more acid."))
 	GLOB.round_statistics.xeno_acid_wells++

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -60,7 +60,6 @@
 	if(!do_after(xeno_owner, 1 SECONDS, NONE, xeno_owner, BUSY_ICON_DANGER))
 		return fail_activate()
 	var/datum/ammo/xeno/leash_ball = GLOB.ammo_list[/datum/ammo/xeno/leash_ball]
-	leash_ball.hivenumber = xeno_owner.hivenumber
 	var/obj/projectile/newspit = new (get_turf(xeno_owner))
 
 	newspit.generate_bullet(leash_ball)

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -10,14 +10,11 @@
 	var/maturity_time = 0
 	///Number of the last maturity stage before bursting
 	var/stage_ready_to_burst = 0
-	///Which hive it belongs to
-	var/hivenumber = XENO_HIVE_NORMAL
 	///How far will targets trigger the burst
 	var/trigger_size = 0
 
-/obj/alien/egg/Initialize(mapload, hivenumber)
+/obj/alien/egg/Initialize(mapload, _hivenumber)
 	. = ..()
-	src.hivenumber = hivenumber
 	advance_maturity(maturity_stage)
 
 /obj/alien/egg/update_icon_state()
@@ -93,11 +90,6 @@
 	overlays.Cut()
 	if(on_fire)
 		overlays += "alienegg_fire"
-	if(hivenumber != XENO_HIVE_NORMAL && GLOB.hive_datums[hivenumber])
-		var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
-		color = hive.color
-		return
-	color = null
 
 /obj/alien/egg/hugger/burst(via_damage)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -881,7 +881,7 @@
 
 	for(var/turf/sticky_tile AS in RANGE_TURFS(1, loc))
 		if(!locate(/obj/effect/xenomorph/spray) in sticky_tile.contents)
-			new /obj/alien/resin/sticky/thin(sticky_tile)
+			new /obj/alien/resin/sticky/thin(sticky_tile, hivenumber)
 
 	for(var/mob/living/carbon/human/target in range(1, loc))
 		if(isxeno(target)) //Xenos aren't affected by sticky resin

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1656,7 +1656,7 @@ to_chat will check for valid clients itself already so no need to double check f
 /atom/proc/get_xeno_hivenumber()
 	return FALSE
 
-/obj/alien/egg/get_xeno_hivenumber()
+/obj/alien/get_xeno_hivenumber()
 	return hivenumber
 
 /obj/item/alien_embryo/get_xeno_hivenumber()
@@ -1677,11 +1677,6 @@ to_chat will check for valid clients itself already so no need to double check f
 		return hivenumber
 	return ..()
 
-/obj/structure/xeno/trap/get_xeno_hivenumber()
-	if(hugger)
-		return hugger.hivenumber
-	return ..()
-
 /mob/living/carbon/human/get_xeno_hivenumber()
 	if(faction == FACTION_ZOMBIE)
 		return FACTION_ZOMBIE
@@ -1692,3 +1687,12 @@ to_chat will check for valid clients itself already so no need to double check f
 /obj/machinery/deployable/mounted/sentry/get_xeno_hivenumber()
 	if(iff_signal == CLF_IFF)
 		return XENO_HIVE_NORMAL
+
+/obj/structure/mineral_door/resin/get_xeno_hivenumber()
+	return hivenumber
+	
+/turf/closed/wall/resin/get_xeno_hivenumber()
+	return hivenumber
+	
+/obj/item/resin_jelly/get_xeno_hivenumber()
+	return hivenumber

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -30,8 +30,11 @@
 	var/list/client/candidates
 	/// Amount of special resin points used to build special resin walls by each hive.
 	var/special_build_points = 50
-	/// These factions cannot sell this hive's corpses.
+	/// These factions cannot sell this hive's resin jelly or corpses
 	var/list/allied_factions = list(FACTION_CLF, FACTION_XENO)
+	/// Supply and dropship points given when a non-allied faction sells one resin jelly from this faction.
+	var/jelly_export_value = list(2,0)
+
 
 	///Reference to upgrades available and purchased by this hive.
 	var/datum/hive_purchases/purchases = new
@@ -1223,6 +1226,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	prefix = "Corrupted "
 	color = "#00ff80"
 	allied_factions = list(FACTION_TERRAGOV)
+	jelly_export_value = list(1,0)
 
 // Make sure they can understand english
 /datum/hive_status/corrupted/post_add(mob/living/carbon/xenomorph/X)
@@ -1696,3 +1700,4 @@ to_chat will check for valid clients itself already so no need to double check f
 	
 /obj/item/resin_jelly/get_xeno_hivenumber()
 	return hivenumber
+

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -30,7 +30,7 @@
 	var/list/client/candidates
 	/// Amount of special resin points used to build special resin walls by each hive.
 	var/special_build_points = 50
-	/// These factions cannot sell this hive's resin jelly or corpses
+	/// These factions will not be attacked by turrets of this hive but cannot sell their resin jelly or corpses.
 	var/list/allied_factions = list(FACTION_CLF, FACTION_XENO)
 	/// Supply and dropship points given when a non-allied faction sells one resin jelly from this faction.
 	var/jelly_export_value = list(2,0)
@@ -1669,7 +1669,10 @@ to_chat will check for valid clients itself already so no need to double check f
 /obj/item/clothing/mask/facehugger/get_xeno_hivenumber()
 	return hivenumber
 
-/mob/living/carbon/xenomorph/get_xeno_hivenumber()
+/mob/living
+	var/hivenumber = FALSE
+
+/mob/living/get_xeno_hivenumber()
 	return hivenumber
 
 /mob/illusion/xeno/get_xeno_hivenumber()
@@ -1681,16 +1684,8 @@ to_chat will check for valid clients itself already so no need to double check f
 		return hivenumber
 	return ..()
 
-/mob/living/carbon/human/get_xeno_hivenumber()
-	if(faction == FACTION_ZOMBIE)
-		return FACTION_ZOMBIE
-	if(faction == FACTION_CLF)
-		return XENO_HIVE_NORMAL
-	return FALSE
-
 /obj/machinery/deployable/mounted/sentry/get_xeno_hivenumber()
-	if(iff_signal == CLF_IFF)
-		return XENO_HIVE_NORMAL
+	return hivenumber
 
 /obj/structure/mineral_door/resin/get_xeno_hivenumber()
 	return hivenumber

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -311,7 +311,7 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	light_system = MOVABLE_LIGHT
 
 	///Hive name define
-	var/hivenumber = XENO_HIVE_NORMAL
+	hivenumber = XENO_HIVE_NORMAL
 	///Hive datum we belong to
 	var/datum/hive_status/hive
 	///Xeno mob specific flags

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -483,6 +483,8 @@
 	for(var/obj/alien/weeds/W in range(strict_turf_check ? 0 : 1, T ? T : get_turf(src)))
 		if(QDESTROYING(W))
 			continue
+		if(!issamexenohive(W))
+			continue
 		return
 	return FALSE
 
@@ -498,6 +500,9 @@
 /mob/living/carbon/xenomorph/proc/handle_weeds_on_movement(datum/source)
 	SIGNAL_HANDLER
 	var/obj/alien/weeds/found_weed = locate(/obj/alien/weeds) in loc
+	if(!issamexenohive(found_weed))
+		loc_weeds_type = null
+		return
 	loc_weeds_type = found_weed?.type
 
 /mob/living/carbon/xenomorph/toggle_resting()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -425,6 +425,7 @@
 	if(should_zombify)
 		set_species("Strong zombie")
 		faction = FACTION_ZOMBIE
+		hivenumber = FACTION_ZOMBIE
 	heal_limbs(- health)
 	set_stat(CONSCIOUS)
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)

--- a/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
@@ -18,19 +18,19 @@
 	var/obj/item/clothing/mask/facehugger/hugger_type = /obj/item/clothing/mask/facehugger
 
 /datum/ammo/xeno/hugger/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_mob), hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_mob), proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/on_hit_obj(obj/target_obj, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_obj), hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_obj), proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/slash

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -31,8 +31,6 @@
 	var/datum/effect_system/smoke_spread/xeno/smoke_system
 	var/smoke_strength
 	var/smoke_range
-	///The hivenumber of this ammo
-	var/hivenumber = XENO_HIVE_NORMAL
 
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
@@ -201,7 +199,7 @@
 
 
 /datum/ammo/xeno/sticky/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	drop_resin(get_turf(target_mob))
+	drop_resin(get_turf(target_mob), proj.firer.get_xeno_hivenumber())
 	if(iscarbon(target_mob))
 		var/mob/living/carbon/target_carbon = target_mob
 		if(target_carbon.issamexenohive(proj.firer))
@@ -215,15 +213,15 @@
 		var/obj/vehicle/sealed/armored/tank = target_obj
 		COOLDOWN_START(tank, cooldown_vehicle_move, tank.move_delay)
 	var/turf/target_turf = get_turf(target_obj)
-	drop_resin(target_turf.density ? proj.loc : target_turf)
+	drop_resin(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/sticky/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_resin(target_turf.density ? proj.loc : target_turf)
+	drop_resin(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/sticky/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_resin(target_turf.density ? proj.loc : target_turf)
+	drop_resin(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
-/datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
+/datum/ammo/xeno/sticky/proc/drop_resin(turf/T, hivenumber = XENO_HIVE_NORMAL)
 	if(T.density || istype(T, /turf/open/space)) // No structures in space
 		return
 
@@ -231,7 +229,7 @@
 		if(is_type_in_typecache(O, GLOB.no_sticky_resin))
 			return
 
-	new /obj/alien/resin/sticky/thin(T)
+	new /obj/alien/resin/sticky/thin(T, hivenumber)
 
 /datum/ammo/xeno/sticky/turret
 	max_range = 9
@@ -255,22 +253,22 @@
 
 /datum/ammo/xeno/sticky/globe/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : target_obj.loc
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_obj), loc_override = det_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_turf(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_turf), loc_override = det_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/det_turf = get_turf(target_mob)
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_mob), loc_override = det_turf)
 
 /datum/ammo/xeno/sticky/globe/do_at_max_range(turf/target_turf, obj/projectile/proj)
 	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_turf), loc_override = det_turf)
 
 /datum/ammo/xeno/acid

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -56,21 +56,21 @@
 	max_range = 8
 
 /datum/ammo/xeno/leash_ball/on_hit_turf(turf/target_turf, obj/projectile/proj)
-	drop_leashball(target_turf.density ? proj.loc : target_turf)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/leash_ball/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	var/turf/target_turf = get_turf(target_mob)
-	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/leash_ball/on_hit_obj(obj/target_obj, obj/projectile/proj)
 	var/turf/target_turf = get_turf(target_obj)
 	if(target_turf.density || (target_obj.density && !(target_obj.allow_pass_flags & PASS_PROJECTILE)))
 		target_turf = get_turf(proj)
-	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/leash_ball/do_at_max_range(turf/target_turf, obj/projectile/proj)
-	drop_leashball(target_turf.density ? proj.loc : target_turf)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /// This spawns a leash ball and checks if the turf is dense before doing so
-/datum/ammo/xeno/leash_ball/proc/drop_leashball(turf/target_turf)
+/datum/ammo/xeno/leash_ball/proc/drop_leashball(turf/target_turf, hivenumber)
 	new /obj/structure/xeno/aoe_leash(get_turf(target_turf), hivenumber)

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 	var/iff_signal = NONE
 	///For minimap icon change if sentry is firing
 	var/firing
+	var/hivenumber = FALSE
 
 //------------------------------------------------------------------
 //Setup and Deletion
@@ -48,6 +49,13 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 		var/mob/living/carbon/human/_deployer = deployer
 		var/obj/item/card/id/id = _deployer.get_idcard(TRUE)
 		iff_signal = id?.iff_signal
+		hivenumber = _deployer.get_xeno_hivenumber()
+	else
+		if(iff_signal & CLF_IFF)
+			hivenumber = XENO_HIVE_NORMAL
+		else
+			if(iff_signal & TGMC_LOYALIST_IFF)
+				hivenumber = XENO_HIVE_CORRUPTED
 
 	knockdown_threshold = gun?.knockdown_threshold ? gun.knockdown_threshold : initial(gun.knockdown_threshold)
 	range = CHECK_BITFIELD(gun.turret_flags, TURRET_RADIAL) ?  gun.turret_range - 2 : gun.turret_range

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -29,6 +29,12 @@
 		. += AM.supply_export(faction_selling)
 		qdel(AM)
 
+/obj/item/resin_jelly/supply_export(faction_selling)
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	if(faction_selling in hive.allied_factions)
+		return list(new /datum/export_report(0, name, faction_selling))
+	. = ..()
+
 /**
  * Getter proc for the point value of this object
  *
@@ -87,3 +93,7 @@
 			if(GLOB.faction_to_alignement[seller_faction] == ALIGNEMENT_FRIENDLY)
 				return FALSE
 			return TRUE
+
+/obj/item/resin_jelly/get_export_value()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	return hive.jelly_export_value

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -24,6 +24,9 @@
 		LAZYADDASSOC(GLOB.xeno_critical_structures_by_hive, hivenumber, src)
 	if((xeno_structure_flags & XENO_STRUCT_WARNING_RADIUS))
 		set_proximity_warning()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 
 /obj/structure/xeno/Destroy()
 	//prox_warning_turfs = null

--- a/code/modules/xenomorph/_xeno_structure.dm
+++ b/code/modules/xenomorph/_xeno_structure.dm
@@ -1,7 +1,7 @@
 /obj/structure/xeno
 	hit_sound = SFX_ALIEN_RESIN_BREAK
 	layer = RESIN_STRUCTURE_LAYER
-	resistance_flags = UNACIDABLE
+	resistance_flags = UNACIDABLE | XENO_DAMAGEABLE
 	///Bitflags specific to xeno structures
 	var/xeno_structure_flags
 	///Which hive(number) do we belong to?
@@ -67,6 +67,8 @@
 		damage_alert()
 
 /obj/structure/xeno/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	if(!(HAS_TRAIT(xeno_attacker, TRAIT_VALHALLA_XENO) && xeno_attacker.a_intent == INTENT_HARM && (tgui_alert(xeno_attacker, "Are you sure you want to tear down [src]?", "Tear down [src]?", list("Yes","No"))) == "Yes"))
 		return ..()
 	if(!do_after(xeno_attacker, 3 SECONDS, NONE, src))

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -102,6 +102,8 @@
 	attack_alien(user)
 
 /obj/structure/xeno/acidwell/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	if(xeno_attacker.a_intent == INTENT_HARM && (CHECK_BITFIELD(xeno_attacker.xeno_caste.caste_flags, CASTE_IS_BUILDER) || xeno_attacker == creator) ) //If we're a builder caste or the creator and we're on harm intent, deconstruct it.
 		balloon_alert(xeno_attacker, "Removing...")
 		if(!do_after(xeno_attacker, XENO_ACID_WELL_FILL_TIME, IGNORE_HELD_ITEM, src, BUSY_ICON_HOSTILE))
@@ -172,7 +174,7 @@
 		stepper.ExtinguishMob()
 		charges_used ++
 
-	if(!isxeno(stepper))
+	if(!issamexenohive(stepper))
 		stepper.next_move_slowdown += charges * 2 //Acid spray has slow down so this should too; scales with charges, Min 2 slowdown, Max 10
 		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID,  penetration = 33)
 		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID,  penetration = 33)

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -19,7 +19,7 @@
 	///What xeno created this well
 	var/mob/living/carbon/xenomorph/creator = null
 
-/obj/structure/xeno/acidwell/Initialize(mapload, _creator)
+/obj/structure/xeno/acidwell/Initialize(mapload, _hivenumber, _creator)
 	. = ..()
 	creator = _creator
 	RegisterSignal(creator, COMSIG_QDELETING, PROC_REF(clear_creator))

--- a/code/modules/xenomorph/jellypod.dm
+++ b/code/modules/xenomorph/jellypod.dm
@@ -62,7 +62,7 @@
 		to_chat(xeno_attacker, span_xenonotice("We reach into \the [src], but only find dregs of resin. We should wait some more.") )
 		return
 	balloon_alert(xeno_attacker, "Retrieved jelly")
-	new /obj/item/resin_jelly(loc)
+	new /obj/item/resin_jelly(loc, hivenumber)
 	chargesleft--
 	if(!(datum_flags & DF_ISPROCESSING) && (chargesleft < maxcharges))
 		START_PROCESSING(SSslowprocess, src)

--- a/code/modules/xenomorph/jellypod.dm
+++ b/code/modules/xenomorph/jellypod.dm
@@ -51,7 +51,10 @@
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE
 
-	if((xeno_attacker.a_intent == INTENT_HARM && isxenohivelord(xeno_attacker)) || xeno_attacker.hivenumber != hivenumber)
+	if(!issamexenohive(xeno_attacker))
+		return ..()
+
+	if(xeno_attacker.a_intent == INTENT_HARM)
 		balloon_alert(xeno_attacker, "Destroying...")
 		if(do_after(xeno_attacker, HIVELORD_TUNNEL_DISMANTLE_TIME, IGNORE_HELD_ITEM, src, BUSY_ICON_BUILD))
 			deconstruct(FALSE)

--- a/code/modules/xenomorph/jellypod.dm
+++ b/code/modules/xenomorph/jellypod.dm
@@ -69,3 +69,16 @@
 	chargesleft--
 	if(!(datum_flags & DF_ISPROCESSING) && (chargesleft < maxcharges))
 		START_PROCESSING(SSslowprocess, src)
+
+/obj/structure/xeno/resin_jelly_pod/attack_hand(mob/living/user)
+	if(!issamexenohive(user))
+		return ..()
+	if(!chargesleft)
+		balloon_alert(user, "No jelly remaining")
+		to_chat(user, span_xenonotice("We reach into \the [src], but only find dregs of resin. We should wait some more.") )
+		return
+	balloon_alert(user, "Retrieved jelly")
+	new /obj/item/resin_jelly(loc, hivenumber)
+	chargesleft--
+	if(!(datum_flags & DF_ISPROCESSING) && (chargesleft < maxcharges))
+		START_PROCESSING(SSslowprocess, src)

--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -242,10 +242,8 @@
 	return ..()
 
 /obj/structure/xeno/acid_maw/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount, damage_type, armor_type, effects, armor_penetration, isrightclick)
-	. = ..()
-	if(xeno_attacker.hivenumber != hivenumber)
-		balloon_alert(xeno_attacker, "wrong hive")
-		return FALSE
+	if(!issamexenohive(xeno_attacker)|| xeno_attacker.a_intent == INTENT_HARM)
+		return ..()
 	if(!isxenoqueen(xeno_attacker) && !isxenoshrike(xeno_attacker) && !isxenoking(xeno_attacker) && !(xeno_attacker.xeno_flags & XENO_LEADER))
 		balloon_alert(xeno_attacker, "must be leader")
 		return FALSE

--- a/code/modules/xenomorph/pherotower.dm
+++ b/code/modules/xenomorph/pherotower.dm
@@ -41,6 +41,8 @@
 
 // Clicking on the tower brings up a radial menu that allows you to select the type of pheromone that this tower will emit.
 /obj/structure/xeno/pherotower/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	var/phero_choice = show_radial_menu(xeno_attacker, src, GLOB.pheromone_images_list, radius = 35, require_near = TRUE)
 
 	if(!phero_choice)

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -11,7 +11,7 @@
 	pixel_x = -32
 	pixel_y = -24
 	max_integrity = 1000
-	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | PLASMACUTTER_IMMUNE
+	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | PLASMACUTTER_IMMUNE | XENO_DAMAGEABLE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS|XENO_STRUCT_DAMAGE_ALERT
 	///How many larva points one silo produce in one minute
 	var/larva_spawn_rate = 0.5

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -30,9 +30,8 @@
 
 /obj/structure/xeno/silo/LateInitialize()
 	. = ..()
-	var/siloprefix = GLOB.hive_datums[hivenumber].name
 	number_silo = length(GLOB.xeno_resin_silos_by_hive[hivenumber]) + 1
-	name = "[siloprefix == "Normal" ? "" : "[siloprefix] "][name] [number_silo]"
+	name = "[name] [number_silo]"
 	LAZYADDASSOC(GLOB.xeno_resin_silos_by_hive, hivenumber, src)
 
 	if(!locate(/obj/alien/weeds) in loc)

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -11,7 +11,7 @@
 	pixel_x = -32
 	pixel_y = -24
 	max_integrity = 500
-	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
+	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | XENO_DAMAGEABLE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS|XENO_STRUCT_DAMAGE_ALERT
 	var/linked_minions = list()
 

--- a/code/modules/xenomorph/trap.dm
+++ b/code/modules/xenomorph/trap.dm
@@ -106,7 +106,7 @@
 	SIGNAL_HANDLER
 	if(!trap_type)
 		return
-	if(AM && (hivenumber == AM.get_xeno_hivenumber()))
+	if(issamexenohive(AM))
 		return
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 	if(iscarbon(AM))
@@ -150,6 +150,8 @@
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE
 
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	if(xeno_attacker.a_intent == INTENT_HARM)
 		return ..()
 	if(trap_type == TRAP_HUGGER)
@@ -196,7 +198,7 @@
 		balloon_alert(user, "Already occupied")
 		return
 
-	if(FH.stat == DEAD)
+	if(FH.stat == DEAD || !issamexenohive(FH))
 		balloon_alert(user, "Cannot insert facehugger")
 		return
 

--- a/code/modules/xenomorph/tunnel.dm
+++ b/code/modules/xenomorph/tunnel.dm
@@ -11,7 +11,7 @@ TUNNEL
 	density = FALSE
 	opacity = FALSE
 	anchored = TRUE
-	resistance_flags = UNACIDABLE|BANISH_IMMUNE
+	resistance_flags = UNACIDABLE|BANISH_IMMUNE|XENO_DAMAGEABLE
 	layer = RESIN_STRUCTURE_LAYER
 
 	max_integrity = 140
@@ -79,6 +79,9 @@ TUNNEL
 /obj/structure/xeno/tunnel/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(!istype(xeno_attacker) || xeno_attacker.stat || xeno_attacker.lying_angle || xeno_attacker.status_flags & INCORPOREAL)
 		return
+	
+	if(!(issamexenohive(xeno_attacker)))
+		return ..()
 
 	if(xeno_attacker.a_intent == INTENT_HARM && xeno_attacker == creator)
 		balloon_alert(xeno_attacker, "Filling in tunnel...")

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -230,7 +230,6 @@
 	if(istype(ammo, /datum/ammo/xeno/hugger))
 		var/datum/ammo/xeno/hugger/hugger_ammo = ammo
 		newshot.color = initial(hugger_ammo.hugger_type.color)
-		hugger_ammo.hivenumber = hivenumber
 	firing = TRUE
 	update_minimap_icon()
 

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -10,7 +10,7 @@
 	max_integrity = 1500
 	layer = ABOVE_MOB_LAYER
 	density = TRUE
-	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE |PORTAL_IMMUNE
+	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE |PORTAL_IMMUNE|XENO_DAMAGEABLE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|HAS_OVERLAY
 	allow_pass_flags = PASS_AIR|PASS_THROW
 	///What kind of spit it uses
@@ -195,14 +195,17 @@
 ///Return TRUE if a possible target is near
 /obj/structure/xeno/xeno_turret/proc/scan()
 	potential_hostiles.Cut()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
 	for (var/mob/living/carbon/human/nearby_human AS in cheap_get_humans_near(src, TURRET_SCAN_RANGE))
 		if(nearby_human.stat == DEAD)
 			continue
-		if(nearby_human.get_xeno_hivenumber() == hivenumber)
+		if(issamexenohive(nearby_human))
+			continue
+		if(nearby_human.faction in hive?.allied_factions)
 			continue
 		potential_hostiles += nearby_human
 	for (var/mob/living/carbon/xenomorph/nearby_xeno AS in cheap_get_xenos_near(src, range))
-		if(GLOB.hive_datums[hivenumber] == nearby_xeno.hive)
+		if(issamexenohive(nearby_xeno))
 			continue
 		if(nearby_xeno.stat == DEAD)
 			continue
@@ -212,6 +215,8 @@
 			potential_hostiles += vehicle
 	for(var/obj/vehicle/sealed/mecha/mech AS in GLOB.mechas_list)
 		if(mech.z == z && get_dist(mech, src) <= range)
+			if(mech.faction in hive?.allied_factions)
+				continue
 			potential_hostiles += mech
 
 ///Signal handler to make the turret shoot at its target

--- a/code/modules/xenomorph/xenoplant.dm
+++ b/code/modules/xenomorph/xenoplant.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!mature && isxeno(user))
+	if(!mature && issamexenohive(user))
 		balloon_alert(user, "Not fully grown")
 		return FALSE
 
@@ -49,6 +49,9 @@
 /obj/structure/xeno/plant/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if((xeno_attacker.status_flags & INCORPOREAL))
 		return FALSE
+
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 
 	if(xeno_attacker.a_intent == INTENT_HARM && isxenodrone(xeno_attacker))
 		balloon_alert(xeno_attacker, "Uprooted the plant")
@@ -225,7 +228,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(ishuman(user))
+	if(ishuman(user) && !issamexenohive(user))
 		balloon_alert(user, "Nothing happens")
 		to_chat(user, span_notice("You caress [src]'s petals, nothing happens."))
 		return FALSE

--- a/code/modules/xenomorph/xenotowers.dm
+++ b/code/modules/xenomorph/xenotowers.dm
@@ -92,6 +92,8 @@
 			take_damage(100, BRUTE, BOMB)
 
 /obj/structure/xeno/lighttower/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+	if(!(issamexenohive(X)))
+		return ..()
 	if(X.a_intent == INTENT_HARM) //If we're a builder caste or the creator and we're on harm intent, deconstruct it.
 		balloon_alert(X, "Removing...")
 		if(!do_after(X, XENO_ACID_WELL_FILL_TIME, IGNORE_HELD_ITEM, src, BUSY_ICON_HOSTILE))
@@ -100,3 +102,4 @@
 		playsound(src, "alien_resin_break", 25)
 		deconstruct(TRUE, X)
 		return
+	return ..()


### PR DESCRIPTION
## About The Pull Request
[Do not merge, work in progress] Posting since there was interest in collaborating.
-Makes pretty much all xeno structures come in distinct versions for each hive, colored with that hives color.  Also makes them slashable by other hives.  
-Makes doors, walls, turrets, acid wells, sticky resin, etc  harder to bypass for xenos of other hives.  
-Prevents xenos from using melee weapons.
-Allows human factions to sell resin jelly of non-allied hives.
TODO: Needs a way for xenos to destroy their own structures without melee weapons, that doesn't make them do it all the time by accident.

## Why It's Good For The Game
TODO
## Changelog
:cl:
TODO
/:cl:
