### PR TITLE
Xenolinguistic Translator Move

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -1001,6 +1001,7 @@
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 50,
 		),
 		"Misc" = list(
+			/obj/item/tool/research/xeno_analyzer = 4,
 			/obj/item/defibrillator = 8,
 			/obj/item/healthanalyzer = 16,
 			/obj/item/bodybag/cryobag = 24,

--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -440,6 +440,7 @@
 			/obj/item/stack/medical/heal_pack/advanced/burn_pack = 50,
 		),
 		"Misc" = list(
+			/obj/item/tool/research/xeno_analyzer = 4,
 			/obj/item/defibrillator = 8,
 			/obj/item/healthanalyzer = 16,
 			/obj/item/bodybag/cryobag = 24,

--- a/code/game/objects/machinery/vending/vending_types.dm
+++ b/code/game/objects/machinery/vending/vending_types.dm
@@ -213,7 +213,6 @@
 			/obj/item/storage/reagent_tank/bktt = 1,
 		),
 		"Misc" = list(
-			/obj/item/tool/research/xeno_analyzer = 2,
 //			/obj/item/tool/research/xeno_probe = -1,
 			/obj/item/tool/research/excavation_tool = -1,
 			/obj/item/storage/pouch/surgery = -1,


### PR DESCRIPTION
## About The Pull Request

Removes Xenolinguistic Translator from NovaMed Vendor (Advanced Medical Vendor)
Adds Xenolinguistic Translator to MarineMed & SyndiMed Vendor 
Increased amount of Xenolinguistic Translators from 2 to 4

## Why It's Good For The Game

The Xenolinguistic Translators are nice, allows you to have a conversation with multiple xenos a little more easily without the constant need for psychic whispers, and the fact that they're both locked to chem/medical access and limited to only two doesn't seem to match their value (or lack thereof)

It's not a medical item, so shouldn't be gated behind medical access and it doesn't give any real advantage besides potentially being able to listen to xeno chatter if you're near enough. 

I've used these a lot for roleplay value and it's irritating to see them sitting in the vendor that most marine roles can't access outside of either being a medic or having snowflake access (Specialist, Vanguard, etc)

:cl:
balance: Upped amount of Xenolinguistic Translators in vendor from 2 to 4
balance: Moved Xenolinguistic Translators from NovaMed to Marinemed Vendor (And SOM equivalent)
/:cl:
