### PR TITLE
Save our Flavors or tgui-core sucks

### DIFF
--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -637,13 +637,15 @@
 			exploit_record = new_record
 
 		if("flavor_text")
-			var/new_record = trim(html_encode(params["characterDesc"]), MAX_MESSAGE_LEN)
+			var/new_record = input(user, "Enter your character's flavor text.", "Flavor text", flavor_text) as null|message
+			new_record = trim(html_encode(new_record), MAX_MESSAGE_LEN)
 			if(!new_record)
 				return
 			flavor_text = new_record
 
 		if("xeno_desc")
-			var/new_record = trim(html_encode(params["xenoDesc"]), MAX_MESSAGE_LEN)
+			var/new_record = input(user, "Enter your character's flavor text.", "Flavor text", xeno_desc) as null|message
+			new_record = trim(html_encode(new_record), MAX_MESSAGE_LEN)
 			if(!new_record)
 				return
 			xeno_desc = new_record

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/BackgroundInformation.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/BackgroundInformation.tsx
@@ -29,53 +29,27 @@ export const BackgroundInformation = (props) => {
       <Section
         title="Character Description"
         buttons={
-          <Box>
-            <Button
-              icon="save"
-              disabled={characterDesc === flavor_text}
-              onClick={() => act('flavor_text', { characterDesc })}
-            >
-              Save
-            </Button>
-            <Button icon="times" onClick={() => setCharacterDesc(flavor_text)}>
-              Reset
-            </Button>
-          </Box>
+          <Button
+            fluid
+            icon="wrench"
+            onClick={() => act('flavor_text', { characterDesc })}
+          >
+            Edit
+          </Button>
         }
-      >
-        <TextArea
-          key="character"
-          height="200px"
-          maxLength={12000}
-          value={characterDesc}
-          onChange={(e, value) => setCharacterDesc(value)}
-        />
-      </Section>
+      />
       <Section
         title="Xenomorph Description"
         buttons={
-          <Box>
-            <Button
-              icon="save"
-              disabled={xenoDesc === xeno_desc}
-              onClick={() => act('xeno_desc', { xenoDesc })}
-            >
-              Save
-            </Button>
-            <Button icon="times" onClick={() => setXenoDesc(xeno_desc)}>
-              Reset
-            </Button>
-          </Box>
+          <Button
+            fluid
+            icon="wrench"
+            onClick={() => act('xeno_desc', { xenoDesc })}
+          >
+            Edit
+          </Button>
         }
-      >
-        <TextArea
-          key="xeno"
-          height="200px"
-          maxLength={12000}
-          value={xenoDesc}
-          onChange={(e, value) => setXenoDesc(value)}
-        />
-      </Section>
+      />
 
       <Stack>
         <Stack.Item grow>


### PR DESCRIPTION

## About The Pull Request

TextArea component in TGUI seems to suck. I do not know what's wrong, but it keeps shitting itself all the time I'm trying to write a long flavor (200+ chars).

I have no clue whatsoever regarding what is wrong with TextArea. Maybe we just need to update our tgui-core dependency. Maybe this is a bug with tgui-core itself. Maybe our implementation is wrong. 
I do not have enough knowledge to fix it. 
For now - enjoy this abomination that opens BYOND native input window.

![image](https://github.com/user-attachments/assets/24a4af84-d633-4cdf-90a8-441fd649af6a)


@Meghan-Rossi IDK what's wrong, before merging - can you please confirm by feeding a particularly long flavor that this is not an issue with my local machine (I've flushed BYOND and IE cache but to no avail)