### PR TITLE
Adds the ML-101 to the imports section in Req, as well as the 3 types of 6 Gauge Ammunition. Buffs 6 Gauge across the board.

### DIFF
--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -202,8 +202,8 @@
 	accuracy_variation = 9
 	accurate_range = 3
 	max_range = 6
-	damage = 55
-	damage_falloff = 7
+	damage = 65
+	damage_falloff = 5
 
 /datum/ammo/bullet/shotgun/heavy_spread
 	name = "additional buckshot"
@@ -211,8 +211,8 @@
 	accuracy_variation = 9
 	accurate_range = 3
 	max_range = 6
-	damage = 50
-	damage_falloff = 7
+	damage = 60
+	damage_falloff = 5
 
 /datum/ammo/bullet/shotgun/heavy_buckshot/on_hit_turf(turf/target_turf, atom/movable/projectile/proj)
 	if(iswallturf(target_turf))
@@ -237,9 +237,9 @@
 	ammo_behavior_flags = AMMO_BALLISTIC
 	shell_speed = 3
 	max_range = 13
-	damage = 120
-	penetration = 25
-	sundering = 9
+	damage = 150
+	penetration = 50
+	sundering = 15
 	damage_falloff = 1.5
 	var/vehicle_stun_duration = 1.5 SECONDS
 
@@ -279,13 +279,13 @@
 	bonus_projectiles_scatter = 3
 	accuracy_variation = 8
 	max_range = 10
-	damage = 65
-	penetration = 20
-	sundering = 15
+	damage = 75
+	penetration = 30
+	sundering = 25
 
 /datum/ammo/bullet/shotgun/flechette/heavy_flechette_spread
 	name = "additional flechette"
-	damage = 55
+	damage = 65
 
 /datum/ammo/bullet/shotgun/heavy_flechette/on_hit_obj(obj/target_obj, atom/movable/projectile/proj)
 	if(istype(target_obj, /obj/machinery/door))

--- a/code/modules/reqs/supplypacks/imports_packs.dm
+++ b/code/modules/reqs/supplypacks/imports_packs.dm
@@ -419,3 +419,31 @@ Imports
 	/obj/item/implanter/jump_mod,
 	)
 	cost = 500
+
+/datum/supply_packs/imports/icc_heavyshotgun
+	name = "ML-101 Heavy Shotgun"
+	contains = list(
+	/obj/item/weapon/gun/shotgun/pump/icc_heavyshotgun,
+	)
+	cost = 400
+
+/datum/supply_packs/imports/icc_heavyshotgun/buckshot
+	name = "6 Gauge Buckshot Shells"
+	contains = list(
+	/obj/item/ammo_magazine/shotgun/heavy_buckshot,
+	)
+	cost = 20
+
+/datum/supply_packs/imports/icc_heavyshotgun/barrikada
+	name = "6 Gauge Barrikada Shells"
+	contains = list(
+	/obj/item/ammo_magazine/shotgun/barrikada,
+	)
+	cost = 40
+
+/datum/supply_packs/imports/icc_heavyshotgun/flechette
+	name = "6 Gauge Barrikada Shells"
+	contains = list(
+	/obj/item/ammo_magazine/shotgun/heavy_flechette,
+	)
+	cost = 30

--- a/code/modules/reqs/supplypacks/imports_packs.dm
+++ b/code/modules/reqs/supplypacks/imports_packs.dm
@@ -442,7 +442,7 @@ Imports
 	cost = 40
 
 /datum/supply_packs/imports/icc_heavyshotgun/flechette
-	name = "6 Gauge Barrikada Shells"
+	name = "6 Gauge Flechette Shells"
 	contains = list(
 	/obj/item/ammo_magazine/shotgun/heavy_flechette,
 	)


### PR DESCRIPTION

## About The Pull Request

Adds the ML-101 and 6 Gauge shells to the req import section. Buffs damage for flechettes and buckshot by 10, for slugs by 30. Sundering and penetration also buffed across the board, though most likely to be placebo compared to the damage changes.

## Why It's Good For The Game

6 Gauge Shotguns got nerfed so hard into the ground that they became completely worthless compared to regular 12 and 16 gauge shotguns resulting in them facing incredibly limited use, coupled with the fact the supplies of these guns and their ammo is limited so even the people who used them in spite of them sucking ass wouldn't be able to feed them for long. This fixes that by placing them at a more competitive spot.


## Proof of Testing

IT RUNS!!!! TTK still kinda sucks ass compared to regular shotguns but each shot counts now.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: Added the ML-101 and 6 gauge ammo to the Req Imports section
balance: Buffed 6 gauge ammunition
/:cl:
