### PR TITLE
Requires players for humanoid flavour text / picture in order to spawn

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -493,7 +493,7 @@
 	ready = !ready
 	if(ready)
 		if((length(client.prefs.flavor_text) < 100) && (client.prefs.profile_pic == ""))
-			to_chat(usr,span_warning("Your humanoid flavor text is too short and you don't have an image reference!"))
+			to_chat(src,span_warning("Your humanoid flavor text is too short and you don't have an image reference!"))
 			ready = FALSE
 			return
 		if(!WHITELIST_CHECK(client))

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -156,11 +156,15 @@
 				to_chat(usr, span_warning("Spawning currently disabled."))
 				return
 			var/datum/job/job_datum = locate(href_list["job_selected"])
-			if(!isxenosjob(job_datum) && (SSmonitor.gamestate == SHUTTERS_CLOSED || (SSmonitor.gamestate == GROUNDSIDE && SSmonitor.current_state <= XENOS_LOSING)))
-				var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
-				if((xeno_job.total_positions-xeno_job.current_positions) > length(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL]) * TOO_MUCH_BURROWED_PROPORTION)
-					if(tgui_alert(src, "There is a lack of xeno players on this round, unbalanced rounds are unfun for everyone. Are you sure you want to play as a marine? ", "Warning : the game is unbalanced", list("Yes", "No")) != "Yes")
-						return
+			if(!isxenosjob(job_datum))
+				if((length(client.prefs.flavor_text) < 100) && (client.prefs.profile_pic == ""))
+					to_chat(usr,span_warning("Your flavor text is too short and you don't have an image reference!"))
+					return
+				if((SSmonitor.gamestate == SHUTTERS_CLOSED || (SSmonitor.gamestate == GROUNDSIDE && SSmonitor.current_state <= XENOS_LOSING)))
+					var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+					if((xeno_job.total_positions-xeno_job.current_positions) > length(GLOB.alive_xeno_list_hive[XENO_HIVE_NORMAL]) * TOO_MUCH_BURROWED_PROPORTION)
+						if(tgui_alert(src, "There is a lack of xeno players on this round, unbalanced rounds are unfun for everyone. Are you sure you want to play as a marine? ", "Warning : the game is unbalanced", list("Yes", "No")) != "Yes")
+							return
 			if(isxenosjob(job_datum))
 				if(XENODEATHTIME_CHECK(usr))
 					if(check_other_rights(usr.client, R_ADMIN, FALSE))
@@ -488,6 +492,10 @@
 		return
 	ready = !ready
 	if(ready)
+		if((length(client.prefs.flavor_text) < 100) && (client.prefs.profile_pic == ""))
+			to_chat(usr,span_warning("Your humanoid flavor text is too short and you don't have an image reference!"))
+			ready = FALSE
+			return
 		if(!WHITELIST_CHECK(client))
 			WHITELIST_MESSAGE(client)
 			ready = FALSE


### PR DESCRIPTION

## About The Pull Request

Requires players for humanoid flavour text / picture in order to readying, or latejoining as a humanoid. Otherwise it won't let you with the error message to use at least one of them.
For reference, the flavour text requirement is fulfilled if it has 100 or more chars.
Benos have no such weakness because they have ever shifting bodies.

## Why It's Good For The Game

Vide's request


## Proof of Testing

Don't worry about it, It Just Works ™️ 

<details>
I said don't worry about it
  
</details>

## Changelog
:cl:
add: Late joining as humanoid or readying now requires you to either have a character image or at least 100 chars worth of flavour text
/:cl:
