### PR TITLE
Improves Queen Screech visuals, refactors it

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -301,12 +301,14 @@ GLOBAL_LIST_EMPTY(blood_particles)
 	pixel_x = -496
 	pixel_y = -496
 
-/obj/effect/temp_visual/shockwave/Initialize(mapload, radius)
+/obj/effect/temp_visual/shockwave/Initialize(mapload, radius, direction, speed_rate=1, easing_type = LINEAR_EASING, y_offset=0, x_offset=0)
 	. = ..()
+	pixel_x += x_offset
+	pixel_y += y_offset
 	deltimer(timerid)
-	timerid = QDEL_IN_STOPPABLE(src, 0.5 * radius)
+	timerid = QDEL_IN_STOPPABLE(src, 0.5 * radius * speed_rate)
 	transform = matrix().Scale(32 / 1024, 32 / 1024)
-	animate(src, time = 1/2 * radius, transform=matrix().Scale((32 / 1024) * radius * 1.5, (32 / 1024) * radius * 1.5))
+	animate(src, time = 1/2 * radius * speed_rate, transform=matrix().Scale((32 / 1024) * radius * 1.5, (32 / 1024) * radius * 1.5), easing=easing_type)
 
 /obj/effect/temp_visual/dir_setting/water_splash
 	icon = 'icons/effects/effects.dmi'

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -370,8 +370,8 @@ Contains most of the procs that are called when a mob is attacked by something
 		if(access_tag in C.access)
 			return TRUE
 
-/mob/living/carbon/human/screech_act(mob/living/carbon/xenomorph/queen/Q, screech_range = WORLD_VIEW, within_sight = TRUE)
-	var/dist_pct = get_dist(src, Q) / screech_range
+/mob/living/carbon/human/screech_act(distance, screech_range = WORLD_VIEW_NUM, within_sight = TRUE)
+	var/dist_pct = distance / screech_range
 
 	// Intensity is reduced by a 80% if you can't see the queen. Hold orders will reduce by an extra 10% per rank.
 	var/reduce_within_sight = within_sight ? 1 : 0.2

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -749,7 +749,7 @@
 			pixel_x += 19
 			pixel_y -= 12
 
-/obj/effect/temp_visual/shockwave/enhanced/Initialize(mapload, radius, direction)
+/obj/effect/temp_visual/shockwave/enhanced/Initialize(mapload, radius, direction, speed_rate=1, easing_type = LINEAR_EASING, y_offset=0, x_offset=0)
 	. = ..()
 	switch(direction)
 		if(NORTH)
@@ -892,7 +892,7 @@
 	rotation = 0
 	spin = generator(GEN_NUM, 5, 20)
 
-/obj/effect/temp_visual/shockwave/primal_wrath/Initialize(mapload, radius, direction)
+/obj/effect/temp_visual/shockwave/primal_wrath/Initialize(mapload, radius, direction, speed_rate=1, easing_type = LINEAR_EASING, y_offset=0, x_offset=0)
 	. = ..()
 	switch(direction)
 		if(NORTH)

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -213,6 +213,8 @@
 	add_cooldown()
 	succeed_activate()
 
+#define SCREECH_RANGE WORLD_VIEW_NUM
+
 // ***************************************
 // *********** Screech
 // ***************************************
@@ -253,19 +255,22 @@
 			SSblackbox.record_feedback("tally", "round_statistics", 1, "queen_screech")
 			xeno_owner.create_shriekwave() // Adds the visual effect. Wom wom wom.
 
-			for(var/obj/vehicle/sealed/armored/tank AS in GLOB.tank_list)
-				if(get_dist(tank, xeno_owner) > WORLD_VIEW_NUM)
+			// If you're a hearer, you get effected more severely.
+			// Remember, your affected thing needs to be hearing sensitive
+			var/list/nearby_living = list()
+			for(var/atom/victim in get_hearers_in_LOS(SCREECH_RANGE, xeno_owner))
+				if(ismob(victim))
+					nearby_living += victim
 					continue
-				if(tank.z != owner.z)
-					continue
-				for(var/mob/living/living_victim AS in tank.occupants)
-					living_victim.screech_act(xeno_owner, WORLD_VIEW_NUM) // Todo: The effects of screech are weird due to relying on get_dist for a mob on a diff z-level.
+				if(isvehicle(victim))
+					var/obj/vehicle/sealed = victim
+					nearby_living += sealed.occupants
 
-			var/list/nearby_living = list() // If you're a hearer, you get effected more severely.
-			for(var/mob/living/living_victim in hearers(WORLD_VIEW, xeno_owner))
-				nearby_living.Add(living_victim)
-			for(var/mob/living/living_victim AS in cheap_get_living_near(xeno_owner, WORLD_VIEW_NUM))
-				living_victim.screech_act(xeno_owner, WORLD_VIEW_NUM, living_victim in nearby_living)
+			for(var/mob/living/living_victim AS in cheap_get_living_near(xeno_owner, SCREECH_RANGE))
+				living_victim.screech_act(get_dist(living_victim, xeno_owner), SCREECH_RANGE, living_victim in nearby_living)
+			for(var/obj/vehicle/sealed/vehicle in cheap_get_mechs_near(xeno_owner, SCREECH_RANGE)|cheap_get_tanks_near(xeno_owner, SCREECH_RANGE))
+				for(var/mob/living/living_victim AS in vehicle.occupants)
+					living_victim.screech_act(get_dist(vehicle, xeno_owner), SCREECH_RANGE, living_victim in nearby_living)
 		if("heal_screech")
 			succeed_activate()
 			add_cooldown(30 SECONDS)

--- a/code/modules/mob/living/carbon/xenomorph/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/update_icons.dm
@@ -74,6 +74,18 @@
 /mob/living/carbon/xenomorph/proc/create_shriekwave()
 	overlays_standing[SUIT_LAYER] = image("icon"='icons/Xeno/64x64_Xeno_overlays.dmi', "icon_state" = "shriek_waves") //Ehh, suit layer's not being used.
 	apply_temp_overlay(SUIT_LAYER, 3 SECONDS)
+	shriek_burst()
+	//decrease range cus they'll be probably mvoing around
+	addtimer(CALLBACK(src, PROC_REF(shriek_burst), -2), 8)
+	addtimer(CALLBACK(src, PROC_REF(shriek_burst), -4), 16)
+
+///executes a burst of shockwaves. quad ease out so it does dash too fast and insta dissapear. maybe should use it on explosions too
+/mob/living/carbon/xenomorph/proc/shriek_burst(range_diff=0)
+	new /obj/effect/temp_visual/shockwave(loc, (WORLD_VIEW_NUM*2)+range_diff, null, 0.5, QUAD_EASING|EASE_OUT)
+	sleep(2) // yes I use sleep and yes I think this tiny tick timers are a not worth it here
+	new /obj/effect/temp_visual/shockwave(loc, (WORLD_VIEW_NUM*2)+range_diff, null, 0.5, QUAD_EASING|EASE_OUT)
+	sleep(2)
+	new /obj/effect/temp_visual/shockwave(loc, (WORLD_VIEW_NUM*2)+range_diff, null, 0.5, QUAD_EASING|EASE_OUT)
 
 /mob/living/carbon/xenomorph/proc/create_stomp()
 	overlays_standing[SUIT_LAYER] = image("icon"='icons/Xeno/64x64_Xeno_overlays.dmi', "icon_state" = "stomp") //Ehh, suit layer's not being used.

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph_defense.dm
@@ -2,7 +2,7 @@
 Contains most of the procs that are called when a xeno is attacked by something
 */
 
-/mob/living/carbon/xenomorph/screech_act(mob/living/carbon/xenomorph/queen/Q)
+/mob/living/carbon/xenomorph/screech_act(distance, screech_range = WORLD_VIEW_NUM, within_sight = TRUE)
 	return
 
 /mob/living/carbon/xenomorph/has_smoke_protection()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -236,7 +236,7 @@
 
 //Mobs on Fire end
 // When they are affected by a queens screech
-/mob/living/proc/screech_act(mob/living/carbon/xenomorph/queen/Q)
+/mob/living/proc/screech_act(distance, screech_range = WORLD_VIEW_NUM, within_sight = TRUE)
 	shake_camera(src, 3 SECONDS, 1)
 
 /mob/living/effect_smoke(obj/effect/particle_effect/smoke/S)

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -226,7 +226,6 @@
 	hud_set_mecha_battery()
 	update_icon()
 
-	become_hearing_sensitive(trait_source = ROUNDSTART_TRAIT)
 	for(var/key in equip_by_category)
 		if(key == MECHA_L_ARM || key == MECHA_R_ARM)
 			var/path = equip_by_category[key]

--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -8,6 +8,10 @@
 	///Current owning faction
 	var/faction
 
+/obj/vehicle/sealed/Initialize(mapload)
+	. = ..()
+	become_hearing_sensitive(ROUNDSTART_TRAIT)
+
 /obj/vehicle/sealed/generate_actions()
 	. = ..()
 	initialize_passenger_action_type(/datum/action/vehicle/sealed/climb_out)


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/TerraGov-Marine-Corps/pull/17350, https://github.com/tgstation/TerraGov-Marine-Corps/pull/17398 and https://github.com/tgstation/TerraGov-Marine-Corps/pull/17599

Added queen visually warping shriek wave
https://streamable.com/vcwovd

Now screech:
Uses a range define
Uses spatial search instead of hearers
Works on mechs too now
Fixes get dist todo crap
Fixes the in vision range stuff not applying to vehicles
Fixes args not being the same
Fixes the default arg runtiming the proc

## Why It's Good For The Game

It looks badass

## Changelog

:cl:
add: Added queen visually warping shriek wave
refactor: Screech_act refactored, performance improved
fix: Screech now calculates distance from queen for effect correctly instead of just applying the minimum for mech/tank/apc
fix: Screech now considers vehicles for line of sight calculations for screech effects
/:cl:
