### PR TITLE
CC/104 Bugfix/Balance Buff

### DIFF
--- a/code/modules/projectiles/ammo_types/revolver_ammo.dm
+++ b/code/modules/projectiles/ammo_types/revolver_ammo.dm
@@ -65,18 +65,12 @@
 	name = "incendiary heavy revolver bullet"
 	ammo_behavior_flags = AMMO_INCENDIARY|AMMO_BALLISTIC
 	damage_type = BURN
-	damage_falloff = 0
-	accuracy = 15
-	accurate_range = 15
 	penetration = 15
 
 /datum/ammo/bullet/revolver/heavy/ap
 	name = "armor-piercing heavy revolver bullet"
-	damage_falloff = 0
-	accuracy = 15
-	accurate_range = 15
 	sundering = 5
-	penetration = 25
+	penetration = 15
 
 /datum/ammo/bullet/revolver/t76
 	name = "magnum bullet"


### PR DESCRIPTION
## About The Pull Request

CC/104 Incendinary cylinder had wrong bullet type resulting in inconsistency with damage. Since that bugfix indirectly buffs incendinary type now that damage has proper type, ap cylinder was buffed accordingly, now causing knockback on hit.

Lowered accuracy was removed from both cylinders since it didn't make much sense. Revolver already has a fire delay, even on single fire mode.

With other revolvers far more precise and doing more there was no point to use any other cylinder type other than incendinary. But since most of your shots would miss even if you landed your burst because of poor accuracy there was no point to use it still, the after recoil would make sure that you would never land a second burst, hooray screenshake and fire delay.

Also for some reason it didn't knockback who you shot before, but it might have been fixed or something.

Now you can actually feel the impact of that weapon. Want to light people on fire? Use incendinary cylinder. Want to really kill them? Ap cylinder is here for you.

## Why It's Good For The Game

If I had a R-44 Revolver in my vendor I would rather use it than CC/104, since it offers an actual option to both damage your opponent and disengage if needed and I'll rather not use luck based gun that CC/104 was.

## Changelog

:cl:
balance: Increased penetration of incend and ap
fix: Incendinary cylinder now uses proper burn damage type instead of brute
/:cl:
