### PR TITLE
Nerf constant xeno healing in XvX

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -248,6 +248,7 @@
 #define TRAIT_FAKEDEATH "fakedeath" //Makes the owner appear as dead to most forms of medical examination
 #define TRAIT_LEGLESS "legless" //Has lost all the appendages needed to stay standing up.
 #define TRAIT_NOPLASMAREGEN "noplasmaregen"//xeno plasma wont recharge
+#define TRAIT_NOHEALTHREGEN "nohealthregen" // xeno health wont regen
 #define TRAIT_UNDEFIBBABLE "undefibbable"//human can't be revived
 #define TRAIT_HOLLOW "hollowedout" //examine trait for puppeteer
 #define TRAIT_IMMEDIATE_DEFIB "immediate_defib"//immediately revives when defibbed, rather than just healing

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -8,9 +8,10 @@
 		changeNext_move(xeno_caste ? xeno_caste.attack_delay : CLICK_CD_MELEE)
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
-	if(isxeno(A && get_xeno_hivenumber(A) != get_xeno_hivenumber(src)))
+	if(isxeno(A))
 		var/mob/living/carbon/xenomorph/X = A
-		X.apply_status_effect(/datum/status_effect/nohealthregen, 10 SECONDS)
+		if(get_xeno_hivenumber() != X.get_xeno_hivenumber())
+			X.apply_status_effect(/datum/status_effect/nohealthregen, 10 SECONDS)
 
 	var/atom/S = A.handle_barriers(src)
 	S.attack_alien(src, xeno_caste.melee_damage * xeno_melee_damage_modifier, isrightclick = islist(modifiers) ? modifiers["right"] : FALSE)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -8,6 +8,9 @@
 		changeNext_move(xeno_caste ? xeno_caste.attack_delay : CLICK_CD_MELEE)
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
+	if(isxeno(A))
+		var/mob/living/carbon/xenomorph/X = A
+		X.apply_status_effect(/datum/status_effect/nohealthregen, 10 SECONDS)
 
 	var/atom/S = A.handle_barriers(src)
 	S.attack_alien(src, xeno_caste.melee_damage * xeno_melee_damage_modifier, isrightclick = islist(modifiers) ? modifiers["right"] : FALSE)

--- a/code/_onclick/xeno.dm
+++ b/code/_onclick/xeno.dm
@@ -8,7 +8,7 @@
 		changeNext_move(xeno_caste ? xeno_caste.attack_delay : CLICK_CD_MELEE)
 	if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED))
 		return
-	if(isxeno(A))
+	if(isxeno(A && get_xeno_hivenumber(A) != get_xeno_hivenumber(src)))
 		var/mob/living/carbon/xenomorph/X = A
 		X.apply_status_effect(/datum/status_effect/nohealthregen, 10 SECONDS)
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -930,6 +930,31 @@
 	duration = 15 SECONDS
 
 // ***************************************
+// *********** Xeno healing debuff
+// ***************************************
+/datum/status_effect/nohealthregen
+	id = "nohealthregen"
+	status_type = STATUS_EFFECT_REPLACE
+
+/datum/status_effect/nohealthregen/on_creation(mob/living/new_owner, set_duration)
+	if(isxeno(new_owner))
+		owner = new_owner
+		duration = set_duration
+		return ..()
+	else
+		CRASH("something applied nohealthregen on a nonxeno, dont do that")
+
+/datum/status_effect/nohealthregen/on_apply()
+	. = ..()
+	if(!.)
+		return
+	ADD_TRAIT(owner, TRAIT_NOHEALTHREGEN, TRAIT_STATUS_EFFECT(id))
+
+/datum/status_effect/nohealthregen/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_NOHEALTHREGEN, TRAIT_STATUS_EFFECT(id))
+	return ..()
+
+// ***************************************
 // *********** Acid Melting
 // ***************************************
 /datum/status_effect/stacking/melting_acid

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -606,7 +606,7 @@
 	SIGNAL_HANDLER
 
 	var/mob/living/carbon/xenomorph/X = owner
-	if(HAS_TRAIT(X,TRAIT_NOPLASMAREGEN)) //No bonus plasma if you're on a diet
+	if(HAS_TRAIT(X, TRAIT_NOPLASMAREGEN)) //No bonus plasma if you're on a diet
 		return
 	var/bonus_plasma = X.xeno_caste.plasma_gain * bonus_regen * (1 + X.recovery_aura * 0.05) * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD //Recovery aura multiplier; 5% bonus per full level
 	X.gain_plasma(bonus_plasma)
@@ -669,6 +669,9 @@
 ///Called when the target xeno regains HP via heal_wounds in life.dm
 /datum/status_effect/healing_infusion/proc/healing_infusion_regeneration(mob/living/carbon/xenomorph/patient, heal_data, seconds_per_tick)
 	SIGNAL_HANDLER
+
+	if(HAS_TRAIT(patient, TRAIT_NOHEALTHREGEN)) //No regen if you're on a diet
+		return
 
 	if(!health_ticks_remaining)
 		qdel(src)

--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -88,6 +88,8 @@
 		adjustBruteLoss(XENO_CRIT_DAMAGE * seconds_per_tick * XENO_PER_SECOND_LIFE_MOD)
 
 /mob/living/carbon/xenomorph/proc/heal_wounds(multiplier = XENO_RESTING_HEAL, scaling = FALSE, seconds_per_tick = 2)
+	if(HAS_TRAIT(src, TRAIT_NOHEALTHREGEN))
+		return
 	var/amount = 1 + (maxHealth * 0.0375) // 1 damage + 3.75% max health, with scaling power.
 	if(recovery_aura)
 		amount += recovery_aura * maxHealth * 0.01 // +1% max health per recovery level, up to +5%


### PR DESCRIPTION
## About The Pull Request

There will be a bit more PRs regarding XvX later on. This one aims to get rid of constant xeno healing, both in crit and fights. If you melee attack a different xeno they will be inflicted with a temporary 10 second debuff that prevents any kind of healing, be it via abilities or natural regen. Castes with high melee defense like Crusher and base King would be able to be killed still since castes with higher speed and range attacks would be able to constantly apply pressure. And other way around, ranged and fast castes would receive more damage since they have lower melee defense and would die faster. Theres also castes with lower slash delay like runner and hunter that can apply constant melee damage despite them not having access to any ranged harassment tools.

## Why It's Good For The Game

XvX is broken. As of now you can't kill a caste like King on weeds that uses recovery pheros as a xeno.  With some future adjustments XvX should become possible, and fair for both sides.

## Changelog

:cl:
add: Added TRAIT_NOHEALTHREGEN
add: Added nonstackable /datum/status_effect/nohealthregen that applies TRAIT_NOHEALTHREGEN for the duration of status effect
balance: Xeno melee attack applies /datum/status_effect/nohealthregen for 10 SECONDS if melee attack target is a xeno and of different hive
balance: If xeno has /datum/status_effect/nohealthregen it will receive no passive or active healing
/:cl:
