### PR TITLE
Disables quicksex entirely, no replacements

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -605,7 +605,7 @@
 		return
 	inactive_hand.attackby(active_hand, src)
 
-/mob/living/MouseDrop_T(atom/dropping, mob/user)
+/*/mob/living/MouseDrop_T(atom/dropping, mob/user)
 	. = ..()
 	if(dropping != usr)
 		return
@@ -676,4 +676,4 @@
 			action = pick(/datum/sex_action/scissoring, /datum/sex_action/tailpegging_vaginal, /datum/sex_action/tailpegging_anal, /datum/sex_action/force_cunnilingus)
 	sexcon.force = SEX_FORCE_MAX
 	sexcon.set_target(target)
-	sexcon.try_start_action(action)
+	sexcon.try_start_action(action)*/// HOLY PREFBREAK BATMAN!!!


### PR DESCRIPTION

## About The Pull Request
Ah yes, please, I do want to start ass fucking corpses, or prefbreaking both the person im fucking AND myself at the same time!... NOT!!! For the love of god the fact this has been in the game for so long is a miracle, this should have been shot down in concept let alone days after practice, its a preference break hell.
## Why It's Good For The Game
If we're not supposed to pref break eachother or face administrative action, why on gods fucking earth do we have a system that can be accidentally triggered that starts hard anal sex potentially on dead people, monkeys, larva, and other extremely unsavory things? Holy fuck, turn this off, PLEASE.
## Proof of Testing
I tested it. Yes. I did. It works, no interactions happen when dragging and dropping onto someone, and you can strip by being in help intent.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
del: completely removes quick sex, no more accidentally throat fucking larva you ment to punch!
/:cl:
