### PR TITLE
SOM FC and CMDR loadout tweaks

### DIFF
--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -50,6 +50,7 @@ Godspeed, commander! And remember, you are not above the law."})
 	name = SOM_COMMANDER
 	jobtype = /datum/job/som/command/commander
 
+	wear_suit = /obj/item/clothing/suit/modular/som/heavy/leader/officer
 	id = /obj/item/card/id/gold
 	ears = /obj/item/radio/headset/mainship/mcom/som
 	belt = /obj/item/storage/holster/belt/mateba/officer/full
@@ -146,7 +147,7 @@ Make the SOM proud!"})
 	shoes = /obj/item/clothing/shoes/marine/som/knife
 	r_store = /obj/item/storage/pouch/general/large/command
 	gloves = /obj/item/clothing/gloves/marine/officer
-	belt = /obj/item/storage/holster/belt/pistol/m4a3/fieldcommander
+	belt = /obj/item/storage/holster/belt/mateba/officer/full
 	glasses = /obj/item/clothing/glasses/hud/health
 	l_store = /obj/item/storage/pouch/grenade/som/combat_patrol
 	back = /obj/item/storage/backpack/satchel/som


### PR DESCRIPTION

## About The Pull Request

Giving SOM FC their deserved mateba belt
Giving SOM CMDR their deserved gorgon armor
The explanation as to why is below.


## Why It's Good For The Game

FC's M1911/M4A3 is dope. The only problem is they are mostly fighting HvH against knockdown meta. Vanguards and NT FCs have matebas. I believe leveling their playing field will only be fair!

Regarding the CMDR and their Gorgon armor: I understand that commanders are designed to act as backline officers, not to fight on the frontlines. However, we are almost always low pop, and sommites are always understaffed. I can't remember the last time we saw both the commander and the field commander present on the martian side.
I'm sure it will have virtually no impact on the balance and any SOM vs NTC fights. But, it will make SOM CMDR's life a wee bit better. 

## Changelog

:cl:
balance: SOM FC got a roundstart mateba; SOM CMDR a roundstart gorgon armor.
/:cl:
