### PR TITLE
Adds the KZ Combat Escort, an unholy mix of Squad Slut and Vanguard Operative for the faction supposed to be elite.

### DIFF
--- a/_maps/map_files/antagmap/antagmap.dmm
+++ b/_maps/map_files/antagmap/antagmap.dmm
@@ -4145,6 +4145,7 @@
 /area/antag_ship/icc/hangar/east)
 "qC" = (
 /obj/effect/landmark/start/job/vsd_leader,
+/obj/effect/landmark/start/job/vsd_escort,
 /obj/structure/flora/pottedplant,
 /turf/open/floor/prison/blackfloor,
 /area/antag_ship/vsd/hall)

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -126,6 +126,7 @@
 #define VSD_ENGINEER "KZ Engineer"
 #define VSD_MEDIC "KZ Medic"
 #define VSD_SPECIALIST "KZ Specialist"
+#define VSD_ESCORT "KZ Combat Escort"
 #define VSD_LEADER "KZ Squad Leader"
 
 #define JOB_CAT_COMMAND "Command"
@@ -176,7 +177,7 @@ MEDICAL_DOCTOR, MEDICAL_RESEARCHER, SQUAD_LEADER, SQUAD_SPECIALIST, SQUAD_SMARTG
 SOM_SQUAD_SLUT, SOM_SQUAD_MARINE, SOM_SQUAD_VETERAN, SOM_SQUAD_ENGINEER, SOM_SQUAD_CORPSMAN, SOM_SQUAD_LEADER, SOM_CHEF, SOM_MEDICAL_DOCTOR, SOM_TECH, SOM_CHIEF_MEDICAL_OFFICER, SOM_CHIEF_ENGINEER, SOM_REQUISITIONS_OFFICER, SOM_MECH_PILOT, SOM_PILOT_OFFICER, SOM_ASSAULT_CREWMAN, SOM_FIELD_COMMANDER, SOM_STAFF_OFFICER, SOM_COMMANDER, \
 PMC_MEDIC, PMC_ENGINEER, PMC_GUNNER, PMC_STANDARD, PMC_SNIPER, PMC_LEADER,\
 "Cult Offering", "Cultist", "Cultist Mender", "Cultist Champion", "Cult Synthetic", "Cultist Sect Leader", "Cultist Technomancer",\
-"KZ Standard", "KZ Engineer", "KZ Medic", "KZ Specialist", "KZ Squad Leader",\
+"KZ Standard", "KZ Engineer", "KZ Medic", "KZ Specialist", "KZ Combat Escort", "KZ Squad Leader",\
 "CM Standard", "CM Medic", "CM Guardsman", "CM Squad Leader", "CM Base Technician",\
 "Prisoner", "SOM Prisoner", "Cult Prisoner",\
 "Morale Officer", "Worker", "Archercorp Liaison", "Novamed Liaison", "TRANSCo Liaison", "Kaizoku Liaison", "Colonial Militia Representative", "Cult Representative", "Sons of Mars Representative", "Cult Messiah", "CM Commander", "CM Militia Captain", "CM Colony Administrator"))

--- a/code/datums/jobs/job/vsd.dm
+++ b/code/datums/jobs/job/vsd.dm
@@ -989,3 +989,15 @@
 
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/vsd_mg, SLOT_IN_L_POUCH)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/vsd_mg, SLOT_IN_L_POUCH)
+
+/datum/job/vsd/escort
+	title = "KZ Combat Escort"
+	paygrade = "KZ4"
+	skills_type = /datum/skills/specialist/escort
+	outfit = /datum/outfit/job/vsd/leader/one
+	multiple_outfits = FALSE
+	outfits = list(
+		/datum/outfit/job/vsd/leader/one,
+		/datum/outfit/job/vsd/leader/two,
+		/datum/outfit/job/vsd/leader/upp_three,
+	)

--- a/code/datums/jobs/job/vsd_squad.dm
+++ b/code/datums/jobs/job/vsd_squad.dm
@@ -135,4 +135,32 @@ and at the same time Kaizoku is pressured into playing along with SOM by their s
 	id = /obj/item/card/id/dogtag/leader
 	ears = /obj/item/radio/headset/mainship/vsd
 
+//VSD Combat Escort
+/datum/job/vsd_squad/escort
+	title = "KZ Combat Escort"
+	paygrade = "KZ4"
+	comm_title = "LT"
+	skills_type = /datum/skills/specialist/escort
+	access = list (ACCESS_VSD_PREP, ACCESS_VSD_MEDPREP, ACCESS_VSD_ENGPREP, ACCESS_VSD_SPECPREP, ACCESS_VSD_LEADPREP, ACCESS_VSD_CARGO, ACCESS_VSD_TADPOLE, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_SOM_MEDICAL)
+	minimal_access = list (ACCESS_VSD_PREP, ACCESS_VSD_MEDPREP, ACCESS_VSD_ENGPREP, ACCESS_VSD_SPECPREP, ACCESS_VSD_LEADPREP, ACCESS_VSD_CARGO, ACCESS_VSD_TADPOLE, ACCESS_MARINE_MEDBAY, ACCESS_MARINE_CHEMISTRY, ACCESS_SOM_MEDICAL)
+	display_order = JOB_DISPLAY_ORDER_SQUAD_MARINE
+	total_positions = 2
+	job_flags = JOB_FLAG_LATEJOINABLE|JOB_FLAG_ROUNDSTARTJOINABLE|JOB_FLAG_ALLOWS_PREFS_GEAR|JOB_FLAG_PROVIDES_BANK_ACCOUNT|JOB_FLAG_ADDTOMANIFEST|JOB_FLAG_PROVIDES_SQUAD_HUD|JOB_FLAG_CAN_SEE_ORDERS|JOB_FLAG_OVERRIDELATEJOINSPAWN
+	outfit = /datum/outfit/job/vsd_squad/escort
+	jobworth = list(
+		/datum/job/xenomorph = LARVA_POINTS_REGULAR,
+		/datum/job/som/squad/veteran = VETERAN_POINTS_REGULAR,
+	)
+
+/datum/outfit/job/vsd_squad/escort
+	name = "KZ Combat Escort"
+	jobtype = /datum/job/vsd_squad/escort
+
+	id = /obj/item/card/id/dogtag/specialist
+	ears = /obj/item/radio/headset/mainship/vsd
+
+/datum/job/vsd_squad/escort/get_spawn_message_information(mob/M)
+	. = ..()
+	. += separator_hr("[span_role_header("<b>[title] Information</b>")]")
+	. += {"\nYou are a chosen elite of the Kaizoku Corporation, handpicked for your exceptional combat skills and unwavering loyalty. Protect Valuable Corporate Assets, Relieve pressure from the frontline troops deployed alongside you and broker deals with the factions planetside, especially if it means using your body!"}
 

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -654,20 +654,16 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	leadership = SKILL_LEAD_EXPERT
 	police = SKILL_POLICE_MP
 	smartgun = SKILL_SMART_TRAINED
+	sex = SKILL_SEX_EXPERT
 
 /datum/skills/specialist/escort
 	name = "VSD Combat Escort" // Fucked up mix of slut and AC specialist skills.
 	unarmed = SKILL_UNARMED_TRAINED // Armed melee fighter as opposed to unarmed brawler.
 	combat = SKILL_COMBAT_TRAINED // Both meanings of escort, DUH.
-	melee_weapons = SKILL_MELEE_SUPER //Katana LARP.
-	pistols = SKILL_PISTOLS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
-	shotguns = SKILL_SHOTGUNS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
-	rifles = SKILL_RIFLES_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
-	smgs = SKILL_SMGS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
-	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
+	melee_weapons = SKILL_MELEE_TRAINED //Katana LARP.
 	medical = SKILL_MEDICAL_PRACTICED // mildly trained at everything, but not enough to be a proper specialist.
 	leadership = SKILL_LEAD_TRAINED // Still an officer rank, backup in case the actual SL dies (just like vanguard).
-	stamina = SKILL_STAMINA_TRAINED // Sex Marathon professionals.
+	stamina = SKILL_STAMINA_TRAINED // Sex Marathon Pros.
 	sex = SKILL_SEX_EXPERT // Healslut/Corporate fuckdoll.
 
 /datum/skills/specialist/pmc

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -655,6 +655,21 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	police = SKILL_POLICE_MP
 	smartgun = SKILL_SMART_TRAINED
 
+/datum/skills/specialist/escort
+	name = "VSD Combat Escort" // Fucked up mix of slut and AC specialist skills.
+	unarmed = SKILL_UNARMED_TRAINED // Armed melee fighter as opposed to unarmed brawler.
+	combat = SKILL_COMBAT_TRAINED // Both meanings of escort, DUH.
+	melee_weapons = SKILL_MELEE_SUPER //Katana LARP.
+	pistols = SKILL_PISTOLS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
+	shotguns = SKILL_SHOTGUNS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
+	rifles = SKILL_RIFLES_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
+	smgs = SKILL_SMGS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
+	heavy_weapons = SKILL_HEAVY_WEAPONS_TRAINED // mildly trained at everything, but not enough to be a proper specialist.
+	medical = SKILL_MEDICAL_PRACTICED // mildly trained at everything, but not enough to be a proper specialist.
+	leadership = SKILL_LEAD_TRAINED // Still an officer rank, backup in case the actual SL dies (just like vanguard).
+	stamina = SKILL_STAMINA_TRAINED // Sex Marathon professionals.
+	sex = SKILL_SEX_EXPERT // Healslut/Corporate fuckdoll.
+
 /datum/skills/specialist/pmc
 	name = "AC Specialist"
 	combat = SKILL_COMBAT_TRAINED

--- a/code/game/objects/effects/landmarks/marine_spawns.dm
+++ b/code/game/objects/effects/landmarks/marine_spawns.dm
@@ -287,6 +287,11 @@
 	icon_state = "MP"
 	job = /datum/job/vsd_squad/spec
 
+
+/obj/effect/landmark/start/job/vsd_escort
+	icon_state = "MP"
+	job = /datum/job/vsd_squad/escort
+
 /obj/effect/landmark/start/job/vsd_leader
 	icon_state = "MP"
 	job = /datum/job/vsd_squad/leader

--- a/ntf_modular/code/datums/gamemodes/extendedplus.dm
+++ b/ntf_modular/code/datums/gamemodes/extendedplus.dm
@@ -99,6 +99,7 @@
 		/datum/job/vsd_squad/medic = 1,
 		/datum/job/vsd_squad/engineer = 1,
 		/datum/job/vsd_squad/spec = 1,
+		/datum/job/vsd_squad/escort = 1,
 		/datum/job/vsd_squad/leader = 1,
 		/datum/job/usl_squad/standard = 3,
 		/datum/job/usl_squad/spec = 1,

--- a/ntf_modular/code/datums/gamemodes/solmode/secrets_of_life.dm
+++ b/ntf_modular/code/datums/gamemodes/solmode/secrets_of_life.dm
@@ -95,6 +95,7 @@
 		/datum/job/vsd_squad/medic = 1,
 		/datum/job/vsd_squad/engineer = 1,
 		/datum/job/vsd_squad/spec = 1,
+		/datum/job/vsd_squad/escort = 1,
 		/datum/job/vsd_squad/leader = 1,
 		/datum/job/icc_squad/standard = -1,
 		/datum/job/icc_squad/medic = 2,

--- a/tgui/packages/tgui/interfaces/PlayerPreferences/JobPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/PlayerPreferences/JobPreferences.tsx
@@ -116,6 +116,7 @@ export const JobPreferences = (props) => {
     'KZ Medic',
     'KZ Engineer',
     'KZ Specialist',
+    'KZ Combat Escort',
     'KZ Squad Leader',
     'Kaizoku Liaison',
   ];


### PR DESCRIPTION
KZ flavored vanguard slut.
## About The Pull Request

KZ lacks a proper "slut" role like the other factions, I figured, with them leaning into the whole "elite corporate mercenary" aesthetic, I might as well make their slut role be closer to a vanguard and also be tasked with being a pretty little corporate charm for high level KZ executives to keep around as protection and eyecandy. Their skills are a mixture of Squad Slut and the AC Specialist, eschewing the unarmed focus of the vanguard to focus on melee instead (since KZ gets katanas on their vendors) as well as baseline experience with all types of ranged weapons (bar smartguns) although to a lesser degree than their melee ability. They don't get any kind of extra loadout items as KZ equipment is already cracked enough as is. Rank structure is the same as that of the KZ specialist (Officer, not command personnel)

## Why It's Good For The Game

Adds a single slot slut role for KZ, more horny shit in game, incredibly unbalanced (not any better than AC specialist).


## Proof of Testing

It runs, it spawns, it FUCKS, it took me two hours to get right (Thanks vide and ghostler)

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: KZ Combat Escort, slutty specialist role for the KZ mercenaries.
/:cl:
