### PR TITLE
Everyone gets to sleep peacefully

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -172,12 +172,14 @@
 		healing += (6 * BASE_HEAL_RATE)
 	if((locate(/obj/item/stack/req_jelly) in owner.loc)) // Helps you sleep a little better
 		healing += (2 * BASE_HEAL_RATE)
+	if(isxeno(owner)) // Xenos should get a much higher healing rate for sleeping, its better than resting!
+		healing += (8 * BASE_HEAL_RATE)
 	if(health_ratio > -0.5)
 		owner.adjustBruteLoss(healing)
 		owner.adjustFireLoss(healing)
 		owner.adjustToxLoss(healing * 0.5, TRUE, TRUE)
 		owner.adjustStaminaLoss(healing * 100)
-		owner.adjustCloneLoss(healing * health_ratio * 0.8)
+		owner.adjustCloneLoss(healing * health_ratio * 0.5)
 	if(human_owner?.drunkenness)
 		human_owner.drunkenness *= 0.997 //reduce drunkenness by 0.3% per tick, 6% per 2 seconds
 	if(prob(20))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -234,14 +234,16 @@
 	set name = "Sleep"
 	set category = "IC"
 
-	if(species.species_flags & ROBOTIC_LIMBS)
+/*	if(species.species_flags & ROBOTIC_LIMBS)
 		to_chat(src, span_warning("Your artificial body does not require sleep."))
-		return
+		return*/// This whole thing prevents xenos from sleeping, I cant guess why, but robots don't get nothing from sleeping anyway
 	if(IsSleeping())
-		to_chat(src, span_warning("You are already sleeping"))
-		return
-	if(tgui_alert(src, "You sure you want to sleep for a while?", "Sleep", list("Yes","No")) == "Yes")
-		SetSleeping(40 SECONDS) //Short nap
+		if(alert(src, "Would you like to wake up soon? (You'll wake up after sleeping a little more, be patient and don't spam the button!)", "Wake Up", "Yes", "No") == "Yes")
+			SetSleeping(400)
+			to_chat(src, span_notice("You start to wake up."))
+	else
+		if(alert(src, "Are you sure you want to sleep for a long time? (You can wake up by pressing this button again)", "Sleep", "Yes", "No") == "Yes")
+			SetSleeping(18000)	//puts you to sleep for 30 minutes, better than never waking up in case my code sucks badly.
 
 /mob/living/carbon/Bump(atom/movable/AM)
 	if(now_pushing)


### PR DESCRIPTION

## About The Pull Request
Lets xenomorphs indulge in the sleepy days, makes sleeping more peaceful by lasting for a while, xenos also heal alot more than normal people while sleeping (Though, never enough to escape critical condition)
## Why It's Good For The Game
With recent sleep changes, maybe xenos are feeling like little mimirs too, also, the QOL of making it toggled instead of 40 seconds is good
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  https://gyazo.com/5358129d7583e59c6e9f36dd6bc6c0e2
</details>

## Changelog
:cl:
balance: Xenos can now indulge in the mimir, and use the sleep verb
/:cl:
