### PR TITLE
KZ Weapon Adjustments Part 2

### DIFF
--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -1158,6 +1158,6 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		)
 	attachable_allowed = list(/obj/item/attachable/flashlight, /obj/item/attachable/magnetic_harness)
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 19,"rail_x" = 13, "rail_y" = 22, "under_x" = 24, "under_y" = 14, "stock_x" = 24, "stock_y" = 12)
-	fire_delay = 1.5 SECONDS
+	fire_delay = 1 SECONDS
 	windup_delay = 0 SECONDS
 	aim_slowdown = 2.75

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -814,7 +814,6 @@
 /obj/item/ammo_magazine/rifle/vsd_carbine/extended
 	name = "\improper CC/77 extended magazine (10x24mm)"
 	icon_state = "c77_ext"
-	default_ammo = /datum/ammo/bullet/rifle
 	max_rounds = 48
 
 /obj/item/ammo_magazine/rifle/vsd_carbine/ap


### PR DESCRIPTION
## About The Pull Request

Replaces CC/77 ext_mag ammo_type and increases AT32 firerate

## Why It's Good For The Game

Those kinda make sense. Check previous weapon adjustment pr if you are looking for reasons of this pr

## Changelog

:cl:
balance: CC/77 Extended magazine now inherits default magazine ammotype
balance: AT32 Fire delay lowered
/:cl:
