### PR TITLE
Culverin ammo buff

### DIFF
--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -124,7 +124,7 @@
 	magazine_features_flags = MAGAZINE_REFUND_IN_CHAMBER|MAGAZINE_WORN
 	w_class = WEIGHT_CLASS_HUGE
 	slowdown = 0.2
-	maxcharge = 3000
+	maxcharge = 9000 //3000 = 100 culverin rounds
 	self_recharge = TRUE
 	charge_amount = 100
 	charge_delay = 2 SECONDS

--- a/code/modules/projectiles/magazines/energy.dm
+++ b/code/modules/projectiles/magazines/energy.dm
@@ -126,7 +126,7 @@
 	slowdown = 0.2
 	maxcharge = 9000 //3000 = 100 culverin rounds
 	self_recharge = TRUE
-	charge_amount = 100
+	charge_amount = 150
 	charge_delay = 2 SECONDS
 	light_range = 0.1
 	light_power = 0.1


### PR DESCRIPTION

## About The Pull Request
Increases culverin ammo from 100 to 300
## Why It's Good For The Game
From my understandment culverin underperforms as a supression weapon thanks to its lack of IFF when sided with its NTF variant, the self recharge while an advantage doesn't really also plays in favour with how long it takes to fully charge the weapon, and its ammo being of 100 falls short when it comes to supressing an actual area, specially when compared to a gatling gun 500 rounds. 
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Increased culverin powerpack maxcharge from 3000 to 9000, which is equivalent to 100 to 300 culverin rounds. 
balance: Culverin recharge increased from 100 to 150, thanks to increased maxcharge

/:cl:
