### PR TITLE
hotfix for missing bonus overlay on L88

### DIFF
--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -847,6 +847,7 @@
 	caliber = CALIBER_556X45
 	icon_state = "aug"
 	icon_state_mini = "mag_rifle_olive"
+	bonus_overlay = "l88_mag"
 	default_ammo = /datum/ammo/bullet/rifle
 	max_rounds = 30
 


### PR DESCRIPTION

## About The Pull Request

Comments in the missing L88_mag bonus overlay for the L88 Assaultcarbine (AUG)

:cl:
add: Missing 30 round mag bonus overlay on L88 (thank you aleph for reporting this)
/:cl:
