### PR TITLE
Crusher given hard armor.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/castedatum_crusher.dm
@@ -36,6 +36,7 @@
 
 	// *** Defense *** //
 	soft_armor = list(MELEE = 90, BULLET = 75, LASER = 75, ENERGY = 75, BOMB = 130, BIO = 100, FIRE = 50, ACID = 100)
+	hard_armor = list(MELEE = 5, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.85


### PR DESCRIPTION

## About The Pull Request

Title
## Why It's Good For The Game

From what i've observed crusher is rarely used/when it is it tends to suffer of the case where the map is super open/not mazed as originally expected in TGMC meaning it rarely has corners to hide behind, that + the crazy speed that marines have means walking and just killing the caste is super easy.

Ig the extra armor should make it more tanky, specially against more ap oriented weapons.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:

balance: +5 hard armor to meele, bullet, laser and energy.

/:cl:
