### PR TITLE
Multi-Hive Improvements

### DIFF
--- a/_maps/map_files/Container/NTF_Container.dmm
+++ b/_maps/map_files/Container/NTF_Container.dmm
@@ -7032,7 +7032,9 @@
 /obj/effect/landmark/start/job/xenomorph/green,
 /obj/effect/landmark/start/job/xenomorph/green,
 /obj/effect/landmark/start/job/xenomorph/green,
-/obj/alien/weeds/node/resting,
+/obj/alien/weeds/node/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/medical_science)
 "gWh" = (
@@ -8061,7 +8063,9 @@
 /turf/open/floor/mainship/stripesquare,
 /area/mainship/hallways/ntf/dorm1)
 "iji" = (
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 5
 	},
@@ -15151,7 +15155,9 @@
 /turf/open/floor/plating/plating_catwalk,
 /area/mainship/hallways/port_hallway)
 "pck" = (
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 10
 	},
@@ -15667,7 +15673,9 @@
 /turf/open/floor/mainship/floor,
 /area/mainship/shipboard/brig_cells)
 "pIi" = (
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 8
 	},
@@ -16280,7 +16288,9 @@
 /turf/open/floor/plating,
 /area/mainship/living/bridgebunks)
 "quS" = (
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 6
 	},
@@ -16434,7 +16444,9 @@
 /obj/machinery/camera/autoname/mainship{
 	dir = 8
 	},
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 4
 	},
@@ -17962,14 +17974,18 @@
 	id = "Containment Cell 3";
 	pixel_y = 30
 	},
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 1
 	},
 /area/mainship/medical/medical_science)
 "sco" = (
 /obj/machinery/light/mainship/small,
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2,
 /area/mainship/medical/medical_science)
 "scM" = (
@@ -23183,7 +23199,9 @@
 /turf/open/floor/mainship/tcomms,
 /area/mainship/command/self_destruct)
 "xfZ" = (
-/obj/alien/weeds/resting,
+/obj/alien/weeds/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor2{
 	dir = 9
 	},

--- a/_maps/map_files/NTC_Nine_Tailed_Fox/NTC_Nine_Tailed_Fox - NO Z.dmm
+++ b/_maps/map_files/NTC_Nine_Tailed_Fox/NTC_Nine_Tailed_Fox - NO Z.dmm
@@ -5144,7 +5144,9 @@
 	bruteloss = 25;
 	fireloss = 25
 	},
-/obj/alien/weeds/node/resting,
+/obj/alien/weeds/node/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/surgery_hallway{
 	name = "Research"

--- a/_maps/map_files/NTC_Nine_Tailed_Fox/NTC_Nine_Tailed_Fox.dmm
+++ b/_maps/map_files/NTC_Nine_Tailed_Fox/NTC_Nine_Tailed_Fox.dmm
@@ -5169,7 +5169,9 @@
 	bruteloss = 25;
 	fireloss = 25
 	},
-/obj/alien/weeds/node/resting,
+/obj/alien/weeds/node/resting{
+	hivenumber = "corrupted_hive"
+	},
 /turf/open/floor/mainship/research/containment/floor1,
 /area/mainship/medical/surgery_hallway{
 	name = "Research"

--- a/code/__DEFINES/xeno.dm
+++ b/code/__DEFINES/xeno.dm
@@ -228,6 +228,8 @@ GLOBAL_LIST_INIT(xeno_ai_spawnable, list(
 #define ERROR_NO_SUPPORT 7
 /// Failed to other blockers such as egg, power plant , coocon , traps
 #define ERROR_CONSTRUCT 8
+// Failed due to enemy weeds
+#define ERROR_ENEMY_WEED 9
 
 #define WEED_REQUIRES_LOS (1<<0)
 #define WEED_TAKES_TIME (1<<1)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -6,7 +6,7 @@
 
 
 /// Checks all conditions if a spot is valid for construction , will return TRUE
-/proc/is_valid_for_resin_structure(turf/target, needs_support = FALSE, planned_building)
+/proc/is_valid_for_resin_structure(turf/target, needs_support = FALSE, planned_building, hivenumber)
 	if(!target || !istype(target))
 		return ERROR_JUST_NO
 	if(ispath(planned_building, /turf/closed/wall/resin) && istype(target, /turf/closed/wall/resin))
@@ -17,6 +17,8 @@
 		return ERROR_NOT_ALLOWED
 	if(!alien_weeds)
 		return ERROR_NO_WEED
+	if(alien_weeds.hivenumber != hivenumber)
+		return ERROR_ENEMY_WEED
 	if(!target.is_weedable())
 		return ERROR_CANT_WEED
 	for(var/obj/effect/forcefield/fog/F in range(1, target))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -81,6 +81,9 @@
 /obj/item/proc/attack_obj(obj/target_object, mob/living/user)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_OBJ, target_object, user) & COMPONENT_NO_ATTACK_OBJ)
 		return
+	if(isxeno(user))
+		to_chat(user, span_warning("We stare at \the [src] cluelessly."))
+		return FALSE
 	if(item_flags & NOBLUDGEON)
 		return
 	user.changeNext_move(attack_speed)
@@ -197,6 +200,10 @@
 
 	if(M.can_be_operated_on() && do_surgery(M, user, src)) //Checks if mob is lying down on table for surgery
 		return TRUE
+
+	if(isxeno(user))
+		to_chat(user, span_warning("We stare at \the [src] cluelessly."))
+		return FALSE
 
 	if(item_flags & NOBLUDGEON)
 		return FALSE
@@ -333,6 +340,10 @@
 	if(SEND_SIGNAL(src, COMSIG_ITEM_ATTACK_ALTERNATE, M, user) & COMPONENT_ITEM_NO_ATTACK)
 		return FALSE
 	if(SEND_SIGNAL(user, COMSIG_MOB_ITEM_ATTACK_ALTERNATE, M, src) & COMPONENT_ITEM_NO_ATTACK)
+		return FALSE
+
+	if(isxeno(user))
+		to_chat(user, span_warning("We stare at \the [src] cluelessly."))
 		return FALSE
 
 	if(item_flags & NOBLUDGEON)

--- a/code/controllers/subsystem/weeds.dm
+++ b/code/controllers/subsystem/weeds.dm
@@ -92,7 +92,7 @@ SUBSYSTEM_DEF(weeds)
 			if(istype(O, /obj/alien/weeds/node))
 				return
 			var/obj/alien/weeds/weed = O
-			if(weed.parent_node && weed.parent_node != node && get_dist_euclidean_square(node, weed) >= get_dist_euclidean_square(weed.parent_node, weed))
+			if(weed.parent_node && weed.parent_node != node && get_dist_euclidean_square(node, weed) >= get_dist_euclidean_square(weed.parent_node, weed) || (!(node.issamexenohive(weed))))
 				return
 			if((weed.type == weed_to_spawn) && (weed.color_variant == node.color_variant))
 				weed.set_parent_node(node)
@@ -100,4 +100,4 @@ SUBSYSTEM_DEF(weeds)
 			weed.swapped = TRUE
 			swapped = TRUE
 			qdel(O)
-	new weed_to_spawn(T, node, swapped)
+	new weed_to_spawn(T, node.hivenumber, node, swapped)

--- a/code/datums/elements/accelerate_on_cross.dm
+++ b/code/datums/elements/accelerate_on_cross.dm
@@ -10,4 +10,5 @@
 	SIGNAL_HANDLER
 	if(isxeno(crosser))
 		var/mob/living/carbon/xenomorph/X = crosser
-		X.next_move_slowdown += X?.xeno_caste?.weeds_speed_mod
+		if(issamexenohive(X))
+			X.next_move_slowdown += X?.xeno_caste?.weeds_speed_mod

--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -8,6 +8,7 @@
 
 /datum/job/clf/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
 	. = ..()
+	C.hivenumber = XENO_HIVE_NORMAL
 	SSminimaps.add_marker(C, MINIMAP_FLAG_MARINE_CLF, image('ntf_modular/icons/UI_icons/map_blips.dmi', null, comm_title))
 	var/datum/action/minimap/clf/mini = new
 	mini.give_action(C)

--- a/code/datums/jobs/job/terragov.dm
+++ b/code/datums/jobs/job/terragov.dm
@@ -1,6 +1,10 @@
 /datum/job/terragov
 	faction = FACTION_TERRAGOV
 
+/datum/job/terragov/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
+	. = ..()
+	C.hivenumber = XENO_HIVE_CORRUPTED
+
 /datum/job/terragov/get_spawn_message_information(mob/M)
 	. = ..()
 	if(istype(SSticker.mode, /datum/game_mode/hvh/combat_patrol))

--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -19,6 +19,7 @@
 	plane = FLOOR_PLANE
 	max_integrity = 25
 	ignore_weed_destruction = TRUE
+	resistance_flags = UNACIDABLE | XENO_DAMAGEABLE
 
 	var/obj/alien/weeds/node/parent_node
 	///The color variant of the sprite
@@ -36,7 +37,7 @@
 /obj/alien/weeds/plasmacutter_act(mob/living/user, obj/item/I)
 	return FALSE // Just attack normally.
 
-/obj/alien/weeds/Initialize(mapload, obj/alien/weeds/node/node, swapped = FALSE)
+/obj/alien/weeds/Initialize(mapload, _hivenumber, obj/alien/weeds/node/node, swapped = FALSE)
 	. = ..()
 	var/static/list/connections = list(
 		COMSIG_FIND_FOOTSTEP_SOUND = TYPE_PROC_REF(/atom/movable, footstep_override)
@@ -160,16 +161,19 @@
 
 	if(isxeno(crosser))
 		var/mob/living/carbon/xenomorph/X = crosser
-		X.next_move_slowdown += X.xeno_caste.weeds_speed_mod
+		if(!issamexenohive(X))
+			X.next_move_slowdown = WEED_SLOWDOWN
+		else
+			X.next_move_slowdown += X.xeno_caste.weeds_speed_mod
 		return
 
-	if(!ishuman(crosser))
+	if(!isliving(crosser))
 		return
 
 	if(CHECK_MULTIPLE_BITFIELDS(crosser.pass_flags, HOVERING))
 		return
 
-	var/mob/living/carbon/human/victim = crosser
+	var/mob/living/victim = crosser
 
 	if(victim.lying_angle)
 		return
@@ -262,7 +266,7 @@
 	///The plasma cost multiplier for this node
 	var/ability_cost_mult = 1
 
-/obj/alien/weeds/node/Initialize(mapload, obj/alien/weeds/node/node)
+/obj/alien/weeds/node/Initialize(mapload, _hivenumber, obj/alien/weeds/node/node)
 	var/swapped = FALSE
 	for(var/obj/alien/weeds/W in loc)
 		if(W != src)
@@ -270,7 +274,7 @@
 			swapped = TRUE
 			qdel(W) //replaces the previous weed
 			break
-	. = ..(mapload, node, swapped)
+	. = ..(mapload, _hivenumber, node, swapped)
 
 	// Generate our full graph before adding to SSweeds
 	node_turfs = filled_turfs(src, node_range, "square")
@@ -332,7 +336,15 @@
 		vehicle.last_move_time += WEED_SLOWDOWN
 		return
 
-	if(!ishuman(crosser))
+	if(isxeno(crosser))
+		var/mob/living/carbon/xenomorph/X = crosser
+		if(!issamexenohive(X))
+			X.next_move_slowdown = WEED_SLOWDOWN
+		else
+			X.next_move_slowdown += X.xeno_caste.weeds_speed_mod
+		return
+
+	if(!isliving(crosser))
 		return
 
 	if(CHECK_MULTIPLE_BITFIELDS(crosser.pass_flags, HOVERING))

--- a/code/game/objects/items/cocoon.dm
+++ b/code/game/objects/items/cocoon.dm
@@ -27,6 +27,9 @@
 	if(!_hivenumber)
 		return
 	hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 	victim = _victim
 	victim.forceMove(src)
 	START_PROCESSING(SSslowprocess, src)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -150,7 +150,6 @@
 	L.visible_message(span_danger("[L] nudges its head against [src]."), \
 	span_danger("You nudge your head against [src]."))
 
-
 ///the obj is deconstructed into pieces, whether through careful disassembly or when destroyed.
 /obj/proc/deconstruct(disassembled = TRUE, mob/living/blame_mob)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -219,18 +219,13 @@
 
 /obj/structure/mineral_door/resin/Cross(atom/movable/mover, turf/target)
 	. = ..()
-	if(!. && isxeno(mover) && !open)
-		if(issamexenohive(mover))
-			var/mob/living/living_mover = mover
-			if((!(istype(living_mover))) || (living_mover.stat != CONSCIOUS))
-				return
+	if(!. && issamexenohive(mover) && !open)
+		var/mob/living/living_mover = mover
+		if((!(istype(living_mover))) || (living_mover.stat != CONSCIOUS))
+			return
+		if(isxeno(living_mover))
 			toggle_state()
-			return TRUE
-	if(ishuman(mover))
-		var/mob/living/carbon/human/H = mover
-		if(!. && !open)
-			if(get_xeno_hivenumber() == XENO_HIVE_NORMAL && H.faction == FACTION_CLF || get_xeno_hivenumber() == XENO_HIVE_CORRUPTED && H.faction == FACTION_TERRAGOV)
-				return TRUE
+		return TRUE
 
 /obj/structure/mineral_door/resin/attack_larva(mob/living/carbon/xenomorph/larva/M)
 	var/turf/cur_loc = M.loc

--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -14,11 +14,24 @@
 	var/on_fire = FALSE
 	///Set this to true if this object isn't destroyed when the weeds under it is.
 	var/ignore_weed_destruction = FALSE
+	///Which hive it belongs to
+	var/hivenumber = XENO_HIVE_NORMAL
 
-/obj/alien/Initialize(mapload)
+/obj/alien/Initialize(mapload, _hivenumber)
 	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 	if(!ignore_weed_destruction)
 		RegisterSignal(loc, COMSIG_TURF_WEED_REMOVED, PROC_REF(weed_removed))
+
+/obj/alien/update_icon_state()
+	.=..()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	if(istype(hive))
+		color = hive.color
 
 /// Destroy the alien effect when the weed it was on is destroyed
 /obj/alien/proc/weed_removed()
@@ -105,7 +118,15 @@
 		COOLDOWN_INCREMENT(vehicle, cooldown_vehicle_move, WEED_SLOWDOWN)
 		return
 
-	if(!ishuman(crosser))
+	if(isxeno(crosser))
+		var/mob/living/carbon/xenomorph/X = crosser
+		if(!issamexenohive(X))
+			X.next_move_slowdown = WEED_SLOWDOWN
+		else
+			X.next_move_slowdown += X.xeno_caste.weeds_speed_mod
+		return
+
+	if(!isliving(crosser))
 		return
 
 	if(HAS_TRAIT(crosser, TRAIT_TANK_DESANT))
@@ -114,7 +135,7 @@
 	if(CHECK_MULTIPLE_BITFIELDS(crosser.allow_pass_flags, HOVERING))
 		return
 
-	var/mob/living/carbon/human/victim = crosser
+	var/mob/living/victim = crosser
 
 	if(victim.lying_angle)
 		return
@@ -125,6 +146,9 @@
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE
 
+	if(!(issamexenohive(xeno_attacker)))
+		return ..()
+
 	if(xeno_attacker.a_intent == INTENT_HARM) //Clear it out on hit; no need to double tap.
 		if(CHECK_BITFIELD(SSticker.mode?.round_type_flags, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.active && refundable)
 			SSresinshaping.quickbuild_points_by_hive[xeno_attacker.hivenumber]++
@@ -132,8 +156,6 @@
 		playsound(src, SFX_ALIEN_RESIN_BREAK, 25) //SFX
 		deconstruct(TRUE)
 		return
-
-	return ..()
 
 /obj/alien/resin/sticky/can_z_move(direction, turf/start, turf/destination, z_move_flags, mob/living/rider)
 	z_move_flags |= ZMOVE_ALLOW_ANCHORED
@@ -159,7 +181,7 @@
 	icon = 'icons/obj/smooth_objects/resin-door.dmi'
 	icon_state = "resin-door-1"
 	base_icon_state = "resin-door"
-	resistance_flags = NONE
+	resistance_flags = UNACIDABLE | XENO_DAMAGEABLE
 	layer = BELOW_OBJ_LAYER
 	max_integrity = 100
 	smoothing_flags = SMOOTH_BITMASK
@@ -178,13 +200,19 @@
 	var/close_delay = 10 SECONDS
 	///The timer that tracks the delay above
 	var/closetimer
+	var/hivenumber = XENO_HIVE_NORMAL
 
 /obj/structure/mineral_door/resin/smooth_icon()
 	. = ..()
 	update_icon()
 
-/obj/structure/mineral_door/resin/Initialize(mapload)
+/obj/structure/mineral_door/resin/Initialize(mapload, _hivenumber)
 	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 	if(!locate(/obj/alien/weeds) in loc)
 		new /obj/alien/weeds(loc)
 
@@ -192,12 +220,16 @@
 /obj/structure/mineral_door/resin/Cross(atom/movable/mover, turf/target)
 	. = ..()
 	if(!. && isxeno(mover) && !open)
-		toggle_state()
-		return TRUE
+		if(issamexenohive(mover))
+			var/mob/living/living_mover = mover
+			if((!(istype(living_mover))) || (living_mover.stat != CONSCIOUS))
+				return
+			toggle_state()
+			return TRUE
 	if(ishuman(mover))
 		var/mob/living/carbon/human/H = mover
-		if(!. && H.faction == FACTION_CLF)
-			if(!open)
+		if(!. && !open)
+			if(get_xeno_hivenumber() == XENO_HIVE_NORMAL && H.faction == FACTION_CLF || get_xeno_hivenumber() == XENO_HIVE_CORRUPTED && H.faction == FACTION_TERRAGOV)
 				return TRUE
 
 /obj/structure/mineral_door/resin/attack_larva(mob/living/carbon/xenomorph/larva/M)
@@ -212,6 +244,8 @@
 	var/turf/cur_loc = xeno_attacker.loc
 	if(!istype(cur_loc))
 		return FALSE //Some basic logic here
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	if(xeno_attacker.a_intent != INTENT_HARM)
 		try_toggle_state(xeno_attacker)
 		return TRUE
@@ -241,7 +275,7 @@
 			take_damage(30, BRUTE, BOMB)
 
 /obj/structure/mineral_door/resin/try_toggle_state(atom/user)
-	if(isxeno(user))
+	if(issamexenohive(user))
 		return ..()
 
 /obj/structure/mineral_door/resin/toggle_state()
@@ -300,6 +334,15 @@
 	var/immune_time = 30 SECONDS
 	///Holder to ensure only one user per resin jelly.
 	var/current_user
+	var/hivenumber = XENO_HIVE_NORMAL
+
+/obj/item/resin_jelly/Initialize(mapload, _hivenumber)
+	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	color = hive.color
 
 /obj/item/resin_jelly/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(xeno_attacker.status_flags & INCORPOREAL)
@@ -310,6 +353,9 @@
 /obj/item/resin_jelly/attack_self(mob/living/carbon/xenomorph/user)
 	//Activates if the item itself is clicked in hand.
 	if(!isxeno(user))
+		return
+	if(!issamexenohive(user))
+		user.balloon_alert(user, "Wrong hive")
 		return
 	if(user.do_actions || !isnull(current_user))
 		return
@@ -329,6 +375,9 @@
 		M.balloon_alert(user, "Cannot apply")
 		return FALSE
 	if(user.do_actions || !isnull(current_user))
+		return FALSE
+	if(!issamexenohive(user))
+		user.balloon_alert(user, "Wrong hive")
 		return FALSE
 	current_user = M
 	M.balloon_alert(user, "Applying...")
@@ -360,6 +409,8 @@
 		return
 	var/mob/living/carbon/xenomorph/X = hit_atom
 	if(X.xeno_caste.caste_flags & CASTE_FIRE_IMMUNE)
+		return
+	if(!issamexenohive(X))
 		return
 	X.visible_message(span_notice("[X] is splattered with jelly!"))
 	INVOKE_ASYNC(src, PROC_REF(activate_jelly), X)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -273,7 +273,7 @@
 	//We do this here so anything that doesn't want to persist can clear itself
 	var/list/old__listen_lookup = _listen_lookup?.Copy()
 	var/list/old_signal_procs = _signal_procs?.Copy()
-	var/turf/W = new path(src)
+	var/turf/W = new path(src, usr?.get_xeno_hivenumber())
 
 	// WARNING WARNING
 	// Turfs DO NOT lose their signals when they get replaced, REMEMBER THIS

--- a/code/game/turfs/walls/resin.dm
+++ b/code/game/turfs/walls/resin.dm
@@ -17,13 +17,21 @@
 	canSmoothWith = list(SMOOTH_GROUP_XENO_STRUCTURES)
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 75, ENERGY = 75, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hard_armor = list(MELEE = 0, BULLET = 15, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-	resistance_flags = UNACIDABLE
+	resistance_flags = UNACIDABLE | XENO_DAMAGEABLE
+	///Which hive it belongs to
+	var/hivenumber = XENO_HIVE_NORMAL
 
 /turf/closed/wall/resin/add_debris_element()
 	AddElement(/datum/element/debris, null, -40, 8, 0.7)
 
-/turf/closed/wall/resin/Initialize(mapload)
+/turf/closed/wall/resin/Initialize(mapload, _hivenumber)
 	. = ..()
+	if(_hivenumber) ///because admins can spawn them
+		hivenumber = _hivenumber
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	name = "[hive.prefix][name]"
+	if(!color)
+		color = hive.color
 	return INITIALIZE_HINT_LATELOAD
 
 /turf/closed/wall/resin/get_mechanics_info()
@@ -124,6 +132,22 @@
 /turf/closed/wall/resin/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return
+	if(!issamexenohive(xeno_attacker))
+		SEND_SIGNAL(xeno_attacker, COMSIG_XENOMORPH_ATTACK_OBJ, src)
+		if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, xeno_attacker) & COMPONENT_NO_ATTACK_ALIEN)
+			return FALSE
+		if(!(resistance_flags & XENO_DAMAGEABLE))
+			to_chat(xeno_attacker, span_warning("We stare at \the [src] cluelessly."))
+			return FALSE
+		if(effects)
+			xeno_attacker.visible_message(span_danger("[xeno_attacker] has slashed [src]!"),
+			span_danger("We slash [src]!"))
+			xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+			playsound(loc, SFX_ALIEN_CLAW_METAL, 25)
+		xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_SMASH)
+		xeno_attacker.changeNext_move(CLICK_CD_MELEE)
+		take_damage(damage_amount, damage_type, armor_type, effects, get_dir(src, xeno_attacker), armor_penetration, xeno_attacker)
+		return TRUE
 	if(CHECK_BITFIELD(SSticker.mode?.round_type_flags, MODE_ALLOW_XENO_QUICKBUILD) && SSresinshaping.active)
 		SSresinshaping.quickbuild_points_by_hive[xeno_attacker.hivenumber]++
 		take_damage(max_integrity) // Ensure its destroyed

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -58,6 +58,7 @@
 	rally_zombie.give_action(H)
 	var/datum/action/set_agressivity/set_zombie_behaviour = new
 	set_zombie_behaviour.give_action(H)
+	H.hivenumber = FACTION_ZOMBIE
 
 /datum/species/zombie/post_species_loss(mob/living/carbon/human/H)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/behemoth/abilities_behemoth.dm
@@ -520,9 +520,10 @@
 		tank_target.explode()
 		return
 	if(istype(object_target, /obj/structure/mineral_door/resin))
-		var/obj/structure/mineral_door/resin/resin_door = object_target
-		resin_door.toggle_state()
-		return
+		if(object_target.issamexenohive(xeno_owner))
+			var/obj/structure/mineral_door/resin/resin_door = object_target
+			resin_door.toggle_state()
+			return
 	if(object_target.obj_integrity <= LANDSLIDE_OBJECT_INTEGRITY_THRESHOLD || istype(object_target, /obj/structure/closet))
 		playsound(object_turf, 'sound/effects/meteorimpact.ogg', 30, TRUE)
 		new /obj/effect/temp_visual/behemoth/landslide/hit(object_turf)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/abilities_hivelord.dm
@@ -300,7 +300,7 @@
 		return FALSE
 
 /datum/action/ability/xeno_action/create_jelly/action_activate()
-	var/obj/item/resin_jelly/jelly = new(owner.loc)
+	var/obj/item/resin_jelly/jelly = new(owner.loc, xeno_owner.hivenumber)
 	owner.put_in_hands(jelly)
 	to_chat(owner, span_xenonotice("We create a globule of resin from our ovipositor.")) // Ewww...
 	add_cooldown()

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/hivemind.dm
@@ -257,10 +257,10 @@
 	if(!amount)
 		amount = 1 //don't want the 'zero health' icon when we still have 4% of our health
 	holder.icon_state = "health[amount]"
-	
+
 	holder.overlays.Cut()
 	if(status_flags & INCORPOREAL)
-		holder.overlays +=image('icons/Xeno/castes/hivemind.dmi', src, "hivemind_marker") 
+		holder.overlays +=image('icons/Xeno/castes/hivemind.dmi', src, "hivemind_marker")
 
 /mob/living/carbon/xenomorph/hivemind/DblClickOn(atom/A, params)
 	if(TIMER_COOLDOWN_RUNNING(src, COOLDOWN_HIVEMIND_MANIFESTATION))
@@ -354,7 +354,7 @@
 	xeno_attacker.visible_message(span_danger("[xeno_attacker] nudges [xeno_attacker.p_their()] head against [src]."), \
 	span_danger("You nudge your head against [src]."))
 
-/obj/structure/xeno/hivemindcore/take_damage(damage_amount, damage_type = BRUTE, armor_type = null, effects = TRUE, attack_dir, armour_penetration = 0, mob/living/blame_mob)
+/obj/structure/xeno/hivemindcore/take_damage(damage_amount, damage_type = BRUTE, armor_type = null, effects = TRUE, attack_dir, armour_penetration = 0, mob/living/blame_mob, silent)
 	. = ..()
 	var/mob/living/carbon/xenomorph/hivemind/our_parent = get_parent()
 	if(isnull(our_parent))

--- a/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/shrike/abilities_shrike.dm
@@ -355,7 +355,7 @@
 	succeed_activate()
 
 	playsound(T, SFX_ALIEN_RESIN_BUILD, 25)
-	new /obj/structure/xeno/acidwell(T, owner)
+	new /obj/structure/xeno/acidwell(T, xeno_owner.hivenumber, owner)
 
 	to_chat(owner, span_xenonotice("We place an acid well; it can be filled with more acid."))
 	GLOB.round_statistics.xeno_acid_wells++

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/abilities_widow.dm
@@ -63,7 +63,6 @@
 	if(!do_after(xeno_owner, 1 SECONDS, NONE, xeno_owner, BUSY_ICON_DANGER))
 		return fail_activate()
 	var/datum/ammo/xeno/leash_ball = GLOB.ammo_list[/datum/ammo/xeno/leash_ball]
-	leash_ball.hivenumber = xeno_owner.hivenumber
 	var/atom/movable/projectile/newspit = new (get_turf(xeno_owner))
 
 	newspit.generate_bullet(leash_ball)

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/abilities_wraith.dm
@@ -567,6 +567,8 @@ GLOBAL_LIST_INIT(wraith_banish_very_short_duration_list, typecacheof(list(
 		var/mob/living/carbon/xenomorph/xeno_crosser = crosser
 		if(xeno_crosser.m_intent == MOVE_INTENT_WALK)
 			return
+		if(!xeno_crosser.issamexenohive(src))
+			return
 	COOLDOWN_START(linked_portal, portal_cooldown, 1)
 	crosser.remove_pass_flags(PASS_MOB, PORTAL_TRAIT)
 	RegisterSignal(crosser, COMSIG_MOVABLE_MOVED, PROC_REF(do_teleport_atom))

--- a/code/modules/mob/living/carbon/xenomorph/egg.dm
+++ b/code/modules/mob/living/carbon/xenomorph/egg.dm
@@ -10,14 +10,11 @@
 	var/maturity_time = 0
 	///Number of the last maturity stage before bursting
 	var/stage_ready_to_burst = 0
-	///Which hive it belongs to
-	var/hivenumber = XENO_HIVE_NORMAL
 	///How far will targets trigger the burst
 	var/trigger_size = 0
 
-/obj/alien/egg/Initialize(mapload, hivenumber)
+/obj/alien/egg/Initialize(mapload, _hivenumber)
 	. = ..()
-	src.hivenumber = hivenumber
 	advance_maturity(maturity_stage)
 
 /obj/alien/egg/update_icon_state()
@@ -93,11 +90,6 @@
 	overlays.Cut()
 	if(on_fire)
 		overlays += "alienegg_fire"
-	if(hivenumber != XENO_HIVE_NORMAL && GLOB.hive_datums[hivenumber])
-		var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
-		color = hive.color
-		return
-	color = null
 
 /obj/alien/egg/hugger/burst(via_damage)
 	. = ..()
@@ -139,7 +131,7 @@
 			span_xenonotice("We clear the hatched egg."))
 			playsound(loc, SFX_ALIEN_RESIN_BREAK, 25)
 			qdel(src)
-			
+
 /obj/alien/egg/hugger/attack_hand(mob/living/user)
 	if(!issamexenohive(user) && !user.faction == FACTION_CLF)
 		return ..()

--- a/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -77,6 +77,7 @@
 		hivenumber = input_hivenumber
 	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
 	name = "[hive.prefix][name]"
+	color = hive.color
 
 	if(input_source)
 		facehugger_register_source(input_source)
@@ -882,7 +883,7 @@
 
 	for(var/turf/sticky_tile AS in RANGE_TURFS(1, loc))
 		if(!locate(/obj/effect/xenomorph/spray) in sticky_tile.contents)
-			new /obj/alien/resin/sticky/thin(sticky_tile)
+			new /obj/alien/resin/sticky/thin(sticky_tile, hivenumber)
 
 	for(var/mob/living/carbon/human/target in range(1, loc))
 		if(isxeno(target)) //Xenos aren't affected by sticky resin

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -33,8 +33,10 @@
 	var/list/client/candidates
 	/// Amount of special resin points used to build special resin walls by each hive.
 	var/special_build_points = 50
-	/// These factions cannot sell this hive's corpses.
+	/// These factions will not be attacked by turrets of this hive but cannot sell their resin jelly or corpses.
 	var/list/allied_factions = list(FACTION_CLF, FACTION_XENO)
+	/// Supply and dropship points given when a non-allied faction sells one resin jelly from this faction.
+	var/jelly_export_value = list(2,0)
 
 	///Reference to upgrades available and purchased by this hive.
 	var/datum/hive_purchases/purchases = new
@@ -1214,6 +1216,7 @@ to_chat will check for valid clients itself already so no need to double check f
 	prefix = "Corrupted "
 	color = "#00ff80"
 	allied_factions = list(FACTION_TERRAGOV)
+	jelly_export_value = list(1,0)
 
 // Make sure they can understand english
 /datum/hive_status/corrupted/post_add(mob/living/carbon/xenomorph/X)
@@ -1647,7 +1650,7 @@ to_chat will check for valid clients itself already so no need to double check f
 /atom/proc/get_xeno_hivenumber()
 	return FALSE
 
-/obj/alien/egg/get_xeno_hivenumber()
+/obj/alien/get_xeno_hivenumber()
 	return hivenumber
 
 /obj/item/alien_embryo/get_xeno_hivenumber()
@@ -1656,7 +1659,10 @@ to_chat will check for valid clients itself already so no need to double check f
 /obj/item/clothing/mask/facehugger/get_xeno_hivenumber()
 	return hivenumber
 
-/mob/living/carbon/xenomorph/get_xeno_hivenumber()
+/mob/living
+	var/hivenumber = FALSE
+
+/mob/living/get_xeno_hivenumber()
 	return hivenumber
 
 /mob/illusion/xeno/get_xeno_hivenumber()
@@ -1668,18 +1674,14 @@ to_chat will check for valid clients itself already so no need to double check f
 		return hivenumber
 	return ..()
 
-/obj/structure/xeno/trap/get_xeno_hivenumber()
-	if(hugger)
-		return hugger.hivenumber
-	return ..()
-
-/mob/living/carbon/human/get_xeno_hivenumber()
-	if(faction == FACTION_ZOMBIE)
-		return FACTION_ZOMBIE
-	if(faction == FACTION_CLF)
-		return XENO_HIVE_NORMAL
-	return FALSE
-
 /obj/machinery/deployable/mounted/sentry/get_xeno_hivenumber()
-	if(iff_signal == CLF_IFF)
-		return XENO_HIVE_NORMAL
+	return hivenumber
+
+/obj/structure/mineral_door/resin/get_xeno_hivenumber()
+	return hivenumber
+
+/turf/closed/wall/resin/get_xeno_hivenumber()
+	return hivenumber
+
+/obj/item/resin_jelly/get_xeno_hivenumber()
+	return hivenumber

--- a/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_upgrades.dm
@@ -138,7 +138,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 	var/building_time = 10 SECONDS
 
 /datum/hive_upgrade/building/can_buy(mob/living/carbon/xenomorph/buyer, silent)
-	. = ..()
+	. = ..() //
 	if(!.)
 		return
 	var/turf/buildloc = get_turf(buyer)
@@ -146,8 +146,11 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 		return FALSE
 
 	if(!buildloc.is_weedable())
+		return FALSE
+
+	if(!buyer.loc_weeds_type)
 		if(!silent)
-			to_chat(buyer, span_warning("We can't do that here."))
+			to_chat(buyer, span_xenowarning("We can't do that here."))
 		return FALSE
 
 	var/obj/alien/weeds/alien_weeds = locate() in buildloc
@@ -354,7 +357,7 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 
 	if(!buyer.loc_weeds_type)
 		if(!silent)
-			to_chat(buyer, span_xenowarning("No weeds here!"))
+			to_chat(buyer, span_xenowarning("We can't do that here."))
 		return FALSE
 
 	if(!T.check_alien_construction(buyer, silent, /obj/structure/xeno/xeno_turret) || !T.check_disallow_alien_fortification(buyer))
@@ -407,8 +410,11 @@ GLOBAL_LIST_INIT(tier_to_primo_upgrade, list(
 		return FALSE
 
 	if(!buildloc.is_weedable())
+		return FALSE
+
+	if(!buyer.loc_weeds_type)
 		if(!silent)
-			to_chat(buyer, span_warning("We can't do that here."))
+			to_chat(buyer, span_xenowarning("We can't do that here."))
 		return FALSE
 
 	var/obj/alien/weeds/alien_weeds = locate() in buildloc

--- a/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xeno_defines.dm
@@ -308,7 +308,7 @@ GLOBAL_LIST_INIT(strain_list, init_glob_strain_list())
 	light_system = MOVABLE_LIGHT
 
 	///Hive name define
-	var/hivenumber = XENO_HIVE_NORMAL
+	hivenumber = XENO_HIVE_NORMAL
 	///Hive datum we belong to
 	var/datum/hive_status/hive
 	///Xeno mob specific flags

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -467,6 +467,8 @@
 	for(var/obj/alien/weeds/W in range(strict_turf_check ? 0 : 1, T ? T : get_turf(src)))
 		if(QDESTROYING(W))
 			continue
+		if(!issamexenohive(W))
+			continue
 		return
 	return FALSE
 
@@ -482,6 +484,9 @@
 /mob/living/carbon/xenomorph/proc/handle_weeds_on_movement(datum/source)
 	SIGNAL_HANDLER
 	var/obj/alien/weeds/found_weed = locate(/obj/alien/weeds) in loc
+	if(!issamexenohive(found_weed))
+		loc_weeds_type = null
+		return
 	loc_weeds_type = found_weed?.type
 
 /mob/living/carbon/xenomorph/toggle_resting()

--- a/code/modules/mob/living/living_health_procs.dm
+++ b/code/modules/mob/living/living_health_procs.dm
@@ -426,6 +426,7 @@
 	if(should_zombify)
 		set_species("Strong zombie")
 		faction = FACTION_ZOMBIE
+		hivenumber = FACTION_ZOMBIE
 	heal_limbs(- health)
 	set_stat(CONSCIOUS)
 	overlay_fullscreen_timer(0.5 SECONDS, 10, "roundstart1", /atom/movable/screen/fullscreen/black)

--- a/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/huggers_xenoammo.dm
@@ -18,19 +18,19 @@
 	var/obj/item/clothing/mask/facehugger/hugger_type = /obj/item/clothing/mask/facehugger
 
 /datum/ammo/xeno/hugger/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_mob), hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_mob), proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_obj), hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(get_turf(target_obj), proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
-	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, hivenumber)
+	var/obj/item/clothing/mask/facehugger/hugger = new hugger_type(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 	hugger.go_idle()
 
 /datum/ammo/xeno/hugger/slash

--- a/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/spits_xenoammo.dm
@@ -31,8 +31,6 @@
 	var/datum/effect_system/smoke_spread/xeno/smoke_system
 	var/smoke_strength
 	var/smoke_range
-	///The hivenumber of this ammo
-	var/hivenumber = XENO_HIVE_NORMAL
 
 /datum/ammo/xeno/toxin
 	name = "neurotoxic spit"
@@ -205,7 +203,7 @@
 
 
 /datum/ammo/xeno/sticky/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
-	drop_resin(get_turf(target_mob))
+	drop_resin(get_turf(target_mob), proj.firer.get_xeno_hivenumber())
 	if(iscarbon(target_mob))
 		var/mob/living/carbon/target_carbon = target_mob
 		if(target_carbon.issamexenohive(proj.firer))
@@ -219,15 +217,15 @@
 		var/obj/vehicle/sealed/seal = target_obj
 		COOLDOWN_INCREMENT(seal, cooldown_vehicle_move, seal.move_delay)
 	var/turf/target_turf = get_turf(target_obj)
-	drop_resin(target_turf.density ? proj.loc : target_turf)
+	drop_resin(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/sticky/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	drop_resin(target_turf.density ? proj.loc : target_turf)
+	drop_resin(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/sticky/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
-	drop_resin(target_turf.density ? proj.loc : target_turf)
+	drop_resin(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
-/datum/ammo/xeno/sticky/proc/drop_resin(turf/T)
+/datum/ammo/xeno/sticky/proc/drop_resin(turf/T, hivenumber = XENO_HIVE_NORMAL)
 	if(T.density || istype(T, /turf/open/space)) // No structures in space
 		return
 
@@ -235,7 +233,7 @@
 		if(is_type_in_typecache(O, GLOB.no_sticky_resin))
 			return
 
-	new /obj/alien/resin/sticky/thin(T)
+	new /obj/alien/resin/sticky/thin(T, hivenumber)
 
 /datum/ammo/xeno/sticky/turret
 	max_range = 9
@@ -259,22 +257,22 @@
 
 /datum/ammo/xeno/sticky/globe/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
 	var/turf/det_turf = target_obj.allow_pass_flags & PASS_PROJECTILE ? get_step_towards(target_obj, proj) : target_obj.loc
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_obj), loc_override = det_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_turf), loc_override = det_turf)
 
 /datum/ammo/xeno/sticky/globe/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/turf/det_turf = get_turf(target_mob)
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_mob), loc_override = det_turf)
 
 /datum/ammo/xeno/sticky/globe/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
 	var/turf/det_turf = target_turf.density ? get_step_towards(target_turf, proj) : target_turf
-	drop_resin(det_turf)
+	drop_resin(det_turf, proj.firer.get_xeno_hivenumber())
 	fire_directionalburst(proj, proj.firer, proj.shot_from, bonus_projectile_quantity, Get_Angle(proj.starting_turf, target_turf), loc_override = det_turf)
 
 /datum/ammo/xeno/acid

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -56,21 +56,21 @@
 	max_range = 8
 
 /datum/ammo/xeno/leash_ball/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
-	drop_leashball(target_turf.density ? proj.loc : target_turf)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/leash_ball/on_hit_mob(mob/target_mob, atom/movable/projectile/proj)
 	var/turf/target_turf = get_turf(target_mob)
-	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/leash_ball/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
 	var/turf/target_turf = get_turf(target_obj)
 	if(target_turf.density || (target_obj.density && !(target_obj.allow_pass_flags & PASS_PROJECTILE)))
 		target_turf = get_turf(proj)
-	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /datum/ammo/xeno/leash_ball/do_at_max_range(turf/target_turf, atom/movable/projectile/proj)
-	drop_leashball(target_turf.density ? proj.loc : target_turf)
+	drop_leashball(target_turf.density ? proj.loc : target_turf, proj.firer.get_xeno_hivenumber())
 
 /// This spawns a leash ball and checks if the turf is dense before doing so
-/datum/ammo/xeno/leash_ball/proc/drop_leashball(turf/target_turf)
+/datum/ammo/xeno/leash_ball/proc/drop_leashball(turf/target_turf, hivenumber)
 	new /obj/structure/xeno/aoe_leash(get_turf(target_turf), hivenumber)

--- a/code/modules/projectiles/sentries.dm
+++ b/code/modules/projectiles/sentries.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 	var/iff_signal = NONE
 	///For minimap icon change if sentry is firing
 	var/firing
+	var/hivenumber = FALSE
 
 //------------------------------------------------------------------
 //Setup and Deletion
@@ -48,6 +49,13 @@ GLOBAL_LIST_INIT(sentry_ignore_List, set_sentry_ignore_List())
 		var/mob/living/carbon/human/_deployer = deployer
 		var/obj/item/card/id/id = _deployer.get_idcard(TRUE)
 		iff_signal = id?.iff_signal
+		hivenumber = _deployer.get_xeno_hivenumber()
+	else
+		if(iff_signal & CLF_IFF)
+			hivenumber = XENO_HIVE_NORMAL
+		else
+			if(iff_signal & TGMC_LOYALIST_IFF)
+				hivenumber = XENO_HIVE_CORRUPTED
 	if(deployer)
 		faction = deployer.faction
 

--- a/code/modules/requisitions/supply_export.dm
+++ b/code/modules/requisitions/supply_export.dm
@@ -30,6 +30,12 @@
 		. += AM.supply_export(faction_selling)
 		qdel(AM)
 
+/obj/item/resin_jelly/supply_export(faction_selling)
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	if(faction_selling in hive.allied_factions)
+		return list(new /datum/export_report(0, name, faction_selling))
+	. = ..()
+
 /**
  * Getter proc for the point value of this object
  *
@@ -88,3 +94,7 @@
 			if(GLOB.faction_to_alignement[seller_faction] == ALIGNEMENT_FRIENDLY)
 				return FALSE
 			return TRUE
+
+/obj/item/resin_jelly/get_export_value()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
+	return hive.jelly_export_value

--- a/code/modules/xenomorph/acidwell.dm
+++ b/code/modules/xenomorph/acidwell.dm
@@ -19,7 +19,7 @@
 	///What xeno created this well
 	var/mob/living/carbon/xenomorph/creator = null
 
-/obj/structure/xeno/acidwell/Initialize(mapload, _creator)
+/obj/structure/xeno/acidwell/Initialize(mapload, _hivenumber, _creator)
 	. = ..()
 	creator = _creator
 	RegisterSignal(creator, COMSIG_QDELETING, PROC_REF(clear_creator))
@@ -102,6 +102,8 @@
 	attack_alien(user)
 
 /obj/structure/xeno/acidwell/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	if(xeno_attacker.a_intent == INTENT_HARM && (CHECK_BITFIELD(xeno_attacker.xeno_caste.caste_flags, CASTE_IS_BUILDER) || xeno_attacker == creator) ) //If we're a builder caste or the creator and we're on harm intent, deconstruct it.
 		balloon_alert(xeno_attacker, "Removing...")
 		if(!do_after(xeno_attacker, XENO_ACID_WELL_FILL_TIME, IGNORE_HELD_ITEM, src, BUSY_ICON_HOSTILE))
@@ -172,7 +174,7 @@
 		stepper.ExtinguishMob()
 		charges_used++
 
-	if(!isxeno(stepper))
+	if(!issamexenohive(stepper))
 		stepper.next_move_slowdown += charges * 2 //Acid spray has slow down so this should too; scales with charges, Min 2 slowdown, Max 10
 		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_L_FOOT, ACID, penetration = 33)
 		stepper.apply_damage(charges * 10, BURN, BODY_ZONE_PRECISE_R_FOOT, ACID, penetration = 33)

--- a/code/modules/xenomorph/jellypod.dm
+++ b/code/modules/xenomorph/jellypod.dm
@@ -51,7 +51,10 @@
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE
 
-	if((xeno_attacker.a_intent == INTENT_HARM && isxenohivelord(xeno_attacker)) || xeno_attacker.hivenumber != hivenumber)
+	if(!issamexenohive(xeno_attacker) && xeno_attacker.a_intent == INTENT_HARM)
+		return ..()
+
+	if(xeno_attacker.a_intent == INTENT_HARM)
 		balloon_alert(xeno_attacker, "Destroying...")
 		if(do_after(xeno_attacker, HIVELORD_TUNNEL_DISMANTLE_TIME, IGNORE_HELD_ITEM, src, BUSY_ICON_BUILD))
 			deconstruct(FALSE)
@@ -62,7 +65,20 @@
 		to_chat(xeno_attacker, span_xenonotice("We reach into \the [src], but only find dregs of resin. We should wait some more.") )
 		return
 	balloon_alert(xeno_attacker, "Retrieved jelly")
-	new /obj/item/resin_jelly(loc)
+	new /obj/item/resin_jelly(loc, hivenumber)
+	chargesleft--
+	if(!(datum_flags & DF_ISPROCESSING) && (chargesleft < maxcharges))
+		START_PROCESSING(SSslowprocess, src)
+
+/obj/structure/xeno/resin_jelly_pod/attack_hand(mob/living/user)
+	if(!issamexenohive(user))
+		return ..()
+	if(!chargesleft)
+		balloon_alert(user, "No jelly remaining")
+		to_chat(user, span_xenonotice("We reach into \the [src], but only find dregs of resin. We should wait some more.") )
+		return
+	balloon_alert(user, "Retrieved jelly")
+	new /obj/item/resin_jelly(loc, hivenumber)
 	chargesleft--
 	if(!(datum_flags & DF_ISPROCESSING) && (chargesleft < maxcharges))
 		START_PROCESSING(SSslowprocess, src)

--- a/code/modules/xenomorph/maw.dm
+++ b/code/modules/xenomorph/maw.dm
@@ -310,15 +310,25 @@
 	return ..()
 
 /obj/structure/xeno/acid_maw/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount, damage_type, armor_type, effects, armor_penetration, isrightclick)
-	. = ..()
+	if(!issamexenohive(xeno_attacker))
+		return ..()
+	if(issamexenohive(xeno_attacker) && xeno_attacker.a_intent == INTENT_HARM)
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] starts tearing down \the [src]!"), \
+		span_xenonotice("We start to tear down \the [src]."))
+		if(!do_after(xeno_attacker, 10 SECONDS, NONE, xeno_attacker, BUSY_ICON_GENERIC))
+			return
+		if(!istype(src)) // Prevent jumping to other turfs if do_after completes with the object already gone
+			return
+		xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] tears down \the [src]!"), \
+		span_xenonotice("We tear down \the [src]."))
+		playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
+		take_damage(max_integrity, silent=TRUE) // Ensure its destroyed
+		return
 	try_fire(xeno_attacker, src)
 
 /// Tries to fire the acid maw after going through various checks and player inputs.
 /obj/structure/xeno/acid_maw/proc/try_fire(mob/living/carbon/xenomorph/xeno_shooter, atom/radical_target, slient, leaders_only = TRUE, requires_adjacency = TRUE)
-	if(xeno_shooter.hivenumber != hivenumber)
-		if(!slient)
-			balloon_alert(xeno_shooter, "wrong hive")
-		return FALSE
 	if(leaders_only && xeno_shooter.tier != XENO_TIER_FOUR && !(xeno_shooter.xeno_flags & XENO_LEADER))
 		if(!slient)
 			balloon_alert(xeno_shooter, "must be leader")

--- a/code/modules/xenomorph/pherotower.dm
+++ b/code/modules/xenomorph/pherotower.dm
@@ -41,6 +41,21 @@
 
 // Clicking on the tower brings up a radial menu that allows you to select the type of pheromone that this tower will emit.
 /obj/structure/xeno/pherotower/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	if(!issamexenohive(xeno_attacker))
+		return ..()
+	if(issamexenohive(xeno_attacker) && xeno_attacker.a_intent == INTENT_HARM)
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] starts tearing down \the [src]!"), \
+		span_xenonotice("We start to tear down \the [src]."))
+		if(!do_after(xeno_attacker, 10 SECONDS, NONE, xeno_attacker, BUSY_ICON_GENERIC))
+			return
+		if(!istype(src)) // Prevent jumping to other turfs if do_after completes with the object already gone
+			return
+		xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_CLAW)
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] tears down \the [src]!"), \
+		span_xenonotice("We tear down \the [src]."))
+		playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
+		take_damage(max_integrity, silent=TRUE) // Ensure its destroyed
+		return
 	var/phero_choice = show_radial_menu(xeno_attacker, src, GLOB.pheromone_images_list, radius = 35, require_near = TRUE)
 
 	if(!phero_choice)

--- a/code/modules/xenomorph/recovery_pylon.dm
+++ b/code/modules/xenomorph/recovery_pylon.dm
@@ -13,6 +13,7 @@
 	var/list/mob/living/carbon/xenomorph/buffed_xenos = list()
 	/// Holds the particles.
 	var/obj/effect/abstract/particle_holder/particle_holder
+	resistance_flags = UNACIDABLE|XENO_DAMAGEABLE
 
 /obj/structure/xeno/recovery_pylon/Initialize(mapload, _hivenumber)
 	. = ..()
@@ -36,6 +37,8 @@
 	SSminimaps.add_marker(src, MINIMAP_FLAG_XENO, image('icons/UI_icons/map_blips.dmi', null, "recovery", MINIMAP_LABELS_LAYER))
 
 /obj/structure/xeno/recovery_pylon/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
+	if(!(issamexenohive(xeno_attacker)))
+		return ..()
 	if(xeno_attacker.a_intent != INTENT_HARM || !(xeno_attacker.xeno_caste.caste_flags & CASTE_IS_BUILDER))
 		return ..()
 	balloon_alert(xeno_attacker, "Removing...")
@@ -51,7 +54,7 @@
 	if(!isxeno(entering_movable))
 		return
 	var/mob/living/carbon/xenomorph/entering_xenomorph = entering_movable
-	if((entering_xenomorph in buffed_xenos) || entering_xenomorph.hivenumber != src.hivenumber)
+	if((entering_xenomorph in buffed_xenos) || !issamexenohive(entering_xenomorph))
 		return
 	buffed_xenos += entering_xenomorph
 	entering_xenomorph.xeno_caste.regen_delay = 1 SECONDS

--- a/code/modules/xenomorph/silo.dm
+++ b/code/modules/xenomorph/silo.dm
@@ -11,7 +11,7 @@
 	pixel_x = -32
 	pixel_y = -24
 	max_integrity = 1000
-	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | PLASMACUTTER_IMMUNE
+	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | PLASMACUTTER_IMMUNE | XENO_DAMAGEABLE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS|XENO_STRUCT_DAMAGE_ALERT
 	///How many larva points one silo produce in one minute
 	var/larva_spawn_rate = 0.5
@@ -37,9 +37,8 @@
 	. = ..()
 	if(!(SSticker.mode?.round_type_flags & MODE_SILO_RESPAWN))
 		QDEL_NULL(proximity_monitor)
-	var/siloprefix = GLOB.hive_datums[hivenumber].name
 	number_silo = length(GLOB.xeno_resin_silos_by_hive[hivenumber]) + 1
-	name = "[siloprefix == "Normal" ? "" : "[siloprefix] "][name] [number_silo]"
+	name = "[name] [number_silo]"
 	LAZYADDASSOC(GLOB.xeno_resin_silos_by_hive, hivenumber, src)
 
 	if(!locate(/obj/alien/weeds) in loc)
@@ -167,7 +166,7 @@
 	animate(src)
 	pixel_x = old_px
 
-/obj/structure/xeno/silo/take_damage(damage_amount, damage_type = BRUTE, armor_type = null, effects = TRUE, attack_dir, armour_penetration = 0, mob/living/blame_mob)
+/obj/structure/xeno/silo/take_damage(damage_amount, damage_type = BRUTE, armor_type = null, effects = TRUE, attack_dir, armour_penetration = 0, mob/living/blame_mob, silent)
 	. = ..()
 	//We took damage, so it's time to start regenerating if we're not already processing
 	if(!CHECK_BITFIELD(datum_flags, DF_ISPROCESSING))

--- a/code/modules/xenomorph/spawner.dm
+++ b/code/modules/xenomorph/spawner.dm
@@ -11,7 +11,7 @@
 	pixel_x = -32
 	pixel_y = -24
 	max_integrity = 500
-	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE
+	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE | XENO_DAMAGEABLE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|CRITICAL_STRUCTURE|XENO_STRUCT_WARNING_RADIUS|XENO_STRUCT_DAMAGE_ALERT
 	var/linked_minions = list()
 

--- a/code/modules/xenomorph/trap.dm
+++ b/code/modules/xenomorph/trap.dm
@@ -106,7 +106,7 @@
 	SIGNAL_HANDLER
 	if(!trap_type)
 		return
-	if(AM && (hivenumber == AM.get_xeno_hivenumber()))
+	if(issamexenohive(AM))
 		return
 	playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 	if(iscarbon(AM))
@@ -150,6 +150,8 @@
 	if(xeno_attacker.status_flags & INCORPOREAL)
 		return FALSE
 
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 	if(xeno_attacker.a_intent == INTENT_HARM)
 		return ..()
 	if(trap_type == TRAP_HUGGER)
@@ -196,7 +198,7 @@
 		balloon_alert(user, "Already occupied")
 		return
 
-	if(FH.stat == DEAD)
+	if(FH.stat == DEAD || !issamexenohive(FH))
 		balloon_alert(user, "Cannot insert facehugger")
 		return
 

--- a/code/modules/xenomorph/tunnel.dm
+++ b/code/modules/xenomorph/tunnel.dm
@@ -11,7 +11,7 @@ TUNNEL
 	density = FALSE
 	opacity = FALSE
 	anchored = TRUE
-	resistance_flags = UNACIDABLE|BANISH_IMMUNE
+	resistance_flags = UNACIDABLE|BANISH_IMMUNE|XENO_DAMAGEABLE
 	layer = BELOW_TABLE_LAYER
 
 	max_integrity = 140
@@ -79,6 +79,9 @@ TUNNEL
 /obj/structure/xeno/tunnel/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if(!istype(xeno_attacker) || xeno_attacker.stat || xeno_attacker.lying_angle || xeno_attacker.status_flags & INCORPOREAL)
 		return
+
+	if(!(issamexenohive(xeno_attacker)))
+		return ..()
 
 	if(xeno_attacker.a_intent == INTENT_HARM && xeno_attacker == creator)
 		balloon_alert(xeno_attacker, "Filling in tunnel...")

--- a/code/modules/xenomorph/xeno_turret.dm
+++ b/code/modules/xenomorph/xeno_turret.dm
@@ -10,7 +10,7 @@
 	max_integrity = 1500
 	layer = ABOVE_MOB_LAYER
 	density = TRUE
-	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE |PORTAL_IMMUNE
+	resistance_flags = UNACIDABLE | DROPSHIP_IMMUNE |PORTAL_IMMUNE|XENO_DAMAGEABLE
 	xeno_structure_flags = IGNORE_WEED_REMOVAL|HAS_OVERLAY
 	allow_pass_flags = PASS_AIR|PASS_THROW
 	///What kind of spit it uses
@@ -176,23 +176,30 @@
 ///Populates the target list on process
 /obj/structure/xeno/xeno_turret/proc/scan()
 	potential_hostiles.Cut()
+	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
 	for (var/mob/living/carbon/human/nearby_human AS in cheap_get_humans_near(src, TURRET_SCAN_RANGE))
 		if(nearby_human.stat == DEAD)
 			continue
-		if(nearby_human.get_xeno_hivenumber() == hivenumber)
+		if(issamexenohive(nearby_human))
+			continue
+		if(nearby_human.faction in hive?.allied_factions)
 			continue
 		potential_hostiles += nearby_human
 	for (var/mob/living/carbon/xenomorph/nearby_xeno AS in cheap_get_xenos_near(src, TURRET_SCAN_RANGE))
-		if(GLOB.hive_datums[hivenumber] == nearby_xeno.hive)
+		if(issamexenohive(nearby_xeno))
 			continue
 		if(nearby_xeno.stat == DEAD)
 			continue
 		potential_hostiles += nearby_xeno
 	for(var/obj/vehicle/unmanned/vehicle AS in GLOB.unmanned_vehicles)
 		if(vehicle.z == z && get_dist(vehicle, src) <= TURRET_SCAN_RANGE)
+			if(vehicle.faction in hive?.allied_factions)
+				continue
 			potential_hostiles += vehicle
 	for(var/obj/vehicle/sealed/mecha/mech AS in GLOB.mechas_list)
 		if(mech.z == z && get_dist(mech, src) <= TURRET_SCAN_RANGE)
+			if(mech.faction in hive?.allied_factions)
+				continue
 			potential_hostiles += mech
 
 ///Signal handler to make the turret shoot at its target
@@ -211,7 +218,6 @@
 	if(istype(ammo, /datum/ammo/xeno/hugger))
 		var/datum/ammo/xeno/hugger/hugger_ammo = ammo
 		newshot.color = initial(hugger_ammo.hugger_type.color)
-		hugger_ammo.hivenumber = hivenumber
 	firing = TRUE
 	update_minimap_icon()
 

--- a/code/modules/xenomorph/xenoplant.dm
+++ b/code/modules/xenomorph/xenoplant.dm
@@ -20,7 +20,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!mature && isxeno(user))
+	if(!mature && issamexenohive(user))
 		balloon_alert(user, "Not fully grown")
 		return FALSE
 
@@ -49,6 +49,9 @@
 /obj/structure/xeno/plant/attack_alien(mob/living/carbon/xenomorph/xeno_attacker, damage_amount = xeno_attacker.xeno_caste.melee_damage, damage_type = BRUTE, armor_type = MELEE, effects = TRUE, armor_penetration = xeno_attacker.xeno_caste.melee_ap, isrightclick = FALSE)
 	if((xeno_attacker.status_flags & INCORPOREAL))
 		return FALSE
+
+	if(!issamexenohive(xeno_attacker))
+		return ..()
 
 	if(xeno_attacker.a_intent == INTENT_HARM && isxenodrone(xeno_attacker))
 		balloon_alert(xeno_attacker, "Uprooted the plant")
@@ -225,7 +228,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(ishuman(user))
+	if(ishuman(user) && !issamexenohive(user))
 		balloon_alert(user, "Nothing happens")
 		to_chat(user, span_notice("You caress [src]'s petals, nothing happens."))
 		return FALSE

--- a/code/modules/xenomorph/xenotowers.dm
+++ b/code/modules/xenomorph/xenotowers.dm
@@ -92,6 +92,8 @@
 			take_damage(100, BRUTE, BOMB)
 
 /obj/structure/xeno/lighttower/attack_alien(mob/living/carbon/xenomorph/X, damage_amount = X.xeno_caste.melee_damage, damage_type = BRUTE, damage_flag = "", effects = TRUE, armor_penetration = 0, isrightclick = FALSE)
+	if(!(issamexenohive(X)))
+		return ..()
 	if(X.a_intent == INTENT_HARM) //If we're a builder caste or the creator and we're on harm intent, deconstruct it.
 		balloon_alert(X, "Removing...")
 		if(!do_after(X, XENO_ACID_WELL_FILL_TIME, IGNORE_HELD_ITEM, src, BUSY_ICON_HOSTILE))
@@ -100,3 +102,4 @@
 		playsound(src, "alien_resin_break", 25)
 		deconstruct(TRUE, X)
 		return
+	return ..()


### PR DESCRIPTION
## About The Pull Request

Basically https://github.com/EaglePhntm/NTFvsAlien/pull/200. This one is finished, though, all the changes was tested on local

## Why It's Good For The Game

That offers a lot and more opportunities for xenomorphs

## Changelog

:cl:
add: Each structure has its own hivetype now
add: Marines can pass through corrupted hive's walls
add: Xenomorphs can destroy their own structures
add: Adjusted mapfiles so corrupted spawn on weeds of their hivetype
add: Xenomorphs get slowed on stickies of different hive, they don't receive any speed bonuses either on a node or weed of different hive
add: Allows human factions to sell resin jelly of non-allied hives
balance: Makes doors, walls, turrets, acid wells, sticky resin, etc. harder to bypass for xenos of other hives
balance: Xenomorphs can't use melee weapons other than their claws. With new changes it's simply not needed
balance: Xenomorphs can't instantly destroy structures of different hives anymore. Now they have to actually slash through
/:cl:
