### PR TITLE
Synth survivor radio fix

### DIFF
--- a/ntf_modular/code/datums/outfits/survivor.dm
+++ b/ntf_modular/code/datums/outfits/survivor.dm
@@ -77,7 +77,7 @@
 
 	id = /obj/item/card/id/gold
 	belt = /obj/item/storage/belt/utility/full
-	ears = /obj/item/radio/headset/mainship/mcom
+	ears = /obj/item/radio/headset/mainship/marine/icc
 	w_uniform = /obj/item/clothing/under/rank/synthetic
 	shoes = /obj/item/clothing/shoes/white
 	gloves = /obj/item/clothing/gloves/insulated


### PR DESCRIPTION

## About The Pull Request
Synth survivors are supposed to have a radio, but due to the faction change to ICC, their radio explodes on spawn, this fixes that
## Why It's Good For The Game
Fixes a bug
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: synth survivors no longer have their radio explode on spawn
/:cl:
