### PR TITLE
'Quick fix' for CRASHING - Hopefully

### DIFF
--- a/code/modules/asset_cache/transports/asset_transport.dm
+++ b/code/modules/asset_cache/transports/asset_transport.dm
@@ -66,6 +66,8 @@
 /datum/asset_transport/proc/get_asset_url(asset_name, datum/asset_cache_item/asset_cache_item)
 	if (!istype(asset_cache_item))
 		asset_cache_item = SSassets.cache[asset_name]
+	if(!asset_cache_item)
+		return url_encode(asset_name)
 	// To ensure code that breaks on cdns breaks in local testing, we only
 	// use the normal filename on legacy assets and name space assets.
 	var/keep_local_name = dont_mutate_filenames \

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -853,7 +853,7 @@
 	metadata_maybes = sanitize_text(metadata_maybes, initial(metadata_maybes))
 	metadata_favs = sanitize_text(metadata_favs, initial(metadata_favs))
 	metadata_ooc_style = sanitize_integer(metadata_ooc_style, FALSE, TRUE, initial(metadata_ooc_style))
-	if(isnewplayer(parent.mob))
+	if(parent && isnewplayer(parent.mob))
 		parent.mob.ooc_notes = metadata
 		parent.mob.ooc_notes_likes = metadata_likes
 		parent.mob.ooc_notes_dislikes = metadata_dislikes

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -141,7 +141,12 @@
 
 
 /datum/preferences/proc/update_preview_icon()
-	screen_main?.update_body()
+	try
+		sanitize_character_appearance_for_render()
+		screen_main?.update_body()
+	catch(var/exception/e)
+		var/debug_ckey = parent?.ckey || "unknown ckey"
+		log_runtime("Character preview update failed for [debug_ckey] slot [default_slot]: [e.name] ([e.file]:[e.line]) prefs=[character_debug_summary()]")
 
 
 /datum/preferences/proc/randomize_species_specific()
@@ -158,7 +163,136 @@
 	else
 		digitigrade_legs = "Normal"
 
+/datum/preferences/proc/character_debug_summary()
+	var/marking_summary = islist(body_markings) ? length(body_markings) : "invalid"
+	return "species=[species]; gender=[gender]; synth=[synthetic_type]/[synthetic_body_base]; robot=[robot_body_base]/[robot_head_base]; tail=[tail]; snout=[snout]; ears=[ears]; horns=[horns]; wings=[wings]; antenna=[synth_antenna]; fluff=[fluff]; legs=[digitigrade_legs]; markings=[marking_summary]"
+
+/datum/preferences/proc/sanitize_character_appearance_for_render()
+	species = sanitize_inlist(species, GLOB.all_species, initial(species))
+	body_color = sanitize_hexcolor(body_color, 6, TRUE, initial(body_color))
+	moth_wings = sanitize_inlist(moth_wings, GLOB.moth_wings_list, initial(moth_wings))
+	allow_emissives = sanitize_integer(allow_emissives, FALSE, TRUE, initial(allow_emissives))
+
+	tail = sanitize_inlist(tail, GLOB.lizard_tails_list, initial(tail))
+	tail_color = sanitize_hexcolor(tail_color, 6, TRUE, "#6BA36B")
+	tail_color_secondary = sanitize_hexcolor(tail_color_secondary, 6, TRUE, "#6BA36B")
+	tail_color_tertiary = sanitize_hexcolor(tail_color_tertiary, 6, TRUE, "#6BA36B")
+	tail_emissive = sanitize_character_creator_emissive_list(tail_emissive)
+
+	snout = sanitize_inlist(snout, GLOB.snouts_list, initial(snout))
+	snout_color = sanitize_hexcolor(snout_color, 6, TRUE, "#6BA36B")
+	snout_color_secondary = sanitize_hexcolor(snout_color_secondary, 6, TRUE, "#6BA36B")
+	snout_color_tertiary = sanitize_hexcolor(snout_color_tertiary, 6, TRUE, "#6BA36B")
+	snout_emissive = sanitize_character_creator_emissive_list(snout_emissive)
+
+	ears = sanitize_inlist(ears, GLOB.ears_list, initial(ears))
+	ears_color = sanitize_hexcolor(ears_color, 6, TRUE, "#6BA36B")
+	ears_color_secondary = sanitize_hexcolor(ears_color_secondary, 6, TRUE, "#6BA36B")
+	ears_color_tertiary = sanitize_hexcolor(ears_color_tertiary, 6, TRUE, "#6BA36B")
+	ears_emissive = sanitize_character_creator_emissive_list(ears_emissive)
+
+	horns = sanitize_inlist(horns, GLOB.horns_list, initial(horns))
+	horns_color = sanitize_hexcolor(horns_color, 6, TRUE, "#555555")
+	horns_color_secondary = sanitize_hexcolor(horns_color_secondary, 6, TRUE, "#555555")
+	horns_color_tertiary = sanitize_hexcolor(horns_color_tertiary, 6, TRUE, "#555555")
+	horns_emissive = sanitize_character_creator_emissive_list(horns_emissive)
+
+	wings = sanitize_inlist(wings, GLOB.wings_list, initial(wings))
+	wings_color = sanitize_hexcolor(wings_color, 6, TRUE, "#6BA36B")
+	wings_color_secondary = sanitize_hexcolor(wings_color_secondary, 6, TRUE, "#6BA36B")
+	wings_color_tertiary = sanitize_hexcolor(wings_color_tertiary, 6, TRUE, "#6BA36B")
+	wings_emissive = sanitize_character_creator_emissive_list(wings_emissive)
+
+	synth_antenna = sanitize_inlist(synth_antenna, GLOB.synth_antennas_list, initial(synth_antenna))
+	synth_antenna_color = sanitize_hexcolor(synth_antenna_color, 6, TRUE, "#6BA36B")
+	synth_antenna_color_secondary = sanitize_hexcolor(synth_antenna_color_secondary, 6, TRUE, "#6BA36B")
+	synth_antenna_color_tertiary = sanitize_hexcolor(synth_antenna_color_tertiary, 6, TRUE, "#6BA36B")
+	synth_antenna_emissive = sanitize_character_creator_emissive_list(synth_antenna_emissive)
+
+	fluff = sanitize_inlist(fluff, GLOB.fluffs_list, initial(fluff))
+	fluff_color = sanitize_hexcolor(fluff_color, 6, TRUE, "#6BA36B")
+	fluff_color_secondary = sanitize_hexcolor(fluff_color_secondary, 6, TRUE, "#6BA36B")
+	fluff_color_tertiary = sanitize_hexcolor(fluff_color_tertiary, 6, TRUE, "#6BA36B")
+	fluff_emissive = sanitize_character_creator_emissive_list(fluff_emissive)
+
+	digitigrade_legs = sanitize_inlist(digitigrade_legs, DIGITIGRADE_LEG_TYPES, initial(digitigrade_legs))
+	if(!(digitigrade_legs in digitigrade_leg_options()))
+		digitigrade_legs = initial(digitigrade_legs)
+	sanitize_body_markings()
+
+	genitalia_ass = sanitize_inlist_assoc(genitalia_ass, GLOB.possible_ass_sprites, initial(genitalia_ass))
+	genitalia_ass_size = sanitize_integer(genitalia_ass_size, 1, 8, initial(genitalia_ass_size))
+	genitalia_ass_color = sanitize_hexcolor(genitalia_ass_color, 6, TRUE, initial(genitalia_ass_color))
+	genitalia_ass_emissive = sanitize_character_creator_emissive_list(genitalia_ass_emissive)
+	genitalia_boobs = sanitize_inlist_assoc(genitalia_boobs, GLOB.possible_boob_sprites, initial(genitalia_boobs))
+	genitalia_boobs_size = sanitize_integer(genitalia_boobs_size, 0, 19, initial(genitalia_boobs_size))
+	genitalia_boobs_color = sanitize_hexcolor(genitalia_boobs_color, 6, TRUE, initial(genitalia_boobs_color))
+	genitalia_boobs_color_secondary = sanitize_hexcolor(genitalia_boobs_color_secondary, 6, TRUE, initial(genitalia_boobs_color_secondary))
+	genitalia_boobs_emissive = sanitize_character_creator_emissive_list(genitalia_boobs_emissive)
+	genitalia_cock = sanitize_inlist_assoc(genitalia_cock, GLOB.possible_cock_sprites, initial(genitalia_cock))
+	genitalia_cock_size = sanitize_integer(genitalia_cock_size, 1, 7, initial(genitalia_cock_size))
+	genitalia_cock_color = sanitize_hexcolor(genitalia_cock_color, 6, TRUE, initial(genitalia_cock_color))
+	genitalia_cock_emissive = sanitize_character_creator_emissive_list(genitalia_cock_emissive)
+	genitalia_vagina = sanitize_inlist_assoc(genitalia_vagina, GLOB.possible_vagina_sprites, initial(genitalia_vagina))
+	genitalia_vagina_color = sanitize_hexcolor(genitalia_vagina_color, 6, TRUE, initial(genitalia_vagina_color))
+	genitalia_vagina_emissive = sanitize_character_creator_emissive_list(genitalia_vagina_emissive)
+	genitalia_belly = sanitize_inlist_assoc(genitalia_belly, GLOB.possible_belly_sprites, initial(genitalia_belly))
+	genitalia_belly_size = sanitize_integer(genitalia_belly_size, 0, 10, initial(genitalia_belly_size))
+	genitalia_belly_color = sanitize_hexcolor(genitalia_belly_color, 6, TRUE, initial(genitalia_belly_color))
+	genitalia_belly_emissive = sanitize_character_creator_emissive_list(genitalia_belly_emissive)
+	genitalia_testicles = sanitize_inlist_assoc(genitalia_testicles, GLOB.possible_testicle_sprites, initial(genitalia_testicles))
+	genitalia_testicles_size = sanitize_integer(genitalia_testicles_size, 0, 8, initial(genitalia_testicles_size))
+	genitalia_testicles_color = sanitize_hexcolor(genitalia_testicles_color, 6, TRUE, initial(genitalia_testicles_color))
+	genitalia_testicles_color_secondary = sanitize_hexcolor(genitalia_testicles_color_secondary, 6, TRUE, initial(genitalia_testicles_color_secondary))
+	genitalia_testicles_emissive = sanitize_character_creator_emissive_list(genitalia_testicles_emissive)
+	return TRUE
+
+/datum/preferences/proc/character_appearance_rebuild_is_safe()
+	if(!MC_RUNNING())
+		return FALSE
+	if(SSticker?.current_state == GAME_STATE_STARTUP || SSticker?.current_state == GAME_STATE_FINISHED)
+		return FALSE
+	return TRUE
+
+/datum/preferences/proc/character_appearance_rebuild_can_defer()
+	return SSticker?.current_state != GAME_STATE_FINISHED
+
+/datum/preferences/proc/rebuild_character_appearance_safely(mob/living/carbon/human/character, deferred_attempts = 0)
+	if(QDELETED(character))
+		return FALSE
+	if(!character_appearance_rebuild_is_safe())
+		if(character_appearance_rebuild_can_defer() && deferred_attempts < 5)
+			addtimer(CALLBACK(src, PROC_REF(rebuild_character_appearance_safely), character, deferred_attempts + 1), 2 SECONDS)
+		return TRUE
+	try
+		character.update_body()
+		character.update_hair()
+	catch(var/exception/e)
+		var/debug_ckey = parent?.ckey || "unknown ckey"
+		log_runtime("Character preference icon rebuild failed for [debug_ckey] slot [default_slot] on [character] ([character.type]): [e.name] ([e.file]:[e.line]) prefs=[character_debug_summary()]")
+		reset_character_cosmetics_for_fallback(character)
+		try
+			character.update_body()
+			character.update_hair()
+		catch(var/exception/fallback_error)
+			log_runtime("Fallback character icon rebuild also failed for [debug_ckey] slot [default_slot] on [character] ([character.type]): [fallback_error.name] ([fallback_error.file]:[fallback_error.line])")
+	return TRUE
+
+/datum/preferences/proc/reset_character_cosmetics_for_fallback(mob/living/carbon/human/character)
+	if(!character)
+		return
+	character.body_markings = list()
+	character.tail = initial(character.tail)
+	character.snout = initial(character.snout)
+	character.ears = initial(character.ears)
+	character.horns = initial(character.horns)
+	character.wings = initial(character.wings)
+	character.synth_antenna = initial(character.synth_antenna)
+	character.fluff = initial(character.fluff)
+	character.digitigrade_legs = initial(character.digitigrade_legs)
+
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, safety = FALSE)
+	sanitize_character_appearance_for_render()
 	var/datum/species/preference_species = GLOB.all_species[species]
 	var/preserve_job_species = character.species?.species_flags & (IS_SYNTHETIC|ROBOTIC_LIMBS)
 	var/preserve_synthetic_job_species = character.species?.species_flags & IS_SYNTHETIC
@@ -325,8 +459,7 @@
 	character.ooc_notes_favs = metadata_favs
 	character.ooc_notes_style = metadata_ooc_style
 
-	character.update_body()
-	character.update_hair()
+	rebuild_character_appearance_safely(character)
 
 ///Create a random character. Uses a specified species if set.
 /datum/preferences/proc/random_character(datum/species/selected)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -73,6 +73,7 @@
 #include "map_templates.dm"
 #include "mapping.dm"
 #include "movement_order_sanity.dm"
+#include "ntf_character_appearance.dm"
 #include "plane_double_transform.dm"
 #include "security_levels.dm"
 #include "spawn_guns.dm"

--- a/code/modules/unit_tests/ntf_character_appearance.dm
+++ b/code/modules/unit_tests/ntf_character_appearance.dm
@@ -1,0 +1,268 @@
+/datum/unit_test/ntf_character_appearance_stress
+	var/list/test_species
+
+/datum/unit_test/ntf_character_appearance_stress/Destroy()
+	fdel("data/ntf_character_appearance_legacy.sav")
+	return ..()
+
+/datum/unit_test/ntf_character_appearance_stress/Run()
+	ensure_body_marking_references()
+
+	test_species = build_species_sample()
+	TEST_ASSERT(length(test_species), "No species were available for NTF character appearance stress testing.")
+
+	var/datum/preferences/corrupt_preferences = build_base_preferences()
+	var/mob/living/carbon/human/corrupt_human = allocate(/mob/living/carbon/human)
+	poison_preferences(corrupt_preferences)
+	if(!try_character_rebuild(corrupt_preferences, corrupt_human, "corrupt saved preference repair"))
+		return
+
+	for(var/species_name in test_species)
+		var/datum/preferences/preferences = build_base_preferences(species_name)
+		var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
+		if(!try_character_rebuild(preferences, human, "baseline species [species_name]"))
+			return
+
+		for(var/accessory_id in preferences.character_creator_part_ids())
+			var/list/part_definition = preferences.character_creator_part_definition(accessory_id)
+			if(!part_definition)
+				continue
+			var/pref_name = part_definition["pref"]
+			if(!pref_name)
+				continue
+			for(var/option_value in sample_option_values(part_definition["values"], part_definition["fallback"]))
+				preferences.vars[pref_name] = option_value
+				apply_accessory_stress_values(preferences, accessory_id, part_definition)
+				if(!try_character_rebuild(preferences, human, "[species_name] [accessory_id] option [option_value || "null"]"))
+					return
+
+	if(!try_legacy_save_load())
+		return
+	if(!try_character_creator_ui_smoke())
+		return
+	if(!try_deferred_rebuild_smoke())
+		return
+
+/datum/unit_test/ntf_character_appearance_stress/proc/build_species_sample()
+	var/list/species_sample = list()
+	var/list/preferred_species = list(
+		"Human",
+		"Combat Robot",
+		"Teshari",
+		"Vulpkanin",
+		"Anthro",
+		"Akula",
+	)
+
+	for(var/species_name in preferred_species)
+		if(species_name in GLOB.all_species)
+			species_sample[species_name] = GLOB.all_species[species_name]
+
+	if(length(species_sample))
+		return species_sample
+
+	var/list/fallback_species = length(GLOB.roundstart_species) ? GLOB.roundstart_species : GLOB.all_species
+	for(var/species_name in fallback_species)
+		species_sample[species_name] = fallback_species[species_name]
+		if(length(species_sample) >= 5)
+			break
+	return species_sample
+
+/datum/unit_test/ntf_character_appearance_stress/proc/build_base_preferences(species_name = "Human")
+	var/datum/preferences/preferences = new
+	preferences.random_name = TRUE
+	preferences.gender = MALE
+	preferences.real_name = "NTF Test"
+	preferences.species = species_name
+	preferences.body_color = "#FFFFFF"
+	preferences.blood_color = "#A10808"
+	preferences.allow_emissives = TRUE
+	return preferences
+
+/datum/unit_test/ntf_character_appearance_stress/proc/build_savefile_preferences(path = "data/ntf_character_appearance_legacy.sav", species_name = "Human")
+	var/datum/preferences/preferences = build_base_preferences(species_name)
+	preferences.path = path
+	preferences.default_slot = 1
+	var/savefile/S = new /savefile(path)
+	S.cd = "/"
+	S["version"] << SAVEFILE_VERSION_MAX
+	S["default_slot"] << 1
+	S.cd = "/character1"
+	S["real_name"] << "Legacy Tester"
+	return preferences
+
+/datum/unit_test/ntf_character_appearance_stress/proc/poison_preferences(datum/preferences/preferences)
+	preferences.species = "Broken Species"
+	preferences.body_color = "definitely not a color"
+	preferences.blood_color = "also bad"
+	preferences.moth_wings = "Broken Wings"
+	preferences.digitigrade_legs = "Too Many Knees"
+	preferences.body_markings = list("broken" = list("not", "a", "marking"))
+
+	for(var/accessory_id in preferences.character_creator_part_ids())
+		var/list/part_definition = preferences.character_creator_part_definition(accessory_id)
+		if(!part_definition)
+			continue
+		var/pref_name = part_definition["pref"]
+		if(pref_name)
+			preferences.vars[pref_name] = "Missing [accessory_id]"
+		for(var/color_index in 1 to (part_definition["colors"] || 0))
+			var/color_var = preferences.character_creator_color_var(accessory_id, color_index)
+			if(color_var)
+				preferences.vars[color_var] = "bad-color"
+		if(part_definition["colors"])
+			var/emissive_var = preferences.character_creator_emissive_var(accessory_id)
+			if(emissive_var)
+				preferences.vars[emissive_var] = list("yes", 99, null, FALSE)
+
+	poison_genitals(preferences)
+
+/datum/unit_test/ntf_character_appearance_stress/proc/poison_genitals(datum/preferences/preferences)
+	preferences.genitalia_ass = "pair_999"
+	preferences.genitalia_ass_color = "bad-color"
+	preferences.genitalia_ass_emissive = list("yes", 2, null)
+	preferences.genitalia_boobs = "pair_999"
+	preferences.genitalia_boobs_color = "bad-color"
+	preferences.genitalia_boobs_color_secondary = "bad-color"
+	preferences.genitalia_boobs_emissive = list("yes", 2, null)
+	preferences.genitalia_cock = "knotted_999"
+	preferences.genitalia_cock_color = "bad-color"
+	preferences.genitalia_cock_emissive = list("yes", 2, null)
+	preferences.genitalia_testicles = "pair_999"
+	preferences.genitalia_testicles_color = "bad-color"
+	preferences.genitalia_testicles_color_secondary = "bad-color"
+	preferences.genitalia_testicles_emissive = list("yes", 2, null)
+	preferences.genitalia_vagina = "Missing Vagina"
+	preferences.genitalia_vagina_color = "bad-color"
+	preferences.genitalia_vagina_emissive = list("yes", 2, null)
+	preferences.genitalia_belly = "999"
+	preferences.genitalia_belly_color = "bad-color"
+	preferences.genitalia_belly_emissive = list("yes", 2, null)
+
+/datum/unit_test/ntf_character_appearance_stress/proc/poison_savefile(path = "data/ntf_character_appearance_legacy.sav")
+	fdel(path)
+	var/savefile/S = new /savefile(path)
+	S.cd = "/"
+	S["version"] << SAVEFILE_VERSION_MAX
+	S["default_slot"] << 1
+	S.cd = "/character1"
+	S["real_name"] << "Legacy Tester"
+	S["species"] << "Broken Species"
+	S["body_color"] << "not-a-color"
+	S["blood_color"] << "not-blood"
+	S["tail"] << "Missing Tail"
+	S["snout"] << "Missing Snout"
+	S["ears"] << "Missing Ears"
+	S["horns"] << "Missing Horns"
+	S["wings"] << "Missing Wings"
+	S["fluff"] << "Missing Fluff"
+	S["digitigrade_legs"] << "Broken Legs"
+	S["body_markings"] << list("broken" = list("not", "a", "marking"))
+	S["tail_emissive"] << list("bad", 99, null)
+	S["genitalia_ass"] << "pair_999"
+	S["genitalia_boobs"] << "pair_999"
+	S["genitalia_cock"] << "knotted_999"
+	S["genitalia_testicles"] << "pair_999"
+	S["genitalia_vagina"] << "Missing Vagina"
+	S["genitalia_belly"] << "999"
+	S["genitalia_ass_color"] << "bad-color"
+	S["genitalia_boobs_color"] << "bad-color"
+	S["genitalia_cock_color"] << "bad-color"
+	S["genitalia_vagina_color"] << "bad-color"
+	S["genitalia_belly_color"] << "bad-color"
+	S["genitalia_testicles_color"] << "bad-color"
+	S["genitalia_cock_emissive"] << list("yes", 2, null)
+
+/datum/unit_test/ntf_character_appearance_stress/proc/sample_option_values(list/options, fallback)
+	var/list/option_values = list()
+	for(var/option_name in options)
+		var/option_value = options[option_name]
+		if(!(option_value in option_values))
+			option_values += option_value
+
+	var/list/samples = list()
+	if(null in option_values)
+		samples += null
+	if(fallback && !(fallback in samples))
+		samples += fallback
+	if(length(option_values))
+		var/list/indexes = list(1, round(length(option_values) / 2), length(option_values))
+		for(var/index in indexes)
+			var/option_value = option_values[clamp(index, 1, length(option_values))]
+			if(!(option_value in samples))
+				samples += option_value
+	return samples
+
+/datum/unit_test/ntf_character_appearance_stress/proc/apply_accessory_stress_values(datum/preferences/preferences, accessory_id, list/part_definition)
+	var/color_count = part_definition["colors"] || 0
+	for(var/color_index in 1 to color_count)
+		var/color_var = preferences.character_creator_color_var(accessory_id, color_index)
+		if(color_var)
+			preferences.vars[color_var] = "#7FA66F"
+	if(color_count)
+		var/emissive_var = preferences.character_creator_emissive_var(accessory_id)
+		if(emissive_var)
+			preferences.vars[emissive_var] = list(TRUE, FALSE, TRUE)
+
+/datum/unit_test/ntf_character_appearance_stress/proc/try_character_rebuild(datum/preferences/preferences, mob/living/carbon/human/human, context)
+	try
+		preferences.sanitize_character_appearance_for_render()
+		preferences.copy_to(human, TRUE)
+		human.update_body()
+		human.update_hair()
+		human.update_accessories()
+	catch(var/exception/error)
+		Fail("NTF character appearance stress failed during [context]: [error] at [error.file]:[error.line]")
+		return FALSE
+	return TRUE
+
+/datum/unit_test/ntf_character_appearance_stress/proc/try_legacy_save_load()
+	var/path = "data/ntf_character_appearance_legacy.sav"
+	try
+		poison_savefile(path)
+		var/datum/preferences/preferences = build_base_preferences()
+		preferences.path = path
+		TEST_ASSERT(preferences.load_character(1), "Legacy character save did not load.")
+		var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
+		if(!try_character_rebuild(preferences, human, "legacy save load"))
+			return FALSE
+	catch(var/exception/error)
+		Fail("NTF character appearance stress failed during legacy save load: [error] at [error.file]:[error.line]")
+		return FALSE
+	return TRUE
+
+/datum/unit_test/ntf_character_appearance_stress/proc/try_character_creator_ui_smoke()
+	try
+		var/datum/preferences/preferences = build_savefile_preferences()
+		for(var/species_name in test_species)
+			preferences.species = species_name
+			preferences.sanitize_character_appearance_for_render()
+
+			var/list/flat_data = list()
+			preferences.write_character_creator_accessory_data(flat_data)
+			TEST_ASSERT(islist(flat_data["character_creator_part_row_ids"]), "Part rows were not generated for [species_name].")
+			TEST_ASSERT(islist(flat_data["character_creator_genital_row_ids"]), "Genital rows were not generated for [species_name].")
+			TEST_ASSERT(islist(flat_data["character_creator_marking_zone_ids"]), "Marking rows were not generated for [species_name].")
+
+			preferences.tab_index = CHARACTER_CUSTOMIZATION
+			var/list/ui_data = preferences.ui_data(null)
+			TEST_ASSERT(islist(ui_data), "Character creator ui_data did not return a list for [species_name].")
+			TEST_ASSERT("character_creator_part_row_ids" in ui_data, "Character creator ui_data missed part rows for [species_name].")
+	catch(var/exception/error)
+		Fail("NTF character appearance stress failed during character creator UI smoke: [error] at [error.file]:[error.line]")
+		return FALSE
+	return TRUE
+
+/datum/unit_test/ntf_character_appearance_stress/proc/try_deferred_rebuild_smoke()
+	try
+		var/datum/preferences/preferences = build_base_preferences()
+		var/mob/living/carbon/human/human = allocate(/mob/living/carbon/human)
+		var/old_state = SSticker?.current_state
+		SSticker.current_state = GAME_STATE_FINISHED
+		TEST_ASSERT(!preferences.character_appearance_rebuild_is_safe(), "Finished ticker state should not be safe for appearance rebuilds.")
+		TEST_ASSERT(preferences.rebuild_character_appearance_safely(human, 5), "Deferred character appearance rebuild did not return success.")
+		SSticker.current_state = old_state
+	catch(var/exception/error)
+		Fail("NTF character appearance stress failed during deferred rebuild smoke: [error] at [error.file]:[error.line]")
+		return FALSE
+	return TRUE


### PR DESCRIPTION
## About The Pull Request

Makes it harder for the character creator to create invalid or legacy saved appearance data: Character appearance rebuilds now avoid unsafe startup/shutdown timing and will try to log more useful failure context. Hopefully this will solve our issue without needing to butcher things up

This adds safety around character preview updates and `copy_to()` appearance rebuilds:
- sanitizes species, accessory, marking, color, emissive, and genital appearance preference values before rendering
- defers character appearance rebuilds when the MC/ticker state is unsafe, such as startup or finished/shutdown states
- logs detailed preference summaries if preview or rebuild rendering fails
- falls back to safer cosmetic defaults if a rebuild throws
- guards parentless preference save loading
- adds a small asset URL fallback for missing cached asset entries seen during test startup
- adds an NTF character appearance stress unit test covering corrupted preferences, legacy save data, accessory combinations, UI data, and unsafe rebuild timing

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>
Ran all I could do without the save files, going all on a hypothesis....it did not crash or even flinched on my local, but then again, that and nothing might be the same thing.
- Ran stress tests with unit test:
  - `/datum/unit_test/ntf_character_appearance_stress`
  - Result: `PASS: /datum/unit_test/ntf_character_appearance_stress 6.1s`

- Confirmed no `TEST_FOCUS` line was left in the committed test file.

</details>

## Changelog

:cl:
fix: Makes it harder for the character creator to create invalid or legacy saved appearance data: Character appearance rebuilds now avoid unsafe startup/shutdown timing and will try to log more useful failure context. Hopefully this will solve our issue without needing to butcher things up
/:cl: