### PR TITLE
Removes zombie crash from the pool of votable modes

### DIFF
--- a/config/modes.txt
+++ b/config/modes.txt
@@ -41,6 +41,7 @@ endmode
 
 mode Zombie Crash
 	requiredplayers 2
+	votable 0
 endmode
 
 mode Combat Patrol


### PR DESCRIPTION

## About The Pull Request

I'm just making it unvotable.

## Why It's Good For The Game

TL;DR - this mode is broken and does not match the preferences of our core audience.

## Changelog


:cl:
config: Zombie crash was disabled.
/:cl:
