### PR TITLE
Weeds QOL

### DIFF
--- a/code/game/objects/effects/weeds.dm
+++ b/code/game/objects/effects/weeds.dm
@@ -157,14 +157,14 @@
 		take_damage(damage_amount, damage_type, armor_type, effects, get_dir(src, xeno_attacker), armor_penetration, xeno_attacker)
 		return TRUE
 	if(issamexenohive(xeno_attacker) && xeno_attacker.a_intent == INTENT_GRAB)
-		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] starts tearing down \the [src]!"), \
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] starts scooping up \the [src]!"), \
 		span_xenonotice("We start to scoop up \the [src]."))
 		if(!do_after(xeno_attacker, 2 SECONDS, NONE, xeno_attacker, BUSY_ICON_GENERIC))
 			return
 		if(!istype(src)) // Prevent jumping to other turfs if do_after completes with the object already gone
 			return
 		xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_CLAW)
-		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] tears down \the [src]!"), \
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] scoops up \the [src]!"), \
 		span_xenonotice("We scoop up \the [src]."))
 		playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 		take_damage(max_integrity) // Ensure its destroyed
@@ -363,14 +363,14 @@
 		take_damage(max_integrity/2)
 		return TRUE
 	if(issamexenohive(xeno_attacker) && xeno_attacker.a_intent == INTENT_GRAB)
-		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] starts tearing down \the [src]!"), \
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] starts scooping up \the [src]!"), \
 		span_xenonotice("We start to scoop up \the [src]."))
 		if(!do_after(xeno_attacker, 2 SECONDS, NONE, xeno_attacker, BUSY_ICON_GENERIC))
 			return
 		if(!istype(src)) // Prevent jumping to other turfs if do_after completes with the object already gone
 			return
 		xeno_attacker.do_attack_animation(src, ATTACK_EFFECT_CLAW)
-		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] tears down \the [src]!"), \
+		xeno_attacker.visible_message(span_xenonotice("\The [xeno_attacker] scoops up \the [src]!"), \
 		span_xenonotice("We scoop up \the [src]."))
 		playsound(src, SFX_ALIEN_RESIN_BREAK, 25)
 		take_damage(max_integrity) // Ensure its destroyed


### PR DESCRIPTION
## About The Pull Request

You can remove your own weeds by clicking on them with grab intent.  You can remove weeds of a different hive by clicking on them with grab intent, instead of harm intent. Makes weed nodes killable in 2 slashes only.

## Why It's Good For The Game

Grab intent is least used for xenos. In the heat of the battle you would missclick a lot on the weeds, not just that but clicking on one would give you a click delay, meaning that it was technically xeno nerf since you would often miss by harming weeds instead of your enemies. Well that behavior is gone now since you destroy them on grab now! As of node health, usually they get taken down by marines in 1 or 2 hits. Didn't make much sense for xenos to take them out in 3. Though their attack delay was increased to make sure that nodes won't be as easily removable and on par with other melee weapons.

## Changelog

:cl:
add: You can destroy weeds with grab intent
balance: Weed NODES now can be taken down in 2 xeno hits, not 3
balance: Increased weed NODE removal click delay
/:cl:
