### PR TITLE
KZ Combat Escort Loadout Hotfix

### DIFF
--- a/code/datums/outfits/quick_load_outfits.dm
+++ b/code/datums/outfits/quick_load_outfits.dm
@@ -3298,7 +3298,6 @@
 
 /datum/outfit/quick/vsd/escort/infiltrator
 	name = "KZ Combat Escort Infiltrator"
-	jobtype = "KZ Combat Escort"
 	desc = "Convenience and timing is key so play your part. Equipped with a KZ Covert Outfit, KZ Rownin Skeleton, MINI-B machinepistol and katana."
 	suit_store = /obj/item/storage/holster/blade/katana/full
 	gloves = /obj/item/clothing/gloves/marine/fingerless

--- a/code/game/objects/machinery/vending/quick_vendor.dm
+++ b/code/game/objects/machinery/vending/quick_vendor.dm
@@ -372,6 +372,7 @@ GLOBAL_LIST_INIT(quick_loadouts, init_quick_loadouts())
 		"KZ Medic",
 		"KZ Engineer",
 		"KZ Specialist",
+		"KZ Combat Escort",
 		"KZ Squad Leader",
 	)
 


### PR DESCRIPTION

## About The Pull Request

There is a comment twice in quick_vendor.dm for (I don't want to remove the duplicate because I'm afraid I'll break something) for the KZ (VSD technically in code) for the quick equipment vendor, I just did a quick test and realized that it didn't work because of this duplicate vendor object.

## Why It's Good For The Game

The hotfix is good.

:cl:
fix: **ACTUALLY** fixes the KZ Combat Escort Quick Equip Loadout