### PR TITLE
Readds early gen and combat robot synth

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -1,6 +1,6 @@
 #define ALLTIPS (SSstrings.get_list_from_file("tips/marine") + SSstrings.get_list_from_file("tips/xeno") + SSstrings.get_list_from_file("tips/meme") + SSstrings.get_list_from_file("tips/meta") + SSstrings.get_list_from_file("tips/HvH"))
 
-#define SYNTH_TYPES list("Synthetic","Early Synthetic")
+#define SYNTH_TYPES list("Synthetic","Early Synthetic","Robot")
 
 #define ROBOT_TYPES list("Basic","Hammerhead","Chilvaris","Ratcher","Sterling","Synskin")
 

--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -189,6 +189,8 @@ Your primary goal is to serve the hive, and ultimate goal is to liberate the col
 /datum/job/clf/silicon/synthetic/clf/return_spawn_type(datum/preferences/prefs)
 	if(prefs?.synthetic_type == "Early Synthetic")
 		return /mob/living/carbon/human/species/early_synthetic
+	if(prefs?.synthetic_type == "Robot")
+		return /mob/living/carbon/human/species/robot
 	return /mob/living/carbon/human/species/synthetic
 
 /datum/job/clf/silicon/synthetic/clf/return_skills_type(datum/preferences/prefs)

--- a/code/datums/jobs/job/fallen.dm
+++ b/code/datums/jobs/job/fallen.dm
@@ -112,6 +112,8 @@
 /datum/job/fallen/marine/synthetic/return_spawn_type(datum/preferences/prefs)
 	if(prefs?.synthetic_type == "Early Synthetic")
 		return /mob/living/carbon/human/species/early_synthetic
+	if(prefs?.synthetic_type == "Robot")
+		return /mob/living/carbon/human/species/robot
 	return /mob/living/carbon/human/species/synthetic
 
 /datum/job/fallen/marine/synthetic/return_skills_type(datum/preferences/prefs)

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -1042,6 +1042,8 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 /datum/job/terragov/silicon/synthetic/return_spawn_type(datum/preferences/prefs)
 	if(prefs?.synthetic_type == "Early Synthetic")
 		return /mob/living/carbon/human/species/early_synthetic
+	if(prefs?.synthetic_type == "Robot")
+		return /mob/living/carbon/human/species/robot
 	return /mob/living/carbon/human/species/synthetic
 
 /datum/job/terragov/silicon/synthetic/return_skills_type(datum/preferences/prefs)

--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -664,6 +664,8 @@ You are also an expert when it comes to botany and hydroponics. If you do not kn
 /datum/job/som/silicon/synthetic/som/return_spawn_type(datum/preferences/prefs)
 	if(prefs?.synthetic_type == "Early Synthetic")
 		return /mob/living/carbon/human/species/early_synthetic
+	if(prefs?.synthetic_type == "Robot")
+		return /mob/living/carbon/human/species/robot
 	return /mob/living/carbon/human/species/synthetic
 
 /datum/job/som/silicon/synthetic/som/return_skills_type(datum/preferences/prefs)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -896,8 +896,8 @@
 	be_special = sanitize_integer(be_special, NONE, MAX_BITFLAG, initial(be_special))
 
 	synthetic_name = reject_bad_name(synthetic_name, TRUE)
-	if(synthetic_type in list("Combat Robot", "Robot"))
-		synthetic_type = "Synthetic"
+/*	if(synthetic_type in list("Combat Robot", "Robot"))
+		synthetic_type = "Robot"*/
 	synthetic_type = sanitize_inlist(synthetic_type, SYNTH_TYPES, initial(synthetic_type))
 	synthetic_body_base = sanitize_inlist(synthetic_body_base, SYNTHETIC_BODY_BASES, initial(synthetic_body_base))
 	robot_type = sanitize_inlist(robot_type, ROBOT_TYPES, initial(robot_type))

--- a/ntf_modular/code/datums/jobs/job/survivor.dm
+++ b/ntf_modular/code/datums/jobs/job/survivor.dm
@@ -49,6 +49,8 @@
 /datum/job/survivor/synth/return_spawn_type(datum/preferences/prefs)
 	if(prefs?.synthetic_type == "Early Synthetic")
 		return /mob/living/carbon/human/species/early_synthetic
+	if(prefs?.synthetic_type == "Robot")
+		return /mob/living/carbon/human/species/robot
 	return /mob/living/carbon/human/species/synthetic
 
 /datum/job/survivor/synth/return_skills_type(datum/preferences/prefs)

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/CharacterCustomization.tsx
@@ -180,7 +180,7 @@ export const CharacterCustomization = (props) => {
   const showSupersoldierParts = !!data.custom_supersoldier_parts;
   const isPrototypeSupersoldier = data.species === 'Prototype Supersoldier';
   const showSyntheticJobBody =
-    data.species === 'Synthetic' || data.species === 'Early Synthetic';
+    data.species === 'Synthetic' || data.species === 'Early Synthetic' || data.species === 'Combat Robot';
   const creatorSizeControl = (row: CharacterCreatorOptionRow) => {
     if (!row.size_id) {
       return null;
@@ -659,15 +659,11 @@ export const CharacterCustomization = (props) => {
                   'Body color',
                 )}
               />
-              {showSyntheticJobBody ? (
-                <SelectFieldPreference
-                  label={'Synthetic job body'}
-                  value={'synthetic_body_base'}
-                  action={'synthetic_body_base'}
-                  fallback={'Human'}
-                  tooltip={'Body base used by the Synthetic and Early Synthetic appearance paths.'}
-                />
-              ) : null}
+              <SelectFieldPreference
+                label={'Synth type'}
+                value={'synthetic_type'}
+                action={'synthetic_type'}
+              />
               {showCombatRobotParts ? (
                 <>
                   <SelectFieldPreference


### PR DESCRIPTION

## About The Pull Request
Readds the synth selection option in the loadout, placing it just underneath species selection. This allows synth players to choose between 3 options; 

1. Being a normal synth, 

2. being slow but having the highest health/skills in the game

3. Obeying combat robot mechanics while being a synth, allowing free insulation & auto-repairs, but removing sprinting and other synth bonuses like having high health

Removes the redundant "Synth Body Selection" as synth respects your species sprite, so you could be a synth that looks like an anthro, or a synth that uses combat robot base as an early gen synth, etc. Very customizable, thank you for adding species options!!!!!!!
## Why It's Good For The Game
Combat robot synths were already in the game, but due to the species selections, were removed, this simply re-instates what is already supposed to be there
## Proof of Testing
Its kind of hard to prove, but heres a few images
<details>
<summary>Screenshots/Videos</summary>
  
<img width="195" height="137" alt="image" src="https://github.com/user-attachments/assets/18962c99-43df-4be8-93cb-8d4e9f1dda26" />
<img width="195" height="137" alt="image" src="https://github.com/user-attachments/assets/18962c99-43df-4be8-93cb-8d4e9f1dda26" />
<img width="397" height="466" alt="image" src="https://github.com/user-attachments/assets/8c10577f-c996-422b-a1b0-9f7d36831ea4" />
<img width="397" height="466" alt="image" src="https://github.com/user-attachments/assets/8c10577f-c996-422b-a1b0-9f7d36831ea4" />

</details>

## Changelog
:cl:
fix: readds the synthetic selections, including robot synths
/:cl:
