### PR TITLE
Edible jelly can be disposed off

### DIFF
--- a/code/game/objects/structures/xeno.dm
+++ b/code/game/objects/structures/xeno.dm
@@ -572,3 +572,15 @@
 	. = ..()
 	var/datum/hive_status/hive = GLOB.hive_datums[hivenumber]
 	. += "It is from the [hive.name] hive"
+
+/obj/item/reagent_containers/food/snacks/nutrient_jelly/attack_self(mob/living/carbon/xenomorph/user)
+	//Activates if the item itself is clicked in hand.
+	if(!isxeno(user))
+		return
+	if(!issamexenohive(user))
+		user.balloon_alert(user, "Wrong hive")
+		return
+	user.balloon_alert(user, "Absorbing...")
+	if(!do_after(user, RESIN_SELF_TIME, TRUE, user, BUSY_ICON_MEDICAL))
+		return
+	qdel(src)

--- a/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
+++ b/code/modules/mob/living/carbon/xenomorph/hive_datum.dm
@@ -1687,3 +1687,6 @@ to_chat will check for valid clients itself already so no need to double check f
 
 /obj/item/resin_jelly/get_xeno_hivenumber()
 	return hivenumber
+
+/obj/item/reagent_containers/food/snacks/nutrient_jelly/get_xeno_hivenumber()
+	return hivenumber


### PR DESCRIPTION
## About The Pull Request

Now you can get rid of edible jelly by absorbing it back

## Why It's Good For The Game

Regular resin jelly for example disappears if you apply it on someone. Edible jelly does not. Keep in mind that it gives you nutriments so you can't eat it away if you make too many. But why eat it if you can absorb it back?

## Changelog

:cl:
add: Edible jelly can be absorbed back if activated in hand
/:cl:
