### PR TITLE
Xenomorph disarm buff

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -80,9 +80,9 @@
 	//Disarm attacks are stronger if human has no stamina buffer left because the xeno still got to take
 	//it down to 200 staminaloss + 50 buffer if at full stam, but they never are because exertion of other means.
 	if(staminaloss > 0)
-		damage *= 2
+		damage *= 3
 	else //if human is energetic yet they will endure.
-		damage *= 0.5
+		damage *= 1.5
 	if(pulledby) //extra damage to people who are grabbed.
 		damage *= 1.5
 	if(lying_angle||incapacitated()||IsParalyzed()||IsKnockdown()) //extra damage to people who are downed already.


### PR DESCRIPTION

## About The Pull Request
A commit from January ( https://github.com/Meghan-Rossi/NTFvsAlien/commit/271f76d9cec0ea6e1fd6ad2b21052a9875382cea ) nerfed xeno disarms to be 1/4 of their previous strength.  This buffs them back up to half their previous strength
<img width="588" height="165" alt="image" src="https://github.com/user-attachments/assets/7b8ba09e-4fc4-4183-be18-416d86a2c7f9" />
## Why It's Good For The Game
Disarm is meant to be useful to xenos trying to capture marines alive.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="488" height="188" alt="image" src="https://github.com/user-attachments/assets/1dc42705-125f-45bd-872c-0ab5bcf8cefb" />
</details>

## Changelog
:cl:
balance: buffed xenomorph disarms
/:cl:
