### PR TITLE
Gives L-88 Assault Carbine their Magazines in SOM Vendor (+ Large General Pouches)

### DIFF
--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -615,6 +615,7 @@
 		"Pouches" = list(
 			/obj/item/storage/pouch/grenade/som = -1,
 			/obj/item/storage/pouch/general/som = -1,
+			/obj/item/storage/pouch/general/large/som = -1,
 			/obj/item/storage/pouch/magazine/large/som = -1,
 			/obj/item/storage/pouch/pistol/som = -1,
 			/obj/item/storage/pouch/shotgun/som = -1,

--- a/code/game/objects/machinery/vending/som_vending.dm
+++ b/code/game/objects/machinery/vending/som_vending.dm
@@ -31,7 +31,7 @@
 			/obj/item/ammo_magazine/rifle/icc_autoshotgun = -1,
 			/obj/item/ammo_magazine/rifle/icc_autoshotgun/frag = 15,
 			/obj/item/weapon/gun/rifle/icc_assaultcarbine = -1,
-			/obj/item/ammo_magazine/rifle/icc_battlecarbine = -1,
+			/obj/item/ammo_magazine/rifle/icc_assaultcarbine = -1,
 			/obj/item/ammo_magazine/rifle/som_big = -1,
 			/obj/item/ammo_magazine/rifle/som_big/incendiary = 10,
 			/obj/item/ammo_magazine/rifle/som_big/anti_armour = 10,


### PR DESCRIPTION
## About The Pull Request

SOM Vendor had the L-88 Assault Carbine but no Magazines in it.

The line for /obj/item/ammo_magazine/rifle/icc_battlecarbine was present twice, instead of the expected /obj/item/ammo_magazine/rifle/icc_assaultcarbine. This is presumed to be in error rather than having two magazines for the same gun. 

SOM were also missing the large variant of their general storage pouches, this has been rectified.

## Changelog

:cl:
fix: Adds the L-88 Assault Carbine mags to SOM vendor
add: Adds the large variant of the general pouch to SOM vendor
/:cl:
