### PR TITLE
Increases SOM Veteran Slots from 2 to 4

### DIFF
--- a/code/datums/gamemodes/secrets_of_life.dm
+++ b/code/datums/gamemodes/secrets_of_life.dm
@@ -71,7 +71,7 @@
 		/datum/job/som/squad/medic = 4,
 		/datum/job/som/squad/engineer = 4,
 		/datum/job/som/squad/leader = 4,
-		/datum/job/som/squad/veteran = 2,
+		/datum/job/som/squad/veteran = 4,
 		/datum/job/other/prisonersom = 2,
 		/datum/job/clf/breeder = 2,
 		/datum/job/clf/standard = 2,


### PR DESCRIPTION
## About The Pull Request

NTC has Four Squads: Alpha, Bravo, Charlie & Delta
NTC has Four Smartgunners, Four Specialists and Four Squad Leader Slots at maximum

SOM has Four Squads: Zulu, Yankee, Xray & Whiskey
SOM has Four Squad Leader Slots at maximum
SOM only has **Two** Veteran Slots at maximum

This PR gives SOM **Four** Veteran Slots at maximum. One for each Squad. 

This brings them in line closer to NTC, with four slots for their "special" role, like NTCs SGer and Spec.

## Changelog

:cl:
balance: Increases SOM Veteran slots from 2 to 4 maximum
/:cl:
