### PR TITLE
Gets rid of pure yellow from KZ Ronin

### DIFF
--- a/ntf_modular/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/ntf_modular/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -127,6 +127,6 @@ warning: overcharging too much will result in an explosion, accumulated energy d
 	blocked_attack_types = list(BRUTE)
 	shield_color_low = COLOR_MAROON
 	shield_color_mid = COLOR_OLIVE
-	shield_color_full = COLOR_VIVID_YELLOW
+	shield_color_full = COLOR_LIGHT_ORANGE
 	shield_color_overmax_full = COLOR_VERY_SOFT_YELLOW
 	shield_color_overmax_full_danger = COLOR_BRIGHT_ORANGE


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

It's too pissy

## Changelog

:cl:
fix: Ronin is no more piss-colored
/:cl:
