### PR TITLE
Revert "Remove combat robot bleedout"

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -195,7 +195,7 @@
 	id = "repairing"
 	tick_interval = 1 SECONDS
 	///How much brute or burn per second
-	var/healing_per_tick = 4
+	var/healing_per_tick = 8 //Robots can now bleedout
 	///Whether the last tick made a sound effect or not
 	var/last_sound
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -451,9 +451,9 @@ Contains most of the procs that are called when a mob is attacked by something
 	if(!I.tool_use_check(user, 2))
 		return TRUE
 
-	var/repair_time = 1.5 SECONDS
-	if(src == user)
-		repair_time *= 3
+	var/repair_time = 1.5 SECONDS // Robots now bleed out, so this is necessary
+/*	if(src == user)
+		repair_time *= 1*/
 
 
 	user.visible_message(span_notice("[user] starts to fix some of the dents on [src]'s [affecting.display_name]."),\

--- a/code/modules/mob/living/carbon/human/species_types/combat_robots.dm
+++ b/code/modules/mob/living/carbon/human/species_types/combat_robots.dm
@@ -80,13 +80,15 @@
 	COOLDOWN_DECLARE(hard_crit_emote_cooldown)
 
 /datum/species/robot/handle_unique_behavior(mob/living/carbon/human/H)
+	if(H.health <= -0 && H.health > -90) // Doesn't kill, purely for sex/capture reasons
+		H.take_overall_damage(rand(2, 6), BURN, updating_health = TRUE, max_limbs = 1) // Melting!!!
 	if(H.health <= 0 && H.health > -50)
 		H.clear_fullscreen("robotlow")
 		H.overlay_fullscreen("robothalf", /atom/movable/screen/fullscreen/robot/machine/robothalf)
 		if(COOLDOWN_FINISHED(H, soft_crit_emote_cooldown))
 			COOLDOWN_START(H, soft_crit_emote_cooldown, 40 SECONDS)
 			H.emote("damaged")
-			to_chat(H, span_warning("Major damage sustained. Repair immediately. <b>Integrity: [round(H.health)]%.</b>"))
+			to_chat(H, span_warning("Critical damage sustained. Repair damage immediately. <b>Integrity: [round(H.health)]%.</b>"))
 		if(prob(25))
 			do_sparks(4, TRUE, H)
 	else if(H.health <= -50)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -506,9 +506,9 @@ GLOBAL_LIST(cable_radial_layer_list)
 		balloon_alert(user, "Already busy!")
 		return TRUE
 
-	var/repair_time = 1.5 SECONDS
-	if(H == user)
-		repair_time *= 3
+	var/repair_time = 1.5 SECONDS // Robots can now bleedout and need this
+/*	if(H == user)
+		repair_time *= 3*/
 
 	user.visible_message(span_notice("[user] starts to fix some of the wires in [H]'s [affecting.display_name]."),\
 		span_notice("You start fixing some of the wires in [H == user ? "your" : "[H]'s"] [affecting.display_name]."))


### PR DESCRIPTION
Reverts EaglePhntm/NTFvsAlien#466
Combat robots are OP as is with 150 hp, thresholds and lack of pain, poison and everything.