### PR TITLE
Gives PTRS to the martians

### DIFF
--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -160,6 +160,8 @@
 			/obj/item/ammo_magazine/rocket/som/thermobaric = 8,
 			/obj/item/ammo_magazine/rocket/som/rad = 6,
 			/obj/item/weapon/gun/flamer/som = 4,
+			/obj/item/weapon/gun/clf_heavyrifle = 3,
+			/obj/item/shotgunbox/clf_heavyrifle = -1,
 		),
 		"Heavy Weapons" = list(
 			/obj/structure/closet/crate/mortar_ammo/mortar_kit = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

3x PRTS rifles for the sommites
And unlimited ammo.

## Why It's Good For The Game

Spare the poor martians. They have it bad enough! Let them have some semi-unique weapons to match their style.

## Changelog

:cl:
balance: Sons of Mars now have access to the PTRS rifle.
/:cl:
