### PR TITLE
dermal wit da equalizer

### DIFF
--- a/ntf_modular/code/modules/clothing/modular_armor/modular.dm
+++ b/ntf_modular/code/modules/clothing/modular_armor/modular.dm
@@ -177,7 +177,11 @@
 		/obj/item/armor_module/module/mimir_environment_protection/som,
 		/obj/item/armor_module/module/eshield/som,
 		/obj/item/armor_module/module/eshield/som/overclocked,
-	)
+// Equalizer Modules
+		/obj/item/armor_module/module/style/light_armor,
+		/obj/item/armor_module/module/style/medium_armor,
+		/obj/item/armor_module/module/style/heavy_armor,
+	) // The people want their equalizer dermal armor, they will get their dermal armor
 
 /obj/item/clothing/shoes/dermal
 	name = "\improper dermal feet pads"


### PR DESCRIPTION

## About The Pull Request
People heard dermal armour and loved it, but they want more, these GREEDY BASTARD WANT MORE!!! ALWAYS!!! GRR!!!!
Allows dermal armour to use style line equalizers, putting it equivalent with the likes of a leather jacket.
## Why It's Good For The Game
People want dermal armour with ARMOUR, not dermal armour that they can just attach modules to
## Proof of Testing
It actually looks really fucking good, check the gif down below
https://gyazo.com/6133a2a4f94d0dfa61d897e4fc465e74
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: dermal armour can now wear armour equalizers.
/:cl:
