### PR TITLE
Reduce idle machinery processing overhead 

### DIFF
--- a/code/__DEFINES/_subsystems.dm
+++ b/code/__DEFINES/_subsystems.dm
@@ -30,6 +30,15 @@
 /// Used to trigger object removal from a processing list
 #define PROCESS_KILL 26
 
+#define SSMACHINES_POWERNETS 1
+#define SSMACHINES_MACHINES_EARLY 2
+#define SSMACHINES_MACHINES 3
+#define SSMACHINES_MACHINES_POWER 4
+#define SSMACHINES_APCS 5
+#define SSMACHINES_APCS_CHARGE 6
+#define SSMACHINES_APCS_LATE 7
+#define SSMACHINES_MACHINES_LATE 8
+
 //For servers that can't do with any additional lag, set this to none in flightpacks.dm in subsystem/processing.
 #define FLIGHTSUIT_PROCESSING_NONE 0
 #define FLIGHTSUIT_PROCESSING_FULL 1

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -6,10 +6,39 @@ SUBSYSTEM_DEF(machines)
 	flags = SS_KEEP_TIMING
 	runlevels = RUNLEVEL_LOBBY|RUNLEVEL_SETUP|RUNLEVEL_GAME|RUNLEVEL_POSTGAME
 
+#define SSMACHINES_PROFILE_THRESHOLD 1
+
 	var/list/currentrun = list()
+	var/list/processing_early = list()
 	var/list/processing = list()
+	var/list/processing_power = list()
+	var/list/processing_late = list()
+	var/list/processing_apcs = list()
 	var/list/powernets = list()
 	var/list/zlevel_cables = list() //up or down cables
+	var/current_part = SSMACHINES_POWERNETS
+	var/cost_powernets = 0
+	var/cost_machines_early = 0
+	var/cost_machines = 0
+	var/cost_machines_power = 0
+	var/cost_apcs = 0
+	var/cost_apcs_charge = 0
+	var/cost_apcs_late = 0
+	var/cost_machines_late = 0
+	var/top_machine_process_type = "none"
+	var/top_machine_process_cost = 0
+	var/top_machine_process_count = 0
+	var/top_machine_power_type = "none"
+	var/top_machine_power_cost = 0
+	var/top_machine_power_count = 0
+	var/list/machine_process_type_costs = list()
+	var/list/machine_process_type_counts = list()
+	var/list/machine_process_group_costs = list()
+	var/list/machine_process_group_counts = list()
+	var/list/machine_power_type_costs = list()
+	var/list/machine_power_type_counts = list()
+	var/list/machine_power_group_costs = list()
+	var/list/machine_power_group_counts = list()
 
 /datum/controller/subsystem/machines/Initialize()
 	makepowernets()
@@ -28,31 +57,305 @@ SUBSYSTEM_DEF(machines)
 			propagate_network(PC,PC.powernet)
 
 /datum/controller/subsystem/machines/stat_entry(msg)
-	msg = "PM:[length(processing)]|PN:[length(powernets)]"
+	msg = "P:[get_current_part_name()]|R:[length(currentrun)]|PE:[length(processing_early)]|PM:[length(processing)]|PW:[length(processing_power)]|APC:[length(processing_apcs)]|PN:[length(powernets)]|PL:[length(processing_late)]"
+	msg += "|C:PN[round(cost_powernets,0.1)] E[round(cost_machines_early,0.1)] M[round(cost_machines,0.1)] PW[round(cost_machines_power,0.1)] A[round(cost_apcs,0.1)] C[round(cost_apcs_charge,0.1)] L[round(cost_apcs_late,0.1)] ML[round(cost_machines_late,0.1)]"
+	msg += "|Top:M [format_top_machine_type(top_machine_process_type, top_machine_process_cost, top_machine_process_count)] PW [format_top_machine_type(top_machine_power_type, top_machine_power_cost, top_machine_power_count)]"
+	msg += "|Grp:M [get_top_machine_process_groups()] PW [get_top_machine_power_groups()]"
 	return ..()
+
+/datum/controller/subsystem/machines/proc/get_current_part_name()
+	switch(current_part)
+		if(SSMACHINES_POWERNETS)
+			return "PN"
+		if(SSMACHINES_MACHINES_EARLY)
+			return "EARLY"
+		if(SSMACHINES_MACHINES)
+			return "M"
+		if(SSMACHINES_MACHINES_POWER)
+			return "PW"
+		if(SSMACHINES_APCS)
+			return "APC"
+		if(SSMACHINES_APCS_CHARGE)
+			return "CHG"
+		if(SSMACHINES_APCS_LATE)
+			return "LATE"
+		if(SSMACHINES_MACHINES_LATE)
+			return "ML"
+	return "?"
 
 /datum/controller/subsystem/machines/fire(resumed = FALSE)
 	if (!resumed)
-		for(var/datum/powernet/Powernet in powernets)
-			Powernet.reset() //reset the power state.
-		src.currentrun = processing.Copy()
-
-	//cache for sanic speed (lists are references anyways)
-	var/list/currentrun = src.currentrun
+		current_part = SSMACHINES_POWERNETS
+		src.currentrun = powernets.Copy()
 
 	var/seconds = wait * 0.1
-	while(length(currentrun))
-		var/obj/machinery/thing = currentrun[length(currentrun)]
-		currentrun.len--
-		if(!QDELETED(thing) && thing.process(seconds) != PROCESS_KILL)
-			if(thing.use_power)
-				thing.auto_use_power() //add back the power state
-		else
-			processing -= thing
+
+	if(current_part == SSMACHINES_POWERNETS)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+
+		while(length(currentrun))
+			var/datum/powernet/powernet = currentrun[length(currentrun)]
+			currentrun.len--
+			if(!QDELETED(powernet))
+				powernet.reset() //reset the power state.
+			if(MC_TICK_CHECK)
+				return
+
+		cost_powernets = MC_AVERAGE(cost_powernets, TICK_USAGE_TO_MS(timer))
+		current_part = SSMACHINES_MACHINES_EARLY
+		processing_power.Cut()
+		src.currentrun = processing_early.Copy()
+
+	if(current_part == SSMACHINES_MACHINES_EARLY)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+
+		while(length(currentrun))
+			var/obj/machinery/thing = currentrun[length(currentrun)]
+			currentrun.len--
 			if(!QDELETED(thing))
+				var/process_result = thing.process(seconds)
+				if(process_result != PROCESS_KILL)
+					if(thing.use_power && !thing.use_static_power)
+						processing_power += thing
+				else
+					processing_early -= thing
+					thing.datum_flags &= ~DF_ISPROCESSING
+			else
+				processing_early -= thing
+			if(MC_TICK_CHECK)
+				return
+
+		cost_machines_early = MC_AVERAGE(cost_machines_early, TICK_USAGE_TO_MS(timer))
+		current_part = SSMACHINES_MACHINES
+		reset_machine_process_profile()
+		src.currentrun = processing.Copy()
+
+	if(current_part == SSMACHINES_MACHINES)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+		var/profile_types = cost_machines >= SSMACHINES_PROFILE_THRESHOLD
+
+		while(length(currentrun))
+			var/obj/machinery/thing = currentrun[length(currentrun)]
+			currentrun.len--
+			if(!QDELETED(thing))
+				var/process_result
+				if(profile_types)
+					var/type_timer = TICK_USAGE_REAL
+					process_result = thing.process(seconds)
+					var/type_cost = TICK_USAGE_TO_MS(type_timer)
+					var/type_key = "[thing.type]"
+					machine_process_type_costs[type_key] += type_cost
+					machine_process_type_counts[type_key] += 1
+					var/group_key = get_machine_profile_group(thing)
+					machine_process_group_costs[group_key] += type_cost
+					machine_process_group_counts[group_key] += 1
+				else
+					process_result = thing.process(seconds)
+				if(process_result != PROCESS_KILL)
+					if(thing.use_power && !thing.use_static_power)
+						processing_power += thing
+				else
+					processing -= thing
+					thing.datum_flags &= ~DF_ISPROCESSING
+			else
+				processing -= thing
+			if(MC_TICK_CHECK)
+				return
+
+		cost_machines = MC_AVERAGE(cost_machines, TICK_USAGE_TO_MS(timer))
+		if(profile_types)
+			update_top_machine_process_type()
+		current_part = SSMACHINES_MACHINES_POWER
+		reset_machine_power_profile()
+		src.currentrun = processing_power.Copy()
+
+	if(current_part == SSMACHINES_MACHINES_POWER)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+		var/profile_types = cost_machines_power >= SSMACHINES_PROFILE_THRESHOLD
+
+		while(length(currentrun))
+			var/obj/machinery/thing = currentrun[length(currentrun)]
+			currentrun.len--
+			if(!QDELETED(thing) && (thing.datum_flags & DF_ISPROCESSING))
+				if(profile_types)
+					var/type_timer = TICK_USAGE_REAL
+					thing.auto_use_power() //add back the power state
+					var/type_cost = TICK_USAGE_TO_MS(type_timer)
+					var/type_key = "[thing.type]"
+					machine_power_type_costs[type_key] += type_cost
+					machine_power_type_counts[type_key] += 1
+					var/group_key = get_machine_profile_group(thing)
+					machine_power_group_costs[group_key] += type_cost
+					machine_power_group_counts[group_key] += 1
+				else
+					thing.auto_use_power() //add back the power state
+			if(MC_TICK_CHECK)
+				return
+
+		cost_machines_power = MC_AVERAGE(cost_machines_power, TICK_USAGE_TO_MS(timer))
+		if(profile_types)
+			update_top_machine_power_type()
+		current_part = SSMACHINES_APCS
+		src.currentrun = processing_apcs.Copy()
+
+	if(current_part == SSMACHINES_APCS)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+
+		while(length(currentrun))
+			var/obj/machinery/power/apc/thing = currentrun[length(currentrun)]
+			currentrun.len--
+			if(QDELETED(thing))
+				processing_apcs -= thing
+			else
+				thing.process_power(seconds)
+			if(MC_TICK_CHECK)
+				return
+
+		cost_apcs = MC_AVERAGE(cost_apcs, TICK_USAGE_TO_MS(timer))
+		current_part = SSMACHINES_APCS_CHARGE
+		src.currentrun = processing_apcs.Copy()
+
+	if(current_part == SSMACHINES_APCS_CHARGE)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+
+		while(length(currentrun))
+			var/obj/machinery/power/apc/thing = currentrun[length(currentrun)]
+			currentrun.len--
+			if(QDELETED(thing))
+				processing_apcs -= thing
+			else
+				thing.process_charge(seconds)
+			if(MC_TICK_CHECK)
+				return
+
+		cost_apcs_charge = MC_AVERAGE(cost_apcs_charge, TICK_USAGE_TO_MS(timer))
+		current_part = SSMACHINES_APCS_LATE
+		src.currentrun = processing_apcs.Copy()
+
+	if(current_part == SSMACHINES_APCS_LATE)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+
+		while(length(currentrun))
+			var/obj/machinery/power/apc/thing = currentrun[length(currentrun)]
+			currentrun.len--
+			if(QDELETED(thing))
+				processing_apcs -= thing
+			else
+				thing.process_late(seconds)
+			if(MC_TICK_CHECK)
+				return
+
+		cost_apcs_late = MC_AVERAGE(cost_apcs_late, TICK_USAGE_TO_MS(timer))
+		current_part = SSMACHINES_MACHINES_LATE
+		src.currentrun = processing_late.Copy()
+
+	if(current_part == SSMACHINES_MACHINES_LATE)
+		//cache for sanic speed (lists are references anyways)
+		var/list/currentrun = src.currentrun
+		var/timer = TICK_USAGE_REAL
+
+		while(length(currentrun))
+			var/obj/machinery/thing = currentrun[length(currentrun)]
+			currentrun.len--
+			if(QDELETED(thing) || thing.process_late(seconds) == PROCESS_KILL)
+				processing_late -= thing
 				thing.datum_flags &= ~DF_ISPROCESSING
-		if(MC_TICK_CHECK)
-			return
+			if(MC_TICK_CHECK)
+				return
+
+		cost_machines_late = MC_AVERAGE(cost_machines_late, TICK_USAGE_TO_MS(timer))
+
+
+/datum/controller/subsystem/machines/proc/reset_machine_process_profile()
+	top_machine_process_type = "none"
+	top_machine_process_cost = 0
+	top_machine_process_count = 0
+	machine_process_type_costs.Cut()
+	machine_process_type_counts.Cut()
+	machine_process_group_costs.Cut()
+	machine_process_group_counts.Cut()
+
+/datum/controller/subsystem/machines/proc/reset_machine_power_profile()
+	top_machine_power_type = "none"
+	top_machine_power_cost = 0
+	top_machine_power_count = 0
+	machine_power_type_costs.Cut()
+	machine_power_type_counts.Cut()
+	machine_power_group_costs.Cut()
+	machine_power_group_counts.Cut()
+
+/datum/controller/subsystem/machines/proc/update_top_machine_process_type()
+	for(var/type_key in machine_process_type_costs)
+		var/type_cost = machine_process_type_costs[type_key]
+		if(type_cost > top_machine_process_cost)
+			top_machine_process_cost = type_cost
+			top_machine_process_count = machine_process_type_counts[type_key]
+			top_machine_process_type = type_key
+
+/datum/controller/subsystem/machines/proc/update_top_machine_power_type()
+	for(var/type_key in machine_power_type_costs)
+		var/type_cost = machine_power_type_costs[type_key]
+		if(type_cost > top_machine_power_cost)
+			top_machine_power_cost = type_cost
+			top_machine_power_count = machine_power_type_counts[type_key]
+			top_machine_power_type = type_key
+
+/datum/controller/subsystem/machines/proc/get_top_machine_process_groups()
+	return get_top_machine_groups(machine_process_group_costs, machine_process_group_counts)
+
+/datum/controller/subsystem/machines/proc/get_top_machine_power_groups()
+	return get_top_machine_groups(machine_power_group_costs, machine_power_group_counts)
+
+/datum/controller/subsystem/machines/proc/get_top_machine_groups(list/group_costs, list/group_counts)
+	var/list/found_groups = list()
+	var/list/output = list()
+	for(var/i in 1 to 3)
+		var/top_group = null
+		var/top_cost = 0
+		for(var/group_key in group_costs)
+			if(found_groups[group_key])
+				continue
+			var/group_cost = group_costs[group_key]
+			if(group_cost > top_cost)
+				top_cost = group_cost
+				top_group = group_key
+		if(!top_group)
+			break
+		found_groups[top_group] = TRUE
+		output += "[top_group]([round(top_cost,0.1)]/[group_counts[top_group]])"
+	if(!length(output))
+		return "none"
+	return output.Join(",")
+
+/datum/controller/subsystem/machines/proc/format_top_machine_type(machine_type, machine_cost, machine_count)
+	if(!machine_count)
+		return "none"
+	return "[machine_type]([round(machine_cost,0.1)]/[machine_count])"
+
+/datum/controller/subsystem/machines/proc/get_machine_profile_group(obj/machinery/thing)
+	var/type_string = "[thing.type]"
+	var/slashes_seen = 0
+	for(var/i in 1 to length(type_string))
+		if(copytext(type_string, i, i + 1) != "/")
+			continue
+		slashes_seen++
+		if(slashes_seen == 4)
+			return copytext(type_string, 1, i)
+	return type_string
 
 /datum/controller/subsystem/machines/proc/setup_template_powernets(list/cables)
 	for(var/A in cables)
@@ -67,5 +370,19 @@ SUBSYSTEM_DEF(machines)
 	if(istype(SSmachines.processing))
 		processing = SSmachines.processing
 
+	if(istype(SSmachines.processing_early))
+		processing_early = SSmachines.processing_early
+
+	if(istype(SSmachines.processing_power))
+		processing_power = SSmachines.processing_power
+
+	if(istype(SSmachines.processing_late))
+		processing_late = SSmachines.processing_late
+
+	if(istype(SSmachines.processing_apcs))
+		processing_apcs = SSmachines.processing_apcs
+
 	if(istype(SSmachines.powernets))
 		powernets = SSmachines.powernets
+
+#undef SSMACHINES_PROFILE_THRESHOLD

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -39,14 +39,17 @@
 	switch(wire)
 		if(WIRE_THROW)
 			V.shoot_inventory = !V.shoot_inventory
+			V.update_processing()
 		if(WIRE_CONTRABAND)
 			V.extended_inventory = !V.extended_inventory
 		if(WIRE_SHOCK)
 			V.seconds_electrified = MACHINE_DEFAULT_ELECTRIFY_TIME
+			V.update_processing()
 		if(WIRE_IDSCAN)
 			V.scan_id = !V.scan_id
 		if(WIRE_SPEAKER)
 			V.shut_up = !V.shut_up
+			V.schedule_slogan()
 
 
 /datum/wires/vending/on_cut(wire, mend, mob/user)
@@ -54,6 +57,7 @@
 	switch(wire)
 		if(WIRE_THROW)
 			V.shoot_inventory = !mend
+			V.update_processing()
 		if(WIRE_CONTRABAND)
 			V.extended_inventory = FALSE
 		if(WIRE_SHOCK)
@@ -61,7 +65,9 @@
 				V.seconds_electrified = MACHINE_NOT_ELECTRIFIED
 			else
 				V.seconds_electrified = MACHINE_ELECTRIFIED_PERMANENT
+			V.update_processing()
 		if(WIRE_IDSCAN)
 			V.scan_id = mend
 		if(WIRE_SPEAKER)
 			V.shut_up = mend
+			V.schedule_slogan()

--- a/code/game/area/area.dm
+++ b/code/game/area/area.dm
@@ -35,6 +35,9 @@
 	var/used_equip = FALSE
 	var/used_light = FALSE
 	var/used_environ = FALSE
+	var/static_used_equip = FALSE
+	var/static_used_light = FALSE
+	var/static_used_environ = FALSE
 
 	var/global/global_uid = 0
 	var/uid
@@ -396,13 +399,13 @@
 	var/used = 0
 	switch(chan)
 		if(LIGHT)
-			used += used_light
+			used += used_light + static_used_light
 		if(EQUIP)
-			used += used_equip
+			used += used_equip + static_used_equip
 		if(ENVIRON)
-			used += used_environ
+			used += used_environ + static_used_environ
 		if(TOTAL)
-			used += used_light + used_equip + used_environ
+			used += used_light + used_equip + used_environ + static_used_light + static_used_equip + static_used_environ
 	return used
 
 
@@ -420,6 +423,15 @@
 			used_light += amount
 		if(ENVIRON)
 			used_environ += amount
+
+/area/proc/addStaticPower(amount, chan)
+	switch(chan)
+		if(STATIC_EQUIP, EQUIP)
+			static_used_equip += amount
+		if(STATIC_LIGHTS, LIGHT)
+			static_used_light += amount
+		if(STATIC_ENVIRON, ENVIRON)
+			static_used_environ += amount
 
 
 

--- a/code/game/objects/machinery.dm
+++ b/code/game/objects/machinery.dm
@@ -10,6 +10,10 @@
 
 	var/machine_stat = NONE
 	var/use_power = IDLE_POWER_USE
+	var/use_static_power = FALSE
+	var/static_power_usage = 0
+	var/registered_static_power_channel = EQUIP
+	var/area/registered_static_power_area
 	var/idle_power_usage = 0
 	var/active_power_usage = 0
 	var/machine_current_charge = 0 //Does it have an integrated, unremovable capacitor? Normally 10k if so.
@@ -36,10 +40,15 @@
 	GLOB.machines += src
 	component_parts = list()
 	set_ai_block()
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/machinery/LateInitialize()
+	update_current_power_usage()
 
 /obj/machinery/Destroy()
+	clear_static_power()
 	GLOB.machines -= src
-	STOP_PROCESSING(SSmachines, src)
+	stop_processing()
 	if(istype(circuit)) //There are some uninitialized legacy path circuits.
 		QDEL_NULL(circuit)
 	operator?.unset_interaction()
@@ -65,6 +74,12 @@
 
 /obj/machinery/proc/is_operational()
 	return !(machine_stat & (NOPOWER|BROKEN|MAINT|DISABLED))
+
+/obj/machinery/proc/on_tgui_open(mob/user, datum/tgui/ui)
+	return
+
+/obj/machinery/proc/on_tgui_close(mob/user, datum/tgui/ui)
+	return
 
 
 /obj/machinery/proc/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver)
@@ -136,17 +151,42 @@
 	return
 
 
-/obj/machinery/proc/start_processing()
+/obj/machinery/proc/start_processing(processing_phase = SSMACHINES_MACHINES)
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
-	START_PROCESSING(subsystem, src)
+	if(!istype(subsystem, /datum/controller/subsystem/machines))
+		START_PROCESSING(subsystem, src)
+		return
+	if(datum_flags & DF_ISPROCESSING)
+		return
+	datum_flags |= DF_ISPROCESSING
+	var/datum/controller/subsystem/machines/machine_subsystem = subsystem
+	switch(processing_phase)
+		if(SSMACHINES_MACHINES_EARLY)
+			machine_subsystem.processing_early += src
+		if(SSMACHINES_MACHINES_LATE)
+			machine_subsystem.processing_late += src
+		else
+			machine_subsystem.processing += src
 
 
 /obj/machinery/proc/stop_processing()
 	var/datum/controller/subsystem/processing/subsystem = locate(subsystem_type) in Master.subsystems
-	STOP_PROCESSING(subsystem, src)
+	if(!istype(subsystem, /datum/controller/subsystem/machines))
+		STOP_PROCESSING(subsystem, src)
+		return
+	datum_flags &= ~DF_ISPROCESSING
+	var/datum/controller/subsystem/machines/machine_subsystem = subsystem
+	machine_subsystem.processing -= src
+	machine_subsystem.processing_early -= src
+	machine_subsystem.processing_late -= src
+	machine_subsystem.processing_power -= src
+	machine_subsystem.currentrun -= src
 
 
 /obj/machinery/process() // If you dont use process or power why are you here
+	return PROCESS_KILL
+
+/obj/machinery/proc/process_late(seconds_per_tick)
 	return PROCESS_KILL
 
 /**

--- a/code/game/objects/machinery/computer/code_generator.dm
+++ b/code/game/objects/machinery/computer/code_generator.dm
@@ -50,6 +50,7 @@
 	running = FALSE
 	deltimer(current_timer)
 	current_timer = null
+	stop_processing()
 	update_minimap_icon()
 	visible_message("<b>[src]</b> shuts down as it loses power. Any running programs will now exit")
 
@@ -124,6 +125,7 @@
 	busy = FALSE
 	running = TRUE
 	current_timer = addtimer(CALLBACK(src, PROC_REF(complete_segment)), segment_time, TIMER_STOPPABLE)
+	start_processing()
 	update_minimap_icon()
 	faction = user.faction
 	return TRUE

--- a/code/game/objects/machinery/computer/computer.dm
+++ b/code/game/objects/machinery/computer/computer.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	use_power = IDLE_POWER_USE
+	use_static_power = TRUE
 	layer = BELOW_OBJ_LAYER
 	idle_power_usage = 300
 	active_power_usage = 300
@@ -24,18 +25,31 @@
 	var/broken_icon
 	///If true has a chance to break from any bullet
 	var/fragile = TRUE
+	///Whether this computer needs normal SSmachines processing immediately on init.
+	var/process_on_init = FALSE
 
 /obj/machinery/computer/Initialize(mapload)
 	. = ..()
 	if(!broken_icon)
 		broken_icon = "[initial(icon_state)]_broken"
-	start_processing()
+	if(process_on_init)
+		start_processing()
 	update_icon()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/computer/LateInitialize()
 	. = ..()
 	power_change()
+
+/obj/machinery/computer/Destroy()
+	return ..()
+
+/obj/machinery/computer/on_tgui_open(mob/user, datum/tgui/ui)
+	update_use_power(ACTIVE_POWER_USE)
+
+/obj/machinery/computer/on_tgui_close(mob/user, datum/tgui/ui)
+	if(length(open_uis) <= 1)
+		update_use_power(IDLE_POWER_USE)
 
 /obj/machinery/computer/examine(mob/user)
 	. = ..()

--- a/code/game/objects/machinery/computer/general_air_control.dm
+++ b/code/game/objects/machinery/computer/general_air_control.dm
@@ -319,7 +319,16 @@ Min Core Pressure: [pressure_limit] kPa<BR>"}
 	var/on_temperature = 1200
 	circuit = /obj/item/circuitboard/computer/air_management/injector_control
 
+/obj/machinery/computer/general_air_control/fuel_injection/Initialize(mapload)
+	. = ..()
+	if(automation)
+		start_processing()
+
 /obj/machinery/computer/general_air_control/fuel_injection/process()
+	if(!automation)
+		stop_processing()
+		return
+
 	if(automation)
 		if(!radio_connection)
 			return 0
@@ -403,6 +412,10 @@ Rate: [volume_rate] L/sec<BR>"}
 
 	if(href_list["toggle_automation"])
 		automation = !automation
+		if(automation)
+			start_processing()
+		else
+			stop_processing()
 
 	if(href_list["toggle_injector"])
 		device_info = null
@@ -434,7 +447,6 @@ Rate: [volume_rate] L/sec<BR>"}
 		)
 
 		radio_connection.post_signal(src, signal, filter = RADIO_ATMOSIA)
-
 
 
 

--- a/code/game/objects/machinery/computer/nt_access.dm
+++ b/code/game/objects/machinery/computer/nt_access.dm
@@ -66,6 +66,7 @@
 	completed_segments = min(completed_segments + 1, total_segments)
 	update_minimap_icon()
 	running = FALSE
+	stop_processing()
 
 	if(completed_segments == total_segments)
 		visible_message(span_notice("[src] beeps as security override code is ready to send."))

--- a/code/game/objects/machinery/computer/nuke_disk_generator.dm
+++ b/code/game/objects/machinery/computer/nuke_disk_generator.dm
@@ -60,6 +60,7 @@
 
 	update_minimap_icon()
 	running = FALSE
+	stop_processing()
 
 	if(completed_segments == total_segments)
 		say("Program retrieval successful. Standing by to print...")

--- a/code/game/objects/machinery/computer/station_alert.dm
+++ b/code/game/objects/machinery/computer/station_alert.dm
@@ -5,6 +5,7 @@
 	icon_state = "computer_small"
 	screen_overlay = "atmos"
 	circuit = /obj/item/circuitboard/computer/stationalert
+	process_on_init = TRUE
 	var/alarms = list("Fire"=list(), "Atmosphere"=list(), "Power"=list())
 
 

--- a/code/game/objects/machinery/telecomms/telecomunications.dm
+++ b/code/game/objects/machinery/telecomms/telecomunications.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(telecomms_freq_listening_list)
 	icon = 'icons/obj/machines/telecomms.dmi'
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE|UNACIDABLE
+	use_static_power = TRUE
 	/// list of machines this machine is linked to
 	var/list/links = list()
 	/**
@@ -78,7 +79,7 @@ GLOBAL_LIST_EMPTY(telecomms_freq_listening_list)
 
 		send_count++
 		if(filtered_machine.is_freq_listening(signal))
-			filtered_machine.traffic++
+			filtered_machine.add_traffic()
 
 		if(copysig)
 			filtered_machine.receive_information(signal.copy(), src)
@@ -86,7 +87,7 @@ GLOBAL_LIST_EMPTY(telecomms_freq_listening_list)
 			filtered_machine.receive_information(signal, src)
 
 	if(send_count > 0 && is_freq_listening(signal))
-		traffic++
+		add_traffic()
 
 	return send_count
 
@@ -108,7 +109,6 @@ GLOBAL_LIST_EMPTY(telecomms_freq_listening_list)
 /obj/machinery/telecomms/Initialize(mapload)
 	. = ..()
 	GLOB.telecomms_list += src
-	start_processing()
 	if(mapload && length(autolinkers))
 		return INITIALIZE_HINT_LATELOAD
 
@@ -159,6 +159,7 @@ GLOBAL_LIST_EMPTY(telecomms_freq_listening_list)
 
 
 /obj/machinery/telecomms/proc/update_power()
+	var/old_on = on
 	if(toggled)
 		if(machine_stat & (BROKEN|NOPOWER|EMPED)) // if powered, on. if not powered, off. if too damaged, off
 			on = FALSE
@@ -166,16 +167,26 @@ GLOBAL_LIST_EMPTY(telecomms_freq_listening_list)
 			on = TRUE
 	else
 		on = FALSE
+	return old_on != on
 
+/obj/machinery/telecomms/power_change()
+	. = ..()
+	if(update_power())
+		update_icon()
+
+/obj/machinery/telecomms/proc/add_traffic(amount = 1)
+	traffic += amount
+	start_processing()
 
 /obj/machinery/telecomms/process()
-	update_power()
-
-	// Update the icon
-	update_icon()
+	if(update_power())
+		update_icon()
 
 	if(traffic > 0)
-		traffic -= netspeed
+		traffic = max(0, traffic - netspeed)
+
+	if(traffic <= 0)
+		stop_processing()
 
 ///adds new_connection to src's links list AND vice versa. also updates links_by_telecomms_type
 /obj/machinery/telecomms/proc/add_new_link(obj/machinery/telecomms/new_connection, mob/user)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -69,6 +69,7 @@
 	layer = BELOW_OBJ_LAYER
 
 	use_power = IDLE_POWER_USE
+	use_static_power = TRUE
 	idle_power_usage = 10
 	active_power_usage = 100
 	obj_flags = CAN_BE_HIT
@@ -151,6 +152,8 @@
 	var/last_slogan = 0
 	///The interval between slogans.
 	var/slogan_delay = 15 MINUTES
+	///Timer id for the next slogan pitch.
+	var/slogan_timer
 	///Icon state when successfuly vending
 	var/icon_vend
 	///Icon state when failing to vend, be it by no access or money.
@@ -207,7 +210,7 @@
 	premium = null
 	products = null
 	contraband = null
-	start_processing()
+	schedule_slogan()
 	update_icon()
 	return INITIALIZE_HINT_LATELOAD
 
@@ -217,6 +220,9 @@
 	power_change()
 
 /obj/machinery/vending/Destroy()
+	if(slogan_timer)
+		deltimer(slogan_timer)
+		slogan_timer = null
 	QDEL_NULL(wires)
 	return ..()
 
@@ -874,14 +880,44 @@
 	if(seconds_electrified > 0)
 		seconds_electrified--
 
-	//Pitch to the people!  Really sell it!
-	if(((last_slogan + slogan_delay) <= world.time) && (length(slogan_list) > 0) && (!shut_up) && prob(5))
-		var/slogan = pick(slogan_list)
-		speak(slogan)
-		last_slogan = world.time
-
 	if(shoot_inventory && prob(2) && !hacking_safety)
 		throw_item()
+
+	update_processing()
+
+/obj/machinery/vending/proc/update_processing()
+	if((seconds_electrified > 0) || (shoot_inventory && !hacking_safety))
+		start_processing()
+		return
+	stop_processing()
+
+/obj/machinery/vending/proc/schedule_slogan(wait_time)
+	if(slogan_timer)
+		deltimer(slogan_timer)
+		slogan_timer = null
+
+	if(!length(slogan_list) || shut_up)
+		return
+
+	if(isnull(wait_time))
+		wait_time = max(1, last_slogan + slogan_delay - world.time)
+
+	slogan_timer = addtimer(CALLBACK(src, PROC_REF(handle_slogan)), wait_time, TIMER_STOPPABLE)
+
+/obj/machinery/vending/proc/handle_slogan()
+	slogan_timer = null
+
+	if(QDELETED(src))
+		return
+
+	if(machine_stat & (BROKEN|NOPOWER) || !active || shut_up || !length(slogan_list))
+		schedule_slogan(1 MINUTES)
+		return
+
+	//Pitch to the people, but without keeping every vendor in SSmachines forever.
+	speak(pick(slogan_list))
+	last_slogan = world.time
+	schedule_slogan(slogan_delay + rand(0, slogan_delay))
 
 /obj/machinery/vending/proc/speak(message)
 	if(machine_stat & NOPOWER)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -21,6 +21,7 @@ log transactions
 	icon_state = "atm"
 	anchored = TRUE
 	use_power = IDLE_POWER_USE
+	use_static_power = TRUE
 	idle_power_usage = 10
 	var/datum/money_account/authenticated_account
 	var/number_incorrect_tries = 0

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -9,6 +9,7 @@
 	layer = BELOW_OBJ_LAYER
 	resistance_flags = XENO_DAMAGEABLE
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE|PASS_WALKOVER
+	use_static_power = TRUE
 	max_integrity = 40
 	soft_armor = list(MELEE = 0, BULLET = 80, LASER = 80, ENERGY = 80, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 

--- a/code/modules/power/apc/apc.dm
+++ b/code/modules/power/apc/apc.dm
@@ -63,6 +63,8 @@
 	///Total amount of power used by the three channels
 	var/lastused_total = 0
 	var/main_status = APC_EXTERNAL_POWER_NONE
+	///Grid excess calculated during the power accounting phase.
+	var/last_power_excess = 0
 	///State of the electronics inside (missing, installed, secured)
 	var/has_electronics = APC_ELECTRONICS_MISSING
 	///Used for counting how many times it has been hit, used for Aliens at the moment
@@ -75,6 +77,8 @@
 	var/update_overlay = NONE
 	///Used to stop the icon from updating too much
 	var/icon_update_needed = FALSE
+	///Set when the APC needs to apply channel power changes after power accounting.
+	var/power_update_needed = FALSE
 	///Probability of APC being broken by a shuttle crash on the same z-level
 	var/crash_break_probability = 5
 
@@ -167,6 +171,17 @@
 		disconnect_terminal()
 
 	return ..()
+
+/obj/machinery/power/apc/start_processing()
+	if(datum_flags & DF_ISPROCESSING)
+		return
+	datum_flags |= DF_ISPROCESSING
+	SSmachines.processing_apcs += src
+
+/obj/machinery/power/apc/stop_processing()
+	datum_flags &= ~DF_ISPROCESSING
+	SSmachines.processing_apcs -= src
+	SSmachines.currentrun -= src
 
 ///Wrapper to guarantee powercells are properly nulled and avoid hard deletes.
 /obj/machinery/power/apc/proc/set_cell(obj/item/cell/new_cell)
@@ -383,8 +398,11 @@
 
 
 /obj/machinery/power/apc/process()
-	if(icon_update_needed)
-		update_appearance()
+	process_power()
+	process_charge()
+	process_late()
+
+/obj/machinery/power/apc/proc/process_power(seconds_per_tick)
 	if(machine_stat & (BROKEN|MAINT))
 		return
 	if(!area.requires_power)
@@ -407,6 +425,7 @@
 	var/last_ch = charging
 
 	var/excess = surplus()
+	last_power_excess = excess
 
 	if(!avail())
 		main_status = APC_EXTERNAL_POWER_NONE
@@ -472,39 +491,6 @@
 			if(cell.percent() > 75)
 				area.poweralert(1, src)
 
-		// now trickle-charge the cell
-		if(chargemode && charging == APC_CHARGING && operating)
-			if(excess > 0)		// check to make sure we have enough to charge
-				// Max charge is capped to % per second constant
-				var/ch = min(excess*GLOB.CELLRATE, cell.maxcharge*GLOB.CHARGELEVEL)
-				add_load(ch/GLOB.CELLRATE) // Removes the power we're taking from the grid
-				cell.give(ch) // actually recharge the cell
-
-			else
-				charging = APC_NOT_CHARGING		// stop charging
-				chargecount = 0
-
-		// show cell as fully charged if so
-		if(cell.charge >= cell.maxcharge)
-			cell.charge = cell.maxcharge
-			charging = APC_FULLY_CHARGED
-
-		if(chargemode)
-			if(!charging)
-				if(excess > cell.maxcharge * GLOB.CHARGELEVEL)
-					chargecount++
-				else
-					chargecount = 0
-
-				if(chargecount == 10)
-
-					chargecount = 0
-					charging = APC_CHARGING
-
-		else // chargemode off
-			charging = APC_NOT_CHARGING
-			chargecount = 0
-
 	else // no cell, switch everything off
 		charging = APC_NOT_CHARGING
 		chargecount = 0
@@ -515,10 +501,65 @@
 
 	// update icon & area power if anything changed
 	if(last_lt != lighting || last_eq != equipment || last_en != environ)
-		queue_icon_update()
-		update()
+		power_update_needed = TRUE
 	else if(last_ch != charging)
 		queue_icon_update()
+
+/obj/machinery/power/apc/proc/process_charge(seconds_per_tick)
+	if(machine_stat & (BROKEN|MAINT))
+		return
+	if(!area.requires_power)
+		return
+	if(!cell || shorted)
+		return
+
+	var/last_ch = charging
+	var/excess = last_power_excess
+
+	// now trickle-charge the cell
+	if(chargemode && charging == APC_CHARGING && operating)
+		if(excess > 0)		// check to make sure we have enough to charge
+			// Max charge is capped to % per second constant
+			var/ch = min(excess*GLOB.CELLRATE, cell.maxcharge*GLOB.CHARGELEVEL)
+			add_load(ch/GLOB.CELLRATE) // Removes the power we're taking from the grid
+			cell.give(ch) // actually recharge the cell
+
+		else
+			charging = APC_NOT_CHARGING		// stop charging
+			chargecount = 0
+
+	// show cell as fully charged if so
+	if(cell.charge >= cell.maxcharge)
+		cell.charge = cell.maxcharge
+		charging = APC_FULLY_CHARGED
+
+	if(chargemode)
+		if(!charging)
+			if(excess > cell.maxcharge * GLOB.CHARGELEVEL)
+				chargecount++
+			else
+				chargecount = 0
+
+			if(chargecount == 10)
+
+				chargecount = 0
+				charging = APC_CHARGING
+
+	else // chargemode off
+		charging = APC_NOT_CHARGING
+		chargecount = 0
+
+	if(last_ch != charging)
+		queue_icon_update()
+
+/obj/machinery/power/apc/process_late(seconds_per_tick)
+	if(power_update_needed)
+		power_update_needed = FALSE
+		queue_icon_update()
+		update()
+
+	if(icon_update_needed)
+		update_appearance()
 
 //val 0 = off, 1 = off(auto) 2 = on, 3 = on(auto)
 //on 0 = off, 1 = auto-on, 2 = auto-off

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -38,7 +38,7 @@
 	. = ..()
 	add_parts()
 	RefreshParts()
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 
 //Maybe this should be moved up to obj/machinery

--- a/code/modules/power/fusion_engine.dm
+++ b/code/modules/power/fusion_engine.dm
@@ -41,7 +41,7 @@
 	is_on = TRUE
 	power_gen_percent = 99//will get to 100 on first tick, updating fuel_rate in the process
 	update_icon()
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 /obj/machinery/power/fusion_engine/random/Initialize(mapload)
 	. = ..()
@@ -141,7 +141,7 @@
 
 	is_on = TRUE
 	update_icon()
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 	return TRUE
 
 /obj/machinery/power/fusion_engine/attackby(obj/item/I, mob/user, params)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -19,7 +19,7 @@
 	. = ..()
 
 	reconnect()
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 //generators connect in dir and reverse_dir(dir) directions
 //mnemonic to determine circulator/generator directions: the cirulators orbit clockwise around the generator

--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -138,7 +138,7 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, COMSIG_GLOB_GAMESTATE_GROUNDSIDE)
 	corruption_on = TRUE
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 /obj/machinery/power/geothermal/process()
 	if(corrupted && corruption_on)
@@ -275,7 +275,7 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 	icon_state = "on10"
 	is_on = TRUE
 	cur_tick = 0
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 	return TRUE
 
 /obj/machinery/power/geothermal/welder_act(mob/living/user, obj/item/I)
@@ -388,7 +388,7 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 	power_gen_percent = 0
 	cur_tick = 0
 	update_appearance()
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 ///Removes corruption from the generator
 /obj/machinery/power/geothermal/proc/decorrupt()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -98,10 +98,93 @@
 	var/area/A = get_area(src)
 	if(!A)
 		return
-	//A.addStaticPower(value, powerchannel) //TODO
+	A.addStaticPower(value, powerchannel)
 
 /obj/machinery/proc/removeStaticPower(value, powerchannel)
 	addStaticPower(-value, powerchannel)
+
+/obj/machinery/proc/static_channel_from_power_channel(chan = power_channel)
+	switch(chan)
+		if(STATIC_EQUIP, EQUIP)
+			return STATIC_EQUIP
+		if(STATIC_LIGHTS, LIGHT)
+			return STATIC_LIGHTS
+		if(STATIC_ENVIRON, ENVIRON)
+			return STATIC_ENVIRON
+	return STATIC_EQUIP
+
+/obj/machinery/proc/current_power_usage()
+	switch(use_power)
+		if(IDLE_POWER_USE)
+			return idle_power_usage
+		if(ACTIVE_POWER_USE)
+			return active_power_usage
+	return 0
+
+/obj/machinery/proc/clear_static_power()
+	if(!registered_static_power_area || !static_power_usage)
+		static_power_usage = 0
+		registered_static_power_area = null
+		return
+	registered_static_power_area.addStaticPower(-static_power_usage, registered_static_power_channel)
+	static_power_usage = 0
+	registered_static_power_area = null
+
+/obj/machinery/proc/update_current_power_usage()
+	if(!use_static_power)
+		return FALSE
+	clear_static_power()
+	var/new_power_usage = current_power_usage()
+	if(!new_power_usage)
+		return FALSE
+	var/area/current_area = get_area(src)
+	if(!current_area)
+		return FALSE
+	static_power_usage = new_power_usage
+	registered_static_power_channel = static_channel_from_power_channel(power_channel)
+	registered_static_power_area = current_area
+	current_area.addStaticPower(static_power_usage, registered_static_power_channel)
+	return TRUE
+
+/obj/machinery/proc/update_use_power(new_use_power)
+	if(use_power == new_use_power)
+		return FALSE
+	if(use_static_power)
+		clear_static_power()
+	use_power = new_use_power
+	if(use_static_power)
+		update_current_power_usage()
+	return TRUE
+
+/obj/machinery/proc/update_power_channel(new_power_channel)
+	if(power_channel == new_power_channel)
+		return FALSE
+	if(use_static_power)
+		clear_static_power()
+	power_channel = new_power_channel
+	if(use_static_power)
+		update_current_power_usage()
+	return TRUE
+
+/obj/machinery/proc/update_mode_power_usage(new_power_usage, power_mode = use_power)
+	switch(power_mode)
+		if(IDLE_POWER_USE)
+			if(idle_power_usage == new_power_usage)
+				return FALSE
+			if(use_static_power)
+				clear_static_power()
+			idle_power_usage = new_power_usage
+		if(ACTIVE_POWER_USE)
+			if(active_power_usage == new_power_usage)
+				return FALSE
+			if(use_static_power)
+				clear_static_power()
+			active_power_usage = new_power_usage
+		else
+			return FALSE
+	if(use_static_power)
+		update_current_power_usage()
+	return TRUE
 
 // connect the machine to a powernet if a node cable or a terminal is present on the turf
 /obj/machinery/power/proc/connect_to_network()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -57,7 +57,7 @@
 	if(!terminal.powernet)
 		terminal.connect_to_network()
 	update_icon()
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 /obj/machinery/power/smes/Destroy()
 	if(terminal)
@@ -173,7 +173,7 @@
 	terminal.setDir(get_dir(T,src))
 	terminal.master = src
 	machine_stat &= ~BROKEN
-	start_processing()
+	start_processing(SSMACHINES_MACHINES_EARLY)
 
 /obj/machinery/power/smes/disconnect_terminal()
 	if(terminal)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/machines/chemical_machines.dmi'
 	icon_state = "dispenser"
 	use_power = IDLE_POWER_USE
+	use_static_power = TRUE
 	idle_power_usage = 40
 	active_power_usage = 250
 	interaction_flags = INTERACT_MACHINE_TGUI
@@ -72,6 +73,10 @@
 
 	cell = new /obj/item/cell/hyper
 	start_processing()
+
+/obj/machinery/chem_dispenser/LateInitialize()
+	. = ..()
+	power_change()
 
 /obj/machinery/chem_dispenser/Destroy()
 	QDEL_NULL(beaker)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -15,6 +15,7 @@
 	density = TRUE
 	active_power_usage = 3500 //The pneumatic pump power. 3 HP ~ 2200W
 	idle_power_usage = 100
+	use_static_power = TRUE
 	allow_pass_flags = PASS_LOW_STRUCTURE|PASSABLE
 	var/mode = 1 //Item mode 0=off 1=charging 2=charged
 	var/flush = 0 //True if flush handle is pulled
@@ -37,7 +38,7 @@
 
 
 	update()
-	start_processing()
+	update_processing()
 
 
 /obj/machinery/disposal/Destroy()
@@ -85,11 +86,13 @@
 				mode = -1 //Set it to doubleoff
 				playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
 				to_chat(user, span_notice("You remove the screws around the power connection."))
+				update_processing()
 				return
 			else if(mode == -1)
 				mode = 0
 				playsound(loc, 'sound/items/screwdriver.ogg', 25, 1)
 				to_chat(user, span_notice("You attach the screws around the power connection."))
+				update_processing()
 				return
 		else if(iswelder(I) && mode == -1)
 			if(length(contents))
@@ -145,6 +148,7 @@
 		span_notice("You place [I] into [src]."))
 
 	update()
+	update_processing()
 
 //Mouse drop another mob or self
 /obj/machinery/disposal/MouseDrop_T(mob/target, mob/user)
@@ -179,6 +183,7 @@
 	target.forceMove(src)
 	flush()
 	update()
+	update_processing()
 
 /obj/machinery/disposal/attack_hand_alternate(mob/living/user)
 	. = ..()
@@ -274,13 +279,16 @@
 		else
 			mode = 0
 		update()
+		update_processing()
 
 	if(href_list["handle"])
 		flush = text2num(href_list["handle"])
 		update()
+		update_processing()
 
 	if(href_list["eject"])
 		eject()
+		update_processing()
 
 //Eject the contents of the disposal unit
 /obj/machinery/disposal/proc/eject()
@@ -339,6 +347,7 @@
 //Timed process, charge the gas reservoir and perform flush if ready
 /obj/machinery/disposal/process()
 	if(machine_stat & BROKEN) //Nothing can happen if broken
+		update_processing()
 		return
 
 	flush_count++
@@ -358,6 +367,17 @@
 		update()
 	else
 		pressurize() //Otherwise charge
+
+	update_processing()
+
+/obj/machinery/disposal/proc/update_processing()
+	if(machine_stat & BROKEN)
+		stop_processing()
+		return
+	if(mode == 1 || flush || (mode == 2 && length(contents)))
+		start_processing()
+		return
+	stop_processing()
 
 /obj/machinery/disposal/proc/pressurize()
 	if(disposal_pressure < SEND_PRESSURE)
@@ -398,12 +418,14 @@
 	if(mode == 2)	//If was ready,
 		mode = 1	//Switch to charging
 	update()
+	update_processing()
 
 
 //Called when area power changes
 /obj/machinery/disposal/power_change()
 	..()	//Do default setting/reset of stat NOPOWER bit
 	update()	//Update icon
+	update_processing()
 
 
 //Called when holder is expelled from a disposal, should usually only occur if the pipe network is modified

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -108,6 +108,9 @@
 		with_data = TRUE,
 		with_static_data = TRUE))
 	SStgui.on_open(src)
+	if(ismachinery(src_object))
+		var/obj/machinery/machine = src_object
+		machine.on_tgui_open(user, src)
 
 	return TRUE
 
@@ -140,6 +143,9 @@
 		// the error message properly.
 		window.release_lock()
 		window.close(can_be_suspended)
+		if(ismachinery(src_object))
+			var/obj/machinery/machine = src_object
+			machine.on_tgui_close(user, src)
 		src_object.ui_close(user)
 		SStgui.on_close(src)
 	state = null


### PR DESCRIPTION
## About The Pull Request

Reworks `SSmachines` into clearer processing phases and moves eligible idle machinery power usage into static area accounting.

This reduces repeated idle processing for machinery that does not need to do work every tick. Computers, vending machines, telecomms, disposals, hydroponics, ATMs, and chem dispensers now avoid unnecessary repeated power processing where possible, while active behavior still wakes normal processing when needed.

This also adds clearer machinery subsystem profiling output so future machine-side overhead is easier to identify.

## Why It's Good For The Game

Idle machinery was contributing a large amount of avoidable `SSmachines` cost, especially through repeated machine and power processing. In testing, idle machinery processing dropped significantly, with power-processing counts falling from hundreds of entries to single digits on the tested maps.

This should reduce server-side lag from idle machinery without changing normal gameplay when it comes to player machine behavior.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

Tested locally with the build script:

`tools\build\build.bat -- clean build`

Result: `tgmc.dmb - 0 errors, 0 warnings`

Runtime MC testing showed idle `SSmachines` dropping from roughly `PM: ~600 / PW: ~489` during earlier testing to around `PM: ~135 / PW: ~7` after the rework, with remaining machine cost mostly coming from active behavior processors such as bots and hydroponics.

</details>

## Changelog

:cl:
server: Reduced idle machinery processing overhead in SSmachines.
/:cl: