### PR TITLE
KZ PDW Vendor Addition

### DIFF
--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -2929,6 +2929,10 @@
 			/obj/item/weapon/gun/rifle/type71 = -1,
 			/obj/item/ammo_magazine/rifle/type71 = -1,
 		),
+		"SMGs" = list(
+			/obj/item/weapon/gun/smg/vsd_pdw = -1,
+			/obj/item/ammo_magazine/smg/vsd_pdw = -1,
+		),
 		"Marksman" = list(
 			/obj/item/weapon/gun/rifle/vsd_rifle = -1,
 			/obj/item/ammo_magazine/rifle/vsd_rifle = -1,


### PR DESCRIPTION
Adds KZ (VSD) PDW to their vendors under a new SMG listing
## About The Pull Request

Adds the KZ PDW to their Vendor in infinite numbers with the proper ammo also added into the vendor under it's own category.

## Why It's Good For The Game

There was no reason for the SMG to not already be in the vendor as it was not special compared to any of the other weapons and KZ had absolutely no SMGs to pick from, this gives the KZ an additional option to choose from and also gives them at least one SMG to use too.

## Changelog
:cl:
add: KZ PDW to KZ Vendor
add: KZ PDW Magazine to KZ Vendor
