### PR TITLE
fixes KZSL recon and SL loadouts proper

### DIFF
--- a/code/datums/outfits/quick_load_outfits.dm
+++ b/code/datums/outfits/quick_load_outfits.dm
@@ -3461,7 +3461,7 @@
 	back = /obj/item/weapon/gun/rifle/type71/flamer
 	ears = /obj/item/radio/headset/mainship/vsd
 
-/datum/outfit/quick/vsd/eod/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/quick/vsd/squadlead/eod/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_HEAD)
@@ -3513,7 +3513,7 @@
 	ears = /obj/item/radio/headset/mainship/vsd
 	belt = /obj/item/belt_harness/marine
 
-/datum/outfit/quick/vsd/recon/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/quick/vsd/squadlead/recon/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/combat_advanced, SLOT_IN_HEAD)


### PR DESCRIPTION
## About The Pull Request

KZSL EOD and Recon did not properly load. I failed to path two lines of code for two separate loadouts. Backpacks, storage module, pouches, ETC. will now be properly filled.

:cl:
fix: KZSL quik-e-quip loadouts now properly spawn in EOD and Recon inventory
/:cl:
