### PR TITLE
Weapon Rebalance: Part 1.5

### DIFF
--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -75,7 +75,7 @@
 
 /datum/ammo/bullet/revolver/t76/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0 SECONDS, knockback = 1)
+        staggerstun(target_mob, proj, weaken = 0, knockback = 1)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, knockback = 1)
 
@@ -90,7 +90,7 @@
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
+        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
 

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -74,7 +74,7 @@
 	sundering = 0.5
 
 /datum/ammo/bullet/revolver/t76/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 2 SECONDS, knockback = 1)
+	staggerstun(target_mob, proj, weaken = 0 SECONDS, knockback = 1)
 
 /datum/ammo/bullet/revolver/highimpact
 	name = "high-impact revolver bullet"
@@ -85,7 +85,7 @@
 	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
+	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/revolver/ricochet
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/small

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -71,10 +71,14 @@
 	handful_amount = 5
 	damage = 100
 	penetration = 40
-	sundering = 1
+	sundering = 0.5
 
 /datum/ammo/bullet/revolver/t76/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 0 SECONDS, knockback = 1)
+    if(ishuman(target_mob))
+        staggerstun(target_mob, proj, weaken = 0 SECONDS, knockback = 1)
+    else
+        staggerstun(target_mob, proj, weaken = 2 SECONDS, knockback = 1)
+
 
 /datum/ammo/bullet/revolver/highimpact
 	name = "high-impact revolver bullet"
@@ -82,10 +86,13 @@
 	handful_amount = 6
 	damage = 50
 	penetration = 20
-	sundering = 6
+	sundering = 3
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
+    if(ishuman(target_mob))
+        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
+    else
+        staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)
 
 /datum/ammo/bullet/revolver/ricochet
 	bonus_projectiles_type = /datum/ammo/bullet/revolver/small

--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -71,7 +71,7 @@
 	handful_amount = 5
 	damage = 100
 	penetration = 40
-	sundering = 0.5
+	sundering = 1
 
 /datum/ammo/bullet/revolver/t76/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 0 SECONDS, knockback = 1)
@@ -82,7 +82,7 @@
 	handful_amount = 6
 	damage = 50
 	penetration = 20
-	sundering = 3
+	sundering = 6
 
 /datum/ammo/bullet/revolver/highimpact/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, slowdown = 1, knockback = 1)

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -19,11 +19,13 @@
 	max_range = 15
 	damage = 100
 	penetration = 20
-	sundering = 12.5
+	sundering = 7.5
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
-
+    if(ishuman(target_mob))
+        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
+    else
+        staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
 /datum/ammo/bullet/shotgun/beanbag
 	name = "beanbag slug"
@@ -92,7 +94,10 @@
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+    if(ishuman(target_mob))
+        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+    else
+        staggerstun(target_mob, proj, weaken = 2, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/hefa_buckshot
 	name = "hefa fragment"
@@ -187,9 +192,10 @@
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
-
-
+    if(ishuman(target_mob))
+        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+    else
+        staggerstun(target_mob, proj, weaken = 2, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/shotgun/barrikada_slug
 	name = "heavy metal slug"
@@ -200,10 +206,13 @@
 	max_range = 15
 	damage = 130
 	penetration = 50
-	sundering = 25
+	sundering = 20
 
 /datum/ammo/bullet/shotgun/barrikada_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 0 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
+    if(ishuman(target_mob))
+        staggerstun(target_mob, proj, weaken = 0 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
+    else
+        staggerstun(target_mob, proj, weaken = 2 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
 
 /datum/ammo/bullet/shotgun/heavy_spread
 	name = "additional buckshot"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -23,7 +23,7 @@
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
+        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
@@ -95,9 +95,9 @@
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
     else
-        staggerstun(target_mob, proj, weaken = 2, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+        staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/hefa_buckshot
 	name = "hefa fragment"
@@ -193,9 +193,9 @@
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
     else
-        staggerstun(target_mob, proj, weaken = 2, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+        staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/shotgun/barrikada_slug
 	name = "heavy metal slug"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -22,7 +22,7 @@
 	sundering = 7.5
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
+	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
 
 /datum/ammo/bullet/shotgun/beanbag
@@ -92,7 +92,7 @@
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 /datum/ammo/bullet/hefa_buckshot
 	name = "hefa fragment"
@@ -187,7 +187,7 @@
 	damage_falloff = 4
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
 
 
@@ -203,7 +203,7 @@
 	sundering = 20
 
 /datum/ammo/bullet/shotgun/barrikada_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
-	staggerstun(target_mob, proj, weaken = 2 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
+	staggerstun(target_mob, proj, weaken = 0 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
 
 /datum/ammo/bullet/shotgun/heavy_spread
 	name = "additional buckshot"

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -23,7 +23,7 @@
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
+        staggerstun(target_mob, proj, weaken = 0 , stagger = 2 SECONDS, knockback = 1, slowdown = 2)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
 
@@ -95,7 +95,7 @@
 
 /datum/ammo/bullet/shotgun/buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
@@ -193,7 +193,7 @@
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
+        staggerstun(target_mob, proj, weaken = 0, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, stagger = 2 SECONDS, knockback = 2, slowdown = 0.5, max_range = 3)
 
@@ -210,7 +210,7 @@
 
 /datum/ammo/bullet/shotgun/barrikada_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
     if(ishuman(target_mob))
-        staggerstun(target_mob, proj, weaken = 0 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
+        staggerstun(target_mob, proj, weaken = 0, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
     else
         staggerstun(target_mob, proj, weaken = 2 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)
 

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -19,7 +19,7 @@
 	max_range = 15
 	damage = 100
 	penetration = 20
-	sundering = 7.5
+	sundering = 12.5
 
 /datum/ammo/bullet/shotgun/slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 0 SECONDS, stagger = 2 SECONDS, knockback = 1, slowdown = 2)
@@ -200,7 +200,7 @@
 	max_range = 15
 	damage = 130
 	penetration = 50
-	sundering = 20
+	sundering = 25
 
 /datum/ammo/bullet/shotgun/barrikada_slug/on_hit_mob(mob/target_mob, obj/projectile/proj)
 	staggerstun(target_mob, proj, weaken = 0 SECONDS, slowdown = 2, stagger = 3 SECONDS, knockback = 2)


### PR DESCRIPTION
## About The Weapon Rebalance Attempt

This PR is the second of a series of PRs that will be made in an attempt to overhaul HvH and HvX balance to better fit this server as opposed to the current tgmc values.
I have been asked to attempt a weapon rebalance for the majority of the servers firearms. This is due to a number of factors:

**Meta:** Predominantly there are a small pool of meta guns that see far more usage than most other weapons on server, these are predominantly shotguns, in which people utilise the impressive damage alongside the "knockdown" stun slugs provide in order to incapacitate a target. This rebalance project aims to bring other weapons up to par with the current meta, as opposed to simply nerfing the meta entirely. 

**Balance:** The server's balance is still rooted in TGMC, which causes issues for both HvH and HvX. On TGMC, Xenomorphs are usually balanced at 1 Xeno for every 5-6 Humans in a typical round, and conflict is usually around 8-12 Humans vs 2-4 Xenos. Xenomorphs are designed to be able to win almost every 1v1 conflict, to punish marine overextension. However on this server the population is typically 1 Xeno for every _2-3_ Humans, or even 1:1 if there's a particularly high Xeno presence, which poses obvious balance repercussions. 

**Feel:** A lot of weapon categories feel indistinct, a standout is SMGs and Sidearms. Currently there's little reason to take SMGs due to their poor performance versus rifles, without any real niche to justify carrying them instead. And sidearms suffer from poor damage output compared to their magazine size. Snipers and DMRs are likewise rarely picked due to the inability to hide behind a wall of allies and snipe. This series of PRs will attempt to expand on weapon categories and make them feel both more distinct, and more useable.

I'm in discussion with players from both the SOM and Xenomorph side of things in an attempt to keep things fair for all sides and ensure that both HvH and HvX balance is considered, rather than leaning too far towards any one aspect.

The _scope_ of these PRs is focused predominantly around **NTC & SOM Vendor Equipment** as ignoring specific outliers, I want to ensure that as many easily available vendor guns as possible feel fun to use and are effective in their roles. Once this is sorted out, other factions equipment (ICC/VSD) can be looked at, alongside things such as mechs, CAS and the like.

These PRs will be difficult to test before merge, whilst I can ensure that nothing is broken, blatantly overpowered or causes errors. I have no real way to test the effects of these changes on a fully fledged firefight locally, and as such (with the exception of part 1 and 1.5) I intend for these PRs to be merged in stages, allowing feedback to be given and changes made where necessary as opposed to changing everything at once and trying to work backwards from there should things still remain too weak, or end up too powerful.

Weapon Rebalance: Part 1 (Ballistics Speedup) 
Weapon Rebalance: Part 1.5 (Human Knockdown/Hardstun Removal) **<- You Are Here**
Weapon Rebalance: Part 2 (Damage and Sunder Increases)
Weapon Rebalance: Part 3 (Damage Falloff Evaluation) 

## About This PR: Overview

This PR is intended to be merged alongside #215 

This PR intends to remove the "knockdown" hardstun that occurs when players are shot with certain weapons, most notably shotgun slugs and the mateba. This has been achieved by removing the "weakness" effect that applies to humans when shot by these rounds, which resulted in a two second stun in which the victim was knocked to the ground and unable to move and interact.

These hardstuns promoted shotgun slug spam above all else, and is quite unsatisfying to play against, as if your opponent gets the first shot off, particularly with the pump action, and heavy pump action shotguns, you will usually end up stunlocked on the ground until dead.

This PR _keeps_ the weaken effect versus xenos however, as well as retaining the weaken effect versus humans for some niche weapons such as the railgun, where the reload speed and scarcity of ammunition prevents mindless knockdown spam.

## About This PR: Changes

Removes the ability of the Mateba revolver to apply weakness to human targets

Removes the ability of the R-76 KC Magnum Revolver to apply weakness to human targets

Removes the ability of 12 Gauge Buckshot & Slugs to apply weakness to human targets
Removes the ability of 6 Gauge Heavy Buckshot & Barrikada Slugs to apply weakness to human targets

## About This PR: Issues

None, PR runs fine and appears to work against human targets, whilst preserving the weakness effect versus xenomorph targets.

## Changelog

:cl:
balance: Removes "weakness" hardstun on humans from Mateba, R-76 Revolver, Buckshot and Shotgun Slugs
/:cl:
