### PR TITLE
Weapon Rebalance: Part 1

### DIFF
--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -711,7 +711,7 @@
 	damage = 40
 	max_range = 14
 	penetration = 5
-	shell_speed = 1.5
+	shell_speed = 2
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_INCENDIARY|AMMO_TARGET_TURF
 	bullet_color = LIGHT_COLOR_ELECTRIC_GREEN
 

--- a/code/modules/projectiles/ammo_types/microrail_ammo.dm
+++ b/code/modules/projectiles/ammo_types/microrail_ammo.dm
@@ -9,7 +9,7 @@
 	hud_state_empty = "grenade_empty_flash"
 	handful_icon_state = "micro_grenade_airburst"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	shell_speed = 2
+	shell_speed = 2.5
 	handful_amount = 3
 	max_range = 3 //failure to detonate if the target is too close
 	damage = 15
@@ -80,7 +80,7 @@
 	sundering = 3
 	damage_falloff = 1
 	max_range = 7
-	shell_speed = 3
+	shell_speed = 3.5
 
 /datum/ammo/bullet/micro_rail_spread/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, stagger = 1 SECONDS, slowdown = 0.5)
@@ -113,7 +113,7 @@
 	sound_armor = SFX_BALLISTIC_ARMOR
 	sound_miss = SFX_BALLISTIC_MISS
 	sound_bounce = SFX_BALLISTIC_BOUNCE
-	shell_speed = 2
+	shell_speed = 2.5
 	damage = 5
 	accuracy = -60 //stop you from just emptying all the bomblets into one guys face for big damage
 	shrapnel_chance = 0
@@ -176,7 +176,7 @@
 	sound_armor = SFX_BALLISTIC_ARMOR
 	sound_miss = SFX_BALLISTIC_MISS
 	sound_bounce = SFX_BALLISTIC_BOUNCE
-	shell_speed = 2
+	shell_speed = 2.5
 	damage = 5
 	shrapnel_chance = 0
 	max_range = 6

--- a/code/modules/projectiles/ammo_types/pistol_ammo.dm
+++ b/code/modules/projectiles/ammo_types/pistol_ammo.dm
@@ -9,6 +9,7 @@
 	hud_state = "pistol"
 	hud_state_empty = "pistol_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
+	shell_speed = 3.5
 	damage = 20
 	penetration = 5
 	accurate_range = 5

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -10,6 +10,7 @@
 	hud_state_empty = "revolver_empty"
 	handful_amount = 7
 	ammo_behavior_flags = AMMO_BALLISTIC
+	shell_speed = 3.5
 	damage = 45
 	penetration = 10
 	sundering = 3

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -11,6 +11,7 @@
 	hud_state_empty = "rifle_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 12
+	shell_speed = 3.5
 	damage = 25
 	penetration = 5
 	sundering = 0.5
@@ -30,6 +31,7 @@
 /datum/ammo/bullet/rifle/hv
 	name = "high-velocity rifle bullet"
 	hud_state = "hivelo"
+	shell_speed = 3.5
 	damage = 20
 	penetration = 20
 	sundering = 0.5
@@ -42,6 +44,7 @@
 /datum/ammo/bullet/rifle/heavy
 	name = "heavy rifle bullet"
 	hud_state = "rifle_heavy"
+	shell_speed = 3.5
 	damage = 30
 	penetration = 10
 	sundering = 1.25
@@ -54,6 +57,7 @@
 /datum/ammo/bullet/rifle/repeater
 	name = "heavy impact rifle bullet"
 	hud_state = "sniper"
+	shell_speed = 3.5
 	damage = 70
 	penetration = 20
 	sundering = 1.25

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -31,7 +31,6 @@
 /datum/ammo/bullet/rifle/hv
 	name = "high-velocity rifle bullet"
 	hud_state = "hivelo"
-	shell_speed = 3.5
 	damage = 20
 	penetration = 20
 	sundering = 0.5
@@ -44,7 +43,6 @@
 /datum/ammo/bullet/rifle/heavy
 	name = "heavy rifle bullet"
 	hud_state = "rifle_heavy"
-	shell_speed = 3.5
 	damage = 30
 	penetration = 10
 	sundering = 1.25
@@ -57,7 +55,6 @@
 /datum/ammo/bullet/rifle/repeater
 	name = "heavy impact rifle bullet"
 	hud_state = "sniper"
-	shell_speed = 3.5
 	damage = 70
 	penetration = 20
 	sundering = 1.25
@@ -183,6 +180,7 @@
 	damage_falloff = 0.5
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accurate_range = 25
+	shell_speed = 4
 	max_range = 40
 	damage = 65
 	penetration = 17.5

--- a/code/modules/projectiles/ammo_types/rifle_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rifle_ammo.dm
@@ -199,6 +199,7 @@
 	hud_state_empty = "hivelo_empty"
 	ammo_behavior_flags = AMMO_BALLISTIC
 	penetration = 15
+	shell_speed = 4
 	damage = 32.5
 	sundering = 1.25
 

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -6,7 +6,7 @@
 
 /datum/ammo/bullet/shotgun
 	hud_state_empty = "shotgun_empty"
-	shell_speed = 2
+	shell_speed = 2.5
 	handful_amount = 5
 
 
@@ -15,7 +15,7 @@
 	handful_icon_state = "shotgun_slug"
 	hud_state = "shotgun_slug"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	shell_speed = 3
+	shell_speed = 3.5
 	max_range = 15
 	damage = 100
 	penetration = 20
@@ -31,6 +31,7 @@
 	icon_state = "beanbag"
 	hud_state = "shotgun_beanbag"
 	ammo_behavior_flags = AMMO_BALLISTIC
+	shell_speed = 3.5
 	damage = 15
 	max_range = 15
 	shrapnel_chance = 0
@@ -45,6 +46,7 @@
 	hud_state = "shotgun_fire"
 	damage_type = BRUTE
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY
+	shell_speed = 3.5
 	max_range = 15
 	damage = 70
 	penetration = 15
@@ -259,7 +261,7 @@
 	name = "shotgun slug"
 	handful_icon_state = "shotgun_slug"
 	hud_state = "shotgun_slug"
-	shell_speed = 3
+	shell_speed = 3.5
 	max_range = 15
 	damage = 40
 	penetration = 20
@@ -290,7 +292,7 @@
 	handful_icon_state = "shotgun_slug"
 	hud_state = "shotgun_slug"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	shell_speed = 3
+	shell_speed = 3.5
 	max_range = 15
 	damage = 60
 	penetration = 30

--- a/code/modules/projectiles/ammo_types/smg_ammo.dm
+++ b/code/modules/projectiles/ammo_types/smg_ammo.dm
@@ -11,6 +11,7 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	accuracy_var_low = 7
 	accuracy_var_high = 7
+	shell_speed = 3.5
 	damage = 20
 	accurate_range = 4
 	damage_falloff = 1

--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -12,7 +12,7 @@
 	damage_falloff = 0
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_SNIPER
 	accurate_range_min = 7
-	shell_speed = 4
+	shell_speed = 4.5
 	accurate_range = 30
 	max_range = 50
 	damage = 90

--- a/code/modules/projectiles/ammo_types/tx54_ammo.dm
+++ b/code/modules/projectiles/ammo_types/tx54_ammo.dm
@@ -16,7 +16,7 @@
 	ammo_behavior_flags = AMMO_TARGET_TURF|AMMO_SNIPER
 	armor_type = BOMB
 	damage_falloff = 0.5
-	shell_speed = 2
+	shell_speed = 2.5
 	accurate_range = 12
 	max_range = 15
 	damage = 12			//impact damage from a grenade to the dome
@@ -133,7 +133,7 @@
 	accuracy_var_low = 5
 	accuracy_var_high = 5
 	max_range = 4
-	shell_speed = 3
+	shell_speed = 3.5
 	damage = 20
 	penetration = 20
 	sundering = 1.5

--- a/code/modules/projectiles/ammo_types/volkite_ammo.dm
+++ b/code/modules/projectiles/ammo_types/volkite_ammo.dm
@@ -14,7 +14,7 @@
 	armor_type = ENERGY
 	max_range = 14
 	accurate_range = 5 //for charger
-	shell_speed = 4
+	shell_speed = 4.5
 	accuracy_var_low = 5
 	accuracy_var_high = 5
 	accuracy = 5


### PR DESCRIPTION
## About The Weapon Rebalance Attempt

This PR is the first of a series of PRs that will be made in an attempt to overhaul HvH and HvX balance to better fit this server as opposed to the current tgmc values.
I have been asked to attempt a weapon rebalance for the majority of the servers firearms. This is due to a number of factors:

**Meta:** Predominantly there are a small pool of meta guns that see far more usage than most other weapons on server, these are predominantly shotguns, in which people utilise the impressive damage alongside the "knockdown" stun slugs provide in order to incapacitate a target. This rebalance project aims to bring other weapons up to par with the current meta, as opposed to simply nerfing the meta entirely. 

**Balance:** The server's balance is still rooted in TGMC, which causes issues for both HvH and HvX. On TGMC, Xenomorphs are usually balanced at 1 Xeno for every 5-6 Humans in a typical round, and conflict is usually around 8-12 Humans vs 2-4 Xenos. Xenomorphs are designed to be able to win almost every 1v1 conflict, to punish marine overextension. However on this server the population is typically 1 Xeno for every _2-3_ Humans, or even 1:1 if there's a particularly high Xeno presence, which poses obvious balance repercussions. 

**Feel:** A lot of weapon categories feel indistinct, a standout is SMGs and Sidearms. Currently there's little reason to take SMGs due to their poor performance versus rifles, without any real niche to justify carrying them instead. And sidearms suffer from poor damage output compared to their magazine size. Snipers and DMRs are likewise rarely picked due to the inability to hide behind a wall of allies and snipe. This series of PRs will attempt to expand on weapon categories and make them feel both more distinct, and more useable.

I'm in discussion with players from both the SOM and Xenomorph side of things in an attempt to keep things fair for all sides and ensure that both HvH and HvX balance is considered, rather than leaning too far towards any one aspect.

The _scope_ of these PRs is focused predominantly around **NTC & SOM Vendor Equipment** as ignoring specific outliers, I want to ensure that as many easily available vendor guns as possible feel fun to use and are effective in their roles. Once this is sorted out, other factions equipment (ICC/VSD) can be looked at, alongside things such as mechs, CAS and the like.

These PRs will be difficult to test before merge, whilst I can ensure that nothing is broken, blatantly overpowered or causes errors. I have no real way to test the effects of these changes on a fully fledged firefight locally, and as such (with the exception of part 1 and 1.5) I intend for these PRs to be merged in stages, allowing feedback to be given and changes made where necessary as opposed to changing everything at once and trying to work backwards from there should things still remain too weak, or end up too powerful.

Weapon Rebalance: Part 1 (Ballistics Speedup) **<- You Are Here**
Weapon Rebalance: Part 1.5 (Human Knockdown/Hardstun Removal)
Weapon Rebalance: Part 2 (Damage and Sunder Increases)
Weapon Rebalance: Part 3 (Damage Falloff Evaluation) 

## About This PR: Overview

This PR itself, aims to increase the speed of projectiles across the board. It should reduce the ability to strafe around and dodge rifles whilst making snipers less easy to bait. Has a knock on effect of making most weapons feel a little more accurate too.

All in all except for DMRs, pretty much every gun has gone up by 0.5 shell_speed
I've applied this to all the base ammotypes, so unless an ammotype already specifies a different shell_speed (some of the HV ones do) they should receive an increase.

Default bullets (/datum/ammo/bullet) were set at shell_speed 3 and this is what things like pistol, revolver and rifle rounds inherited from. I've left this at 3, but changed the specific ammo type datum (bullet/rifle, bullet/pistol, etc) to 3.5 instead.

This should effect NTC and SOM equally, unless certain weapons use a niche ammotype that's not grouped with the others, I think I've caught them all but please let me know if I've left anything out.

My main area for _concern_ with this change is barrel chargers as an attachment.
The barrel charger, gives a flat +200% (3x) to speed
The extended barrel, gives a flat +100% (2x) to speed

Previously with a barrel charger:
A rifle with 3 bullet speed would have had 9 
Now a rifle with 3.5 bullet speed has 10.5

A sniper with 4 bullet speed would have had 12
Now a sniper with 4.5 bullet speed has 13.5

## About This PR: Changes

Sweeping Changes:

Bullet speed for every gun using some variant of **/datum/ammo/bullet/rifle**
Examples: Rifles, Machineguns, Repeater, DMRs
Changed from **3** to **3.5**

Bullet speed for every gun using some variant of **/datum/ammo/bullet/smg** 
Examples: MP-19, SMG-90, SMG-45, V-21
Changed from **3** to **3.5**

Bullet speed for every gun using some variant of **/datum/ammo/bullet/pistol**
Examples: P-14, P-23, Desert Eagle
Changed from **3** to **3.5**

Bullet speed for every gun using some variant of **/datum/ammo/bullet/revolver**
Examples: R-44, Mateba, Magnum
Changed from **3** to **3.5**

Bullet speed for specific DMRs that still use **/datum/ammo/bullet/rifle**  (DMR-37 and BR-64)
Changed from **3** to **4**

Bullet speed for every gun using some variant of **/datum/ammo/bullet/sniper**
Examples: SR-127, SVD, Martini Henry
Changed from **4** to **4.5**

Bullet speed for every gun using some variant of **/datum/ammo/energy/volkite**
Examples: VX-42 Culverin, VX-33 Caliver
Changed from **4** to **4.5**

Bullet Speed for Shotgun Buckshot & Flechettes changed from **2** to **2.5** 
Bullet Speed for Shotgun Slugs changed from **3** to **3.5** (Includes slug variants such as incendiary and beanbag)
Examples: SH-35, SH-39, SH-15

**Individual Changes:**
MicroRail Grenade Speed changed from **2** to **2.5**
MicroRail Shrapnel Speed (Submunitions such as smoke, incendiary bomblets & shrap) changed from **3** to **3.5**
GL-54 Grenade Speed changed from **2** to **2.5**
GL-54 Shrapnel Speed  (Submunitions such as smoke, incendiary and normal shrap) changed from **3** to **3.5**
Plasma Pistol Projectile Speed changed from **1.5** to **2**


## About This PR: Issues

The only issue I've found during testing involves the GL-54 Airburst Grenade Launcher.

The GL-54s Grenade Launcher appears to have no main projectile icon when fired, only visible projectiles for submunitions. This does not occur on the "master" branch, _however_ when creating a new branch with no changes from the master branch, this issue occurs. Even though the code is identical. So I doubt this issue is related to the PR, but still something to keep an eye out for.

## Changelog

:cl:
balance: Overhauls bullet speed across the board, most bullets now have 0.5 higher shell_speed
/:cl:
