### PR TITLE
Adds handcrank to buyables

### DIFF
--- a/code/modules/reqs/supplypacks/engineering_packs.dm
+++ b/code/modules/reqs/supplypacks/engineering_packs.dm
@@ -51,6 +51,11 @@ ENGINEERING
 	contains = list(/obj/item/tool/pickaxe/plasmacutter/)
 	cost = 300
 
+/datum/supply_packs/engineering/handcrank
+	name = "Hand held charger"
+	contains = list(/obj/item/tool/handheld_charger)
+	cost = 500
+
 /datum/supply_packs/engineering/quikdeploycade
 	name = "Quikdeploy barricade"
 	contains = list(/obj/item/quikdeploy/cade)


### PR DESCRIPTION

## About The Pull Request
The handcrank is a really useful item but its completely one of a kind, only available to synths or NTF engineers, makes this less of a speciality item and more widely available
## Why It's Good For The Game
The handcrank is incredibly useful, especially for laser weapon users or plasma weapon users.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: handcrank can now be bought in engineering tab
/:cl:
