### PR TITLE
Fixes Underwear + Duplicate + Synthetic

### DIFF
--- a/code/modules/clothing/glasses/night.dm
+++ b/code/modules/clothing/glasses/night.dm
@@ -13,6 +13,7 @@
 		"Synskin Combat Robot" = 'icons/mob/species/robot/glasses.dmi')
 	icon_state = "night"
 	worn_icon_state = "glasses"
+	worn_item_state_slots = list()
 	toggleable = TRUE
 	// deactive_state = "night_vision_off" // gonna test what it does without a deactive_state
 	color_cutoffs = list(10, 30, 10)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -636,10 +636,12 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 	overlays_standing[BODYPARTS_LAYER] = image(icon=stand_icon, icon_state="blank", layer=-BODYPARTS_LAYER)
 	apply_overlay(BODYPARTS_LAYER)
 
-/proc/ntf_north_body_clothing_layer(direction)
+/proc/ntf_north_body_clothing_layer(direction, clothing_layer)
 	if(direction != NORTH)
 		return null
-	return -(BODYPARTS_LAYER - 0.5)
+	. = -(BODYPARTS_LAYER - 0.5)
+	if(!isnull(clothing_layer))
+		. -= clothing_layer * 0.001
 
 /proc/ntf_set_worn_appearance_layer(mutable_appearance/standing, draw_layer)
 	if(isnull(draw_layer) || !standing)
@@ -919,7 +921,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		w_socks.screen_loc = "WEST:6,SOUTH+5:15"
 		client.screen += w_socks
 
-	overlays_standing[SOCKS_LAYER] = ntf_set_worn_appearance_layer(w_socks.make_worn_icon(species_type = species.name, slot_name = slot_socks_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = SOCKS_LAYER), ntf_north_body_clothing_layer(dir))
+	overlays_standing[SOCKS_LAYER] = ntf_set_worn_appearance_layer(w_socks.make_worn_icon(species_type = species.name, slot_name = slot_socks_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = SOCKS_LAYER), ntf_north_body_clothing_layer(dir, SOCKS_LAYER))
 
 	apply_overlay(SOCKS_LAYER)
 
@@ -932,7 +934,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		w_underwear.screen_loc = "WEST:6,SOUTH+4:13"
 		client.screen += w_underwear
 
-	overlays_standing[UNDERWEAR_LAYER] = ntf_set_worn_appearance_layer(w_underwear.make_worn_icon(species_type = species.name, slot_name = slot_underwear_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = UNDERWEAR_LAYER), ntf_north_body_clothing_layer(dir))
+	overlays_standing[UNDERWEAR_LAYER] = ntf_set_worn_appearance_layer(w_underwear.make_worn_icon(species_type = species.name, slot_name = slot_underwear_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = UNDERWEAR_LAYER), ntf_north_body_clothing_layer(dir, UNDERWEAR_LAYER))
 
 	apply_overlay(UNDERWEAR_LAYER)
 
@@ -945,7 +947,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		w_undershirt.screen_loc = "WEST:6,SOUTH+6:17"
 		client.screen += w_undershirt
 
-	overlays_standing[UNDERSHIRT_LAYER] = ntf_set_worn_appearance_layer(w_undershirt.make_worn_icon(species_type = species.name, slot_name = slot_shirt_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = UNDERSHIRT_LAYER), ntf_north_body_clothing_layer(dir))
+	overlays_standing[UNDERSHIRT_LAYER] = ntf_set_worn_appearance_layer(w_undershirt.make_worn_icon(species_type = species.name, slot_name = slot_shirt_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = UNDERSHIRT_LAYER), ntf_north_body_clothing_layer(dir, UNDERSHIRT_LAYER))
 
 	apply_overlay(UNDERSHIRT_LAYER)
 
@@ -958,7 +960,7 @@ GLOBAL_LIST_EMPTY(damage_icon_parts)
 		bra.screen_loc = "WEST+1:8,SOUTH+4:13"
 		client.screen += bra
 
-	overlays_standing[BRA_LAYER] = ntf_set_worn_appearance_layer(bra.make_worn_icon(species_type = species.name, slot_name = slot_bra_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = BRA_LAYER), ntf_north_body_clothing_layer(dir))
+	overlays_standing[BRA_LAYER] = ntf_set_worn_appearance_layer(bra.make_worn_icon(species_type = species.name, slot_name = slot_bra_str, default_icon = 'ntf_modular/modules/underwear/underwear/underwear.dmi', default_layer = BRA_LAYER), ntf_north_body_clothing_layer(dir, BRA_LAYER))
 
 	apply_overlay(BRA_LAYER)
 

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -639,6 +639,9 @@
 /mob/living/carbon/xenomorph/proc/sync_hive_abilities()
 	if(hive)
 		for(var/datum/action/ability/hive_ability AS in hive.hive_abilities)
+			var/ability_type = ispath(hive_ability) ? hive_ability : hive_ability.type
+			if(actions_by_path[ability_type])
+				continue
 			if(((hive_ability.parent_type) in xeno_caste.actions) && !hive_ability.cooldown_duration)
 				continue
 			add_ability(hive_ability)

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -160,10 +160,14 @@
 
 
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, safety = FALSE)
-	if(species && GLOB.all_species[species])
-		character.set_species(species)
-	else
-		character.set_species("Human")
+	var/datum/species/preference_species = GLOB.all_species[species]
+	var/preserve_job_species = (character.species?.species_flags & (IS_SYNTHETIC|ROBOTIC_LIMBS)) && !(preference_species?.species_flags & (IS_SYNTHETIC|ROBOTIC_LIMBS))
+	// Synthetic jobs spawn an exact synthetic/robot species before preferences are copied.
+	if(!preserve_job_species)
+		if(preference_species)
+			character.set_species(species)
+		else
+			character.set_species("Human")
 	sync_synthetic_type_to_species()
 
 	var/new_name

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -57,7 +57,7 @@ img.icon {
 	text-align: center;
 	white-space: nowrap;
 	vertical-align: middle;
-	background-color: crimson;
+	background-color: #dc143c;
 	border-radius: 10px;
 }
 

--- a/ntf_modular/code/datums/genital_menu.dm
+++ b/ntf_modular/code/datums/genital_menu.dm
@@ -175,6 +175,11 @@ GLOBAL_LIST_INIT(breast_number_to_size, list(
 		"vaginaState" = GLOB.possible_vagina_sprite_names[human.vagina],
 		"bellyState" = GLOB.possible_belly_sprite_names[human.belly],
 		"testicleState" = GLOB.possible_testicle_sprite_names[human.testicles],
+		"assSize" = human.ass_size,
+		"boobSize" = GLOB.breast_number_to_size["[human.boobs_size]"] || GLOB.breast_number_to_size["3"],
+		"cockSize" = human.cock_size,
+		"bellySize" = human.belly_size,
+		"testicleSize" = human.testicles_size,
 	)
 	data["possibleCockStates"] = list()
 	for(var/entry in GLOB.possible_cock_sprites)
@@ -199,6 +204,10 @@ GLOBAL_LIST_INIT(breast_number_to_size, list(
 	data["possibleTesticleStates"] = list()
 	for(var/entry in GLOB.possible_testicle_sprites)
 		data["possibleTesticleStates"] += entry
+
+	data["possibleBoobSizes"] = list()
+	for(var/entry in GLOB.breast_size_to_number)
+		data["possibleBoobSizes"] += entry
 
 	return data
 
@@ -271,6 +280,32 @@ GLOBAL_LIST_INIT(breast_number_to_size, list(
 			human.update_genitals()
 			return TRUE
 
+		if("changeSize")
+			var/size_field = params["field"]
+			switch(size_field)
+				if("ass")
+					human.ass_size = sanitize_integer(params["newSize"], 1, 8, initial(human.ass_size))
+					human.client?.prefs?.genitalia_ass_size = human.ass_size
+				if("boobs")
+					var/new_boob_size = params["newSize"]
+					if(!(new_boob_size in GLOB.breast_size_to_number))
+						return TRUE
+					human.boobs_size = GLOB.breast_size_to_number[new_boob_size]
+					human.client?.prefs?.genitalia_boobs_size = human.boobs_size
+				if("cock")
+					human.cock_size = sanitize_integer(params["newSize"], 1, 7, initial(human.cock_size))
+					human.client?.prefs?.genitalia_cock_size = human.cock_size
+				if("belly")
+					human.belly_size = sanitize_integer(params["newSize"], 0, 10, initial(human.belly_size))
+					human.client?.prefs?.genitalia_belly_size = human.belly_size
+				if("testicles")
+					human.testicles_size = sanitize_integer(params["newSize"], 0, 8, initial(human.testicles_size))
+					human.client?.prefs?.genitalia_testicles_size = human.testicles_size
+				else
+					return TRUE
+			human.update_genitals()
+			return TRUE
+
 		if("reset")
 			human.boobs = null
 			human.ass = null
@@ -278,11 +313,21 @@ GLOBAL_LIST_INIT(breast_number_to_size, list(
 			human.vagina = null
 			human.belly = null
 			human.testicles = null
+			human.boobs_size = initial(human.boobs_size)
+			human.ass_size = initial(human.ass_size)
+			human.cock_size = initial(human.cock_size)
+			human.belly_size = initial(human.belly_size)
+			human.testicles_size = initial(human.testicles_size)
 			human.client?.prefs?.genitalia_boobs = null
 			human.client?.prefs?.genitalia_ass = null
 			human.client?.prefs?.genitalia_cock = null
 			human.client?.prefs?.genitalia_vagina = null
 			human.client?.prefs?.genitalia_belly = null
 			human.client?.prefs?.genitalia_testicles = null
+			human.client?.prefs?.genitalia_boobs_size = human.boobs_size
+			human.client?.prefs?.genitalia_ass_size = human.ass_size
+			human.client?.prefs?.genitalia_cock_size = human.cock_size
+			human.client?.prefs?.genitalia_belly_size = human.belly_size
+			human.client?.prefs?.genitalia_testicles_size = human.testicles_size
 			human.update_genitals()
 			return TRUE

--- a/ntf_modular/code/modules/client/preferences_character_creator.dm
+++ b/ntf_modular/code/modules/client/preferences_character_creator.dm
@@ -622,6 +622,25 @@
 		return TRUE
 
 	switch(action)
+		if("sync_character_creator_colors_to_body")
+			var/field = params["field"]
+			var/body_color_to_copy = sanitize_hexcolor(body_color, 6, TRUE, initial(body_color))
+			if(field in genital_actions)
+				for(var/color_index in 1 to character_creator_genital_color_count(field))
+					var/color_var = character_creator_genital_color_var(field, color_index)
+					if(color_var)
+						vars[color_var] = body_color_to_copy
+				update_preview_icon()
+				return TRUE
+			if(field in character_creator_part_ids())
+				var/list/part_definition = character_creator_part_definition(field)
+				var/color_count = part_definition?["colors"] || 0
+				for(var/color_index in 1 to color_count)
+					var/color_var = character_creator_color_var(field, color_index)
+					if(color_var)
+						vars[color_var] = body_color_to_copy
+				update_preview_icon()
+				return TRUE
 		if("genitalia_ass_size")
 			genitalia_ass_size = sanitize_integer(params["newValue"], 1, 8, initial(genitalia_ass_size))
 			update_preview_icon()

--- a/tgui/packages/tgui/interfaces/GenitalMenu.tsx
+++ b/tgui/packages/tgui/interfaces/GenitalMenu.tsx
@@ -1,4 +1,11 @@
-import { Button, Dropdown, LabeledList, Section, Stack } from 'tgui-core/components';
+import {
+  Button,
+  Dropdown,
+  LabeledList,
+  NumberInput,
+  Section,
+  Stack,
+} from 'tgui-core/components';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';
@@ -10,12 +17,18 @@ interface InputData {
   vaginaState: string;
   bellyState: string;
   testicleState: string;
+  assSize: number;
+  boobSize: string;
+  cockSize: number;
+  bellySize: number;
+  testicleSize: number;
   possibleCockStates: string[];
   possibleAssStates: string[];
   possibleBoobStates: string[];
   possibleVaginaStates: string[];
   possibleBellyStates: string[];
   possibleTesticleStates: string[];
+  possibleBoobSizes: string[];
 }
 
 export const GenitalMenu = (props: any, context: any) => {
@@ -27,16 +40,22 @@ export const GenitalMenu = (props: any, context: any) => {
     vaginaState,
     bellyState,
     testicleState,
+    assSize,
+    boobSize,
+    cockSize,
+    bellySize,
+    testicleSize,
     possibleCockStates,
     possibleAssStates,
     possibleBoobStates,
     possibleVaginaStates,
     possibleBellyStates,
     possibleTesticleStates,
+    possibleBoobSizes,
   } = data;
 
   return (
-    <Window title="Genital selection" width={300} height={310}>
+    <Window title="Genital selection" width={330} height={470}>
       <Window.Content />
       <Section>
         <Stack fill vertical>
@@ -64,6 +83,21 @@ export const GenitalMenu = (props: any, context: any) => {
                   }
                 />
               </LabeledList.Item>
+              <LabeledList.Item label="Butt Size">
+                <NumberInput
+                  value={assSize}
+                  minValue={1}
+                  maxValue={8}
+                  step={1}
+                  width="64px"
+                  onChange={(value) =>
+                    act('changeSize', {
+                      field: 'ass',
+                      newSize: value,
+                    })
+                  }
+                />
+              </LabeledList.Item>
               <LabeledList.Item label="Boobs">
                 <Dropdown
                   options={possibleBoobStates}
@@ -71,6 +105,18 @@ export const GenitalMenu = (props: any, context: any) => {
                   onSelected={(e: string) =>
                     act('changeBoobs', {
                       newState: e,
+                    })
+                  }
+                />
+              </LabeledList.Item>
+              <LabeledList.Item label="Boob Size">
+                <Dropdown
+                  options={possibleBoobSizes}
+                  selected={boobSize}
+                  onSelected={(e: string) =>
+                    act('changeSize', {
+                      field: 'boobs',
+                      newSize: e,
                     })
                   }
                 />
@@ -97,6 +143,21 @@ export const GenitalMenu = (props: any, context: any) => {
                   }
                 />
               </LabeledList.Item>
+              <LabeledList.Item label="Testicle Size">
+                <NumberInput
+                  value={testicleSize}
+                  minValue={0}
+                  maxValue={8}
+                  step={1}
+                  width="64px"
+                  onChange={(value) =>
+                    act('changeSize', {
+                      field: 'testicles',
+                      newSize: value,
+                    })
+                  }
+                />
+              </LabeledList.Item>
               <LabeledList.Item label="Belly">
                 <Dropdown
                   options={possibleBellyStates}
@@ -104,6 +165,36 @@ export const GenitalMenu = (props: any, context: any) => {
                   onSelected={(e: string) =>
                     act('changeBelly', {
                       newState: e,
+                    })
+                  }
+                />
+              </LabeledList.Item>
+              <LabeledList.Item label="Belly Size">
+                <NumberInput
+                  value={bellySize}
+                  minValue={0}
+                  maxValue={10}
+                  step={1}
+                  width="64px"
+                  onChange={(value) =>
+                    act('changeSize', {
+                      field: 'belly',
+                      newSize: value,
+                    })
+                  }
+                />
+              </LabeledList.Item>
+              <LabeledList.Item label="Penis Size">
+                <NumberInput
+                  value={cockSize}
+                  minValue={1}
+                  maxValue={7}
+                  step={1}
+                  width="64px"
+                  onChange={(value) =>
+                    act('changeSize', {
+                      field: 'cock',
+                      newSize: value,
                     })
                   }
                 />

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
@@ -76,7 +76,7 @@ export const CharacterCustomization = (props) => {
       onClick={() => act(action)}
     />
   );
-  const colorField = (label, color, action, extra = null) => (
+  const colorField = (label, color, action, extra: any = null) => (
     <LabeledList.Item label={label}>
       {colorSwatchButton(color, action, color)}
       {extra}
@@ -219,6 +219,16 @@ export const CharacterCustomization = (props) => {
     }
     return (
       <Box as="span">
+        <Button
+          compact
+          icon="fill-drip"
+          tooltip="Match body color"
+          onClick={() =>
+            act('sync_character_creator_colors_to_body', {
+              field: row.id,
+            })
+          }
+        />
         {Array.from({ length: colorCount }, (_, index) => {
           const colorIndex = index + 1;
           const colorAction =


### PR DESCRIPTION
## About The Pull Request

This PR fixes several character customization and appearance issues on the current branch.

It prevents synthetic/job-assigned synthetic species from being overwritten by saved character species preferences during spawn. This keeps synthetic species traits intact, including their intended synthetic flags and related abilities.

It also fixes underwear/body overlay layering so underwear-style overlays do not render above worn clothing, fixes a BYOND stylesheet compile warning caused by a named color value, and removes runtime noise from night vision goggles initializing their worn icon state.

For customization, it adds body-color matching controls to genital/accessory color fields, adds genital size controls to the character customization screen, and adds size controls to the in-game `IC -> Genital selection` menu.

There is also a small guard for xeno hive ability syncing to avoid adding duplicate ability actions.

## Why It's Good For The Game

Synthetics should keep their synthetic species behavior after spawning. Losing those traits can cause major gameplay issues, including missing built-in synthetic functionality and potentially gaining unintended organic species behavior.

The appearance fixes make character customization more reliable and less frustrating. Players can more easily match colors, adjust sizes in-game, and avoid visual bugs where body overlays appear over clothing.

The runtime and duplicate-action fixes reduce avoidable noise and help keep debugging cleaner. (It was also annoying seeing it there)

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
<img width="1401" height="1001" alt="dreamseeker_F4RMo9lHDT" src="https://github.com/user-attachments/assets/63cca19f-21b1-48a6-8a12-6fee9cb02cb6" />
<img width="770" height="632" alt="image" src="https://github.com/user-attachments/assets/bd86f1fb-bfc3-493d-b3d9-76fb8c85bbc3" />


Compiled successfully with:

```powershell
tools\build\build.bat dm

</details>
Changelog
:cl:
add: Added body color matching controls for genital/accessory color customization.
add: Added genital size controls to character customization and the in-game genital selection menu.
fix: Fixed synthetics losing their intended synthetic species traits after spawning.
fix: Fixed underwear/body overlays rendering above clothing.
fix: Fixed night vision goggles causing runtime noise during initialization.
fix: Fixed a stylesheet compile warning from an invalid color value.
admin: Improved xeno hive ability syncing to avoid duplicate ability actions.
/:cl:
```