### PR TITLE
Reverts Nerfs + Buffs W.Blast

### DIFF
--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/chimera/abilities_chimera.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/chimera/abilities_chimera.dm
@@ -132,7 +132,7 @@
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_CHIMERA_WARP_BLAST,
 	)
-	var/range = 2
+	var/range = 3
 	var/warp_blast_damage = 30
 
 /datum/action/ability/xeno_action/warp_blast/action_activate()
@@ -302,4 +302,4 @@
 	update_button_icon()
 
 /datum/action/ability/activable/xeno/blink/chimera
-	ability_cost = 75
+	ability_cost = 35

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/chimera/chimera.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/chimera/chimera.dm
@@ -6,7 +6,7 @@
 	icon_state = "Chimera Walking"
 	health = 400
 	maxHealth = 400
-	plasma_stored = 300
+	plasma_stored = 400
 	pixel_x = -16
 	drag_delay = 3
 	tier = XENO_TIER_THREE


### PR DESCRIPTION

## About The Pull Request

Reverts nerfs made to the Tier 3 Xenomorph, Chimera which effectively made it a non-viable pick.
Buffs the range of the ability "Warp Blast" to a radius of 3. (It was _really_ easy to miss before, will see about increasing the cost of the ability if the range increase seems too powerful)
## Why It's Good For The Game

To paraphrase what I said within #discussions, the Chimera is a T3 Xenomorph. In a war gamemode, there's realistically only 1 T3 slot, and with how weak Chimera was nerfed, it felt extremely weak. It's extreme movement capabilities are offset by the fact it has very little health for it's tier.

These nerf reversions are intended to make it a viable pick again, because it felt like a T2 that takes up a very expensive T3 slot.
Plus I was told to PR it.


## Changelog
:cl:
balance: Chimera max plasma reverted to 400, was 300
balance: Chimera "Blink" ability cost reverted to 35, was 75
buff: Chimera "Warp Blast" range increased to 3, was 2 (Let me know if I need to increase the cost to offset buff)
:cl:
