### PR TITLE
Unlocks all xeno leaders from poplock

### DIFF
--- a/code/datums/gamemodes/infestation.dm
+++ b/code/datums/gamemodes/infestation.dm
@@ -18,9 +18,9 @@
 	 * [caste datum] = [amount of xenos needed]
 	 */
 	var/list/evo_requirements = list(
-		/datum/xeno_caste/queen = 8,
-		/datum/xeno_caste/king = 12,
-		/datum/xeno_caste/dragon = 12,
+		/datum/xeno_caste/queen = 0,
+		/datum/xeno_caste/king = 0,
+		/datum/xeno_caste/dragon = 0,
 	)
 	var/spawn_xeno_shit = TRUE
 

--- a/code/datums/gamemodes/nuclear_war.dm
+++ b/code/datums/gamemodes/nuclear_war.dm
@@ -43,9 +43,9 @@
 	)
 
 	evo_requirements = list(
-		/datum/xeno_caste/queen = 8,
-		/datum/xeno_caste/king = 12,
-		/datum/xeno_caste/dragon = 18,
+		/datum/xeno_caste/queen = 0,
+		/datum/xeno_caste/king = 0,
+		/datum/xeno_caste/dragon = 0,
 	)
 
 	max_larva_preg_at_once = 1

--- a/code/datums/gamemodes/sovl_war.dm
+++ b/code/datums/gamemodes/sovl_war.dm
@@ -46,9 +46,9 @@
 	)
 
 	evo_requirements = list(
-		/datum/xeno_caste/queen = 8,
-		/datum/xeno_caste/king = 12,
-		/datum/xeno_caste/dragon = 12,
+		/datum/xeno_caste/queen = 0,
+		/datum/xeno_caste/king = 0,
+		/datum/xeno_caste/dragon = 0,
 	)
 /* NTF edit
 	restricted_castes = list(/datum/xeno_caste/wraith, /datum/xeno_caste/hivemind)

--- a/ntf_modular/code/datums/gamemodes/solmode/secrets_of_life.dm
+++ b/ntf_modular/code/datums/gamemodes/solmode/secrets_of_life.dm
@@ -158,9 +158,9 @@
 	var/sound_to_play = pop_lock ? pick('ntf_modular/sound/music/war_mode/hell_march_noearrape.ogg') : pick('ntf_modular/sound/music/war_mode/conflicttensionaltnoearrape.ogg', 'ntf_modular/sound/music/war_mode/konami-intro-metal-gear-solid.ogg')
 	if(pop_lock)
 		evo_requirements = list(
-			/datum/xeno_caste/queen = 8,
-			/datum/xeno_caste/king = 12,
-			/datum/xeno_caste/dragon = 12,
+			/datum/xeno_caste/queen = 0,
+			/datum/xeno_caste/king = 0,
+			/datum/xeno_caste/dragon = 0,
 		)
 		/*
 		for(var/mob/living/carbon/xenomorph/xeno in GLOB.xeno_mob_list)


### PR DESCRIPTION

## About The Pull Request
Removes poplock from leader castes, allowing xenos to actually play with these castes in modes like nukewar
## Why It's Good For The Game
I'm sorry, you mean to tell me that marines get infinite slots and can easily outnumber xenomorphs 2:1, and get CAS, and APC, and get mechs, AND specialists that spawn with req gear, AND leadership, AND binoculars from the campaign, AND free req gear with their personal agents, but xenomorphs cant even have a good crowd control caste? Are we for real?

Restores balance to the ecosystem
## Proof of Testing
I did not test it because its a numbers change that cannot possibly fail
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Removes the pop locks on all xenomorph castes.
/:cl:
