### PR TITLE
Reduces the SH-39's fire rate by 0.2

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -105,7 +105,7 @@
 	attachable_offset = list("muzzle_x" = 41, "muzzle_y" = 20,"rail_x" = 15, "rail_y" = 20, "under_x" = 23, "under_y" = 12, "stock_x" = 11, "stock_y" = 14)
 	starting_attachment_types = list(/obj/item/attachable/stock/t39stock)
 
-	fire_delay = 1.2 SECONDS
+	fire_delay = 1.4 SECONDS
 	accuracy_mult = 1.05
 	accuracy_mult_unwielded = 0.65
 	scatter = 3


### PR DESCRIPTION

## About The Pull Request
After my previous slight tweak, play in testing has shown that the shotgun is still extremely strong, this brings it more in line with other shotguns, making it not literally the best shotgun in the game.
## Why It's Good For The Game
This weapon requires no skill to use and guarantees you will kill your target if you aren't braindead, TGMC made this shotgun have a fire delay of 1.75, so I think this is fine.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  

https://github.com/user-attachments/assets/9307249e-daed-4b14-b6c9-378fa7cbfaea


</details>

## Changelog
:cl:
balance: the SH-39's fire delay is now 1.4 instead of 1.2
/:cl:
