### PR TITLE
Adds QoL kitchen & ingredients to req imports

### DIFF
--- a/code/modules/reqs/supplypacks/imports_packs.dm
+++ b/code/modules/reqs/supplypacks/imports_packs.dm
@@ -419,3 +419,98 @@ Imports
 	/obj/item/implanter/jump_mod,
 	)
 	cost = 500
+
+/datum/supply_packs/imports/plasticfork
+	name = "Plastic Fork"
+	contains = list(/obj/item/tool/kitchen/utensil/pfork)
+	cost = 1
+
+/datum/supply_packs/imports/plasticknife
+	name = "Plastic Knife"
+	contains = list(/obj/item/tool/kitchen/utensil/pknife)
+	cost = 1
+
+/datum/supply_packs/imports/plasticknife
+	name = "Plastic Spoon"
+	contains = list(/obj/item/tool/kitchen/utensil/pspoon)
+	cost = 1
+
+/datum/supply_packs/imports/utensilfork
+	name = "Utensil Fork"
+	contains = list(/obj/item/tool/kitchen/utensil/fork)
+	cost = 3
+
+/datum/supply_packs/imports/untensilknife
+	name = "Utensil Knife"
+	contains = list(/obj/item/tool/kitchen/utensil/knife)
+	cost = 3
+
+/datum/supply_packs/imports/utensilspoon
+	name = "Utensil Spoon"
+	contains = list(/obj/item/tool/kitchen/utensil/spoon)
+	cost = 3
+
+/datum/supply_packs/imports/kitchenknife
+	name = "Kitchen Knife"
+	contains = list(/obj/item/tool/kitchen/knife)
+	cost = 5
+
+/datum/supply_packs/imports/butcherknife
+	name = "Butcher Cleaver"
+	contains = list(/obj/item/tool/kitchen/knife/butcher)
+	cost = 20
+
+/datum/supply_packs/imports/rollingpin
+	name = "Rolling Pin"
+	contains = list(/obj/item/tool/kitchen/rollingpin)
+	cost = 5
+
+/datum/supply_packs/imports/flour
+	name = "Flour Bag"
+	contains = list(/obj/item/reagent_containers/food/snacks/flour)
+	cost = 5
+
+/datum/supply_packs/imports/milk
+	name = "Milk Carton"
+	contains = list(/obj/item/reagent_containers/food/drinks/milk)
+	cost = 5
+
+/datum/supply_packs/imports/soymilk
+	name = "Soy Milk Carton"
+	contains = list(/obj/item/reagent_containers/food/drinks/soymilk)
+	cost = 5
+
+/datum/supply_packs/imports/universalenzyme
+	name = "Universal Enzyme Bottle"
+	contains = list(/obj/item/reagent_containers/food/condiment/enzyme)
+	cost = 5
+
+/datum/supply_packs/imports/hotsauce
+	name = "Hot Sauce Bottle"
+	contains = list(/obj/item/reagent_containers/cup/bottle/capsaicin)
+	cost = 5
+
+/datum/supply_packs/imports/syrup
+	name = "Syrup Bottle"
+	contains = list(/obj/item/reagent_containers/cup/bottle/syrup_bottle)
+	cost = 5
+
+/datum/supply_packs/imports/saltshaker
+	name = "Salt Shaker"
+	contains = list(/obj/item/reagent_containers/food/condiment/saltshaker)
+	cost = 5
+
+/datum/supply_packs/imports/peppermill
+	name = "Pepper Mill"
+	contains = list(/obj/item/reagent_containers/food/condiment/peppermill)
+	cost = 5
+
+/datum/supply_packs/imports/frostoil
+	name = "Frost Oil"
+	contains = list(/obj/item/reagent_containers/cup/bottle/frostoil)
+	cost = 50
+
+/datum/supply_packs/imports/pizzarandom
+	name = "Mystery Pizza"
+	contains = list(/obj/item/pizzabox/random)
+	cost = 25


### PR DESCRIPTION
## Requisitions goodies, kitchen appliances, ingredients, condiments and pizza too...

Become your own chef or caterer.
## About The Pull Request

Adds almost twenty new & cheap requisition imports available for purchase: Specifically revolving around kitchenware, ingredients, condiments and food.
## Why It's Good For The Game

**Quality of life requisitions update for imports intended for players who want to create RP events surrounding catering venues, cooking and more.**

- You might be a worker, staff or a chef aboard the NTF ship who wants to cater to operatives or board members during a meeting

- You're with the Colonial Militia and you want to RP providing aid, provisions and rations to colony survivors

- You're SOM and don't have a kitchen, but you want to at least have a kitchen in the FOB

**The possibilities go on...**

## Changelog

:cl:
add: kitchen utensils, kitchen knives, rolling pin, ingredients, condiments and mystery pizza boxes (box with a random pizza type)
