### PR TITLE
Quick fix lag issue

### DIFF
--- a/ntf_modular/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/ntf_modular/code/modules/mob/living/carbon/human/human_defines.dm
@@ -42,4 +42,5 @@
 	var/mob/living/carbon/xenomorph/devouring_mob
 	// Haul resist cooldown
 	var/next_haul_resist
+	var/last_directional_overlay_dir = NONE
 	speaking_noise = 'ntf_modular/sound/voice/talk.ogg'

--- a/ntf_modular/code/modules/mob/living/carbon/human/update_accessories.dm
+++ b/ntf_modular/code/modules/mob/living/carbon/human/update_accessories.dm
@@ -552,15 +552,29 @@
 	. = ..()
 	if(old_dir == dir)
 		return
+	if(ISDIAGONALDIR(old_dir) || ISDIAGONALDIR(dir))
+		queue_directional_overlay_update()
+	else
+		update_directional_overlays()
+
+/mob/living/carbon/human/proc/queue_directional_overlay_update()
+	addtimer(CALLBACK(src, PROC_REF(update_directional_overlays)), 1, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+/mob/living/carbon/human/proc/update_directional_overlays()
+	if(ISDIAGONALDIR(dir))
+		return
+	if(last_directional_overlay_dir == dir)
+		return
+	last_directional_overlay_dir = dir
 	update_accessories()
-	update_genitals()
-	update_inv_w_uniform()
-	update_inv_gloves()
+	update_genitals(FALSE)
+	update_inv_w_uniform(FALSE)
+	update_inv_gloves(FALSE)
 	update_inv_belt()
-	update_inv_back()
-	update_inv_shoes()
-	update_inv_wear_suit()
+	update_inv_shoes(FALSE)
+	update_inv_wear_suit(FALSE)
 	update_inv_socks()
 	update_inv_underwear()
 	update_inv_undershirt()
 	update_inv_bra()
+	update_body_marking_emissives()

--- a/ntf_modular/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/ntf_modular/code/modules/mob/living/carbon/human/update_icons.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_EMPTY(human_genitals_cache)
 		return FALSE
 	return TRUE
 
-/mob/living/carbon/human/proc/update_genitals()
+/mob/living/carbon/human/proc/update_genitals(save_character = TRUE)
 	remove_overlay(GENITAL_LAYER)
 	if(!species?.has_genital_selection)
 		return
@@ -149,25 +149,30 @@ GLOBAL_LIST_EMPTY(human_genitals_cache)
 
 	overlays_standing[GENITAL_LAYER] = genilist
 	apply_overlay(GENITAL_LAYER)
-	client?.prefs.save_character()
+	if(save_character)
+		client?.prefs.save_character()
 
-/mob/living/carbon/human/update_inv_w_uniform()
+/mob/living/carbon/human/update_inv_w_uniform(update_dependent_overlays = TRUE)
 	. = ..()
-	update_genitals()
-	update_body_marking_emissives()
+	if(update_dependent_overlays)
+		update_genitals()
+		update_body_marking_emissives()
 
-/mob/living/carbon/human/update_inv_wear_suit()
+/mob/living/carbon/human/update_inv_wear_suit(update_dependent_overlays = TRUE)
 	. = ..()
-	update_genitals()
-	update_body_marking_emissives()
+	if(update_dependent_overlays)
+		update_genitals()
+		update_body_marking_emissives()
 
-/mob/living/carbon/human/update_inv_gloves()
+/mob/living/carbon/human/update_inv_gloves(update_dependent_overlays = TRUE)
 	. = ..()
-	update_body_marking_emissives()
+	if(update_dependent_overlays)
+		update_body_marking_emissives()
 
-/mob/living/carbon/human/update_inv_shoes()
+/mob/living/carbon/human/update_inv_shoes(update_dependent_overlays = TRUE)
 	. = ..()
-	update_body_marking_emissives()
+	if(update_dependent_overlays)
+		update_body_marking_emissives()
 
 /mob/living/carbon/human/update_inv_head()
 	. = ..()


### PR DESCRIPTION
About The Pull Request
Changes how human directional overlay refreshes behave when movement passes through diagonal directions.

Human overlay updates that go through diagonal-facing transitions are now coalesced instead of being rebuilt repeatedly during the same movement flow. Normal cardinal-facing updates still apply immediately, so direction-sensitive layers can continue to update when needed.

This also avoids duplicate dependent redraws and skips character preference saves during direction-only genital overlay refreshes.

Why It's Good For The Game
Diagonal human movement was causing repeated expensive overlay refreshes, which showed up as SSinput spikes and movement lag. This reduces that unnecessary work while preserving the visual updates needed for north/south/east/west-facing human overlays.

Players should experience smoother diagonal movement on humans, especially in cases where humans have several worn items or customization overlays.

Proof of Testing
<details> <summary>Screenshots/Videos</summary>
Compiled with tools/build/build.bat --wait-on-error clean build.
TGUI rebuilt successfully.
DreamMaker compiled successfully with 0 errors, 0 warnings.
Tested human cardinal movement and diagonal movement in-game.
Confirmed diagonal movement no longer causes the same level of SSinput complaints as before.
</details>
Changelog
:cl:
fix: Reduced input lag caused by human diagonal movement repeatedly refreshing directional overlays.
/:cl: