### PR TITLE
RIghting a gross injustice: updating corpsman and vanguard skillset

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -311,8 +311,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 /datum/skills/combat_medic
 	name = SQUAD_CORPSMAN
 	leadership = SKILL_LEAD_BEGINNER
-	medical = SKILL_MEDICAL_PRACTICED
-	surgery = SKILL_SURGERY_TRAINED
+	medical = SKILL_MEDICAL_COMPETENT
+	surgery = SKILL_SURGERY_PROFESSIONAL
 
 /datum/skills/combat_medic/crafty
 	name = "Crafty Combat Medic"
@@ -643,8 +643,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	unarmed = SKILL_UNARMED_MASTER
 	construction = SKILL_CONSTRUCTION_PLASTEEL
 	engineer = SKILL_ENGINEER_ENGI
-	medical = SKILL_MEDICAL_COMPETENT
-	surgery = SKILL_SURGERY_TRAINED
+	medical = SKILL_MEDICAL_PRACTICED
+	surgery = SKILL_SURGERY_DEFAULT
 	leadership = SKILL_LEAD_EXPERT
 	police = SKILL_POLICE_MP
 	stamina = SKILL_STAMINA_TRAINED

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -641,8 +641,8 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 /datum/skills/specialist/vanguard
 	name = VANGUARD
 	unarmed = SKILL_UNARMED_MASTER
-	construction = SKILL_CONSTRUCTION_PLASTEEL
-	engineer = SKILL_ENGINEER_ENGI
+	construction = SKILL_MEDICAL_UNTRAINED
+	engineer = SKILL_ENGINEER_DEFAULT
 	medical = SKILL_MEDICAL_PRACTICED
 	surgery = SKILL_SURGERY_DEFAULT
 	leadership = SKILL_LEAD_EXPERT


### PR DESCRIPTION
## About The Pull Request

Buffing NTC corpsman skillset, nerfing vanguard's surgery and med skills

## Why It's Good For The Game

Vanguards really do not need med/surgery skills aside from `SKILL_MEDICAL_PRACTICED`, on par with FC's and SO's skill set.
After all, what the vanguards need is the ability to quickly scan an officer's health, inject a couple of drugs to stabilize the body to get them to the medical bay. They don't need a skill set that allows them to operate on the VIP themselves.

Removed Vanguard's proficiency in construction and engineering. They do not need it.

Buffed corpsman skill set to 
```
	medical = SKILL_MEDICAL_COMPETENT
	surgery = SKILL_SURGERY_PROFESSIONAL
```
NTC gets synths/doctors basically never. Your typical round sees one, maybe two corpsman characters - one of whom is definitely busy scening somewhere. 

## Changelog

:cl:
balance: Vanguards got their med & med&surgery skills lowered. 
balance: Corpsman skill set was buffed in terms of their medical and surgical proficiencies.
/:cl:
