### PR TITLE
[Balance] Makes Research require researcher trait.

### DIFF
--- a/_ntf_modular/code/__DEFINES/traits.dm
+++ b/_ntf_modular/code/__DEFINES/traits.dm
@@ -9,5 +9,6 @@
 #define TRAIT_SURRENDERING "surrendering"
 #define TRAIT_FRAIL_LARVABURSTS "frail_larvabursts"
 #define TRAIT_CULTIST "cultist"
+#define TRAIT_RESEARCHER "researcher"
 
 #define TRAIT_EXOSUIT_NV "exosuit_nightvision" //Able to see in dark

--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -265,6 +265,10 @@ In addition, being a Synthetic gives you knowledge in every field and specializa
 		/datum/job/terragov/command/mech_pilot = MECH_POINTS_REGULAR,
 	)
 
+/datum/job/clf/mo/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
+	. = ..()
+	ADD_TRAIT(C, TRAIT_RESEARCHER, "[type]")
+
 //the bigus dickus leader of the cult
 /datum/job/clf/messiah
 	title = "Cult Messiah"

--- a/code/datums/jobs/job/clf.dm
+++ b/code/datums/jobs/job/clf.dm
@@ -200,6 +200,7 @@ Your primary goal is to serve the hive, and ultimate goal is to liberate the col
 
 /datum/job/clf/silicon/synthetic/clf/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -793,6 +793,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "CMO"
 	new_human.wear_id.update_label()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 
 //Medical Officer
 /datum/job/terragov/medical/medicalofficer
@@ -920,7 +921,7 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "PROF"
 	new_human.wear_id.update_label()
-
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 
 /datum/job/terragov/civilian
 	job_category = JOB_CAT_CIVILIAN

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -1054,6 +1054,7 @@ Use your office fax machine to communicate with corporate headquarters or to acq
 
 /datum/job/terragov/silicon/synthetic/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob

--- a/code/datums/jobs/job/shipside.dm
+++ b/code/datums/jobs/job/shipside.dm
@@ -775,6 +775,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 
 /datum/job/terragov/medical/professor/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob
@@ -793,7 +794,6 @@ Make sure that the doctors and nurses are doing their jobs and keeping the marin
 		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "CMO"
 	new_human.wear_id.update_label()
-	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 
 //Medical Officer
 /datum/job/terragov/medical/medicalofficer
@@ -903,6 +903,7 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 
 /datum/job/terragov/medical/researcher/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob
@@ -921,7 +922,6 @@ It is also recommended that you gear up like a regular marine, or your 'internsh
 		if(18001 to INFINITY) // 300 hrs
 			new_human.wear_id.paygrade = "PROF"
 	new_human.wear_id.update_label()
-	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 
 /datum/job/terragov/civilian
 	job_category = JOB_CAT_CIVILIAN

--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -676,6 +676,7 @@ You are also an expert when it comes to botany and hydroponics. If you do not kn
 
 /datum/job/som/silicon/synthetic/som/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob

--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -523,6 +523,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the SOM h
 
 /datum/job/som/medical/professor/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob
@@ -534,7 +535,6 @@ Make sure that the doctors and nurses are doing their jobs and keeping the SOM h
 			new_human.wear_id.paygrade = "CHO"
 		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "CMO"
-	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 
 //Medical Officer
 /datum/job/som/medical/medicalofficer

--- a/code/datums/jobs/job/sons_of_mars_shipside.dm
+++ b/code/datums/jobs/job/sons_of_mars_shipside.dm
@@ -534,6 +534,7 @@ Make sure that the doctors and nurses are doing their jobs and keeping the SOM h
 			new_human.wear_id.paygrade = "CHO"
 		if(3001 to INFINITY) // 50 hrs
 			new_human.wear_id.paygrade = "CMO"
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 
 //Medical Officer
 /datum/job/som/medical/medicalofficer

--- a/code/datums/jobs/job/survivor.dm
+++ b/code/datums/jobs/job/survivor.dm
@@ -78,6 +78,10 @@ Good luck, but do not expect to survive."}
 	skills_type = /datum/skills/civilian/survivor/scientist
 	outfit = /datum/outfit/job/survivor/scientist
 
+/datum/job/survivor/scientist/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
+	. = ..()
+	ADD_TRAIT(C, TRAIT_RESEARCHER, "[type]")
+
 //Doctor
 /datum/job/survivor/doctor
 	title = "Doctor Colonist"

--- a/code/game/objects/items/tools/research_tools.dm
+++ b/code/game/objects/items/tools/research_tools.dm
@@ -84,7 +84,7 @@
 
 /obj/item/tool/research/excavation_tool/unique_action(mob/user)
 	. = ..()
-	if(HAS_TRAIT(user, TRAIT_RESEARCHER))
+	if(!HAS_TRAIT(user, TRAIT_RESEARCHER))
 		balloon_alert(user, "not a researcher!")
 		return
 

--- a/code/game/objects/items/tools/research_tools.dm
+++ b/code/game/objects/items/tools/research_tools.dm
@@ -1,9 +1,5 @@
 // Tools used for research
 /obj/item/tool/research
-	///Skill type needed to use the tool
-	var/skill_type = SKILL_MEDICAL
-	///Skill level needed to use the tool
-	var/skill_threshold = SKILL_MEDICAL_EXPERT
 
 /obj/item/tool/research/xeno_analyzer
 	name = "xenolinguistic translator"
@@ -88,8 +84,8 @@
 
 /obj/item/tool/research/excavation_tool/unique_action(mob/user)
 	. = ..()
-	if(user.skills.getRating(skill_type) < skill_threshold)
-		balloon_alert(user, "not skilled enough!")
+	if(HAS_TRAIT(user, TRAIT_RESEARCHER))
+		balloon_alert(user, "not a researcher!")
 		return
 
 	if(!do_after(user, 10 SECONDS, NONE, user.loc, BUSY_ICON_FRIENDLY, null, PROGRESS_BRASS))

--- a/ntf_modular/code/datums/jobs/job/survivor.dm
+++ b/ntf_modular/code/datums/jobs/job/survivor.dm
@@ -60,6 +60,7 @@
 
 /datum/job/survivor/synth/after_spawn(mob/living/carbon/new_mob, mob/user, latejoin = FALSE)
 	. = ..()
+	ADD_TRAIT(new_mob, TRAIT_RESEARCHER, "[type]")
 	if(!ishuman(new_mob))
 		return
 	var/mob/living/carbon/human/new_human = new_mob


### PR DESCRIPTION

## About The Pull Request
Makes Research tools use the research trait, which is job exclusive to research jobs (CMO (CLF and SOM too), Researcher, Scientists, non combat synthetics), instead of medical 4.

## Why It's Good For The Game
We had a string of super drugged KZ players abusing the system to get to medical 4 to get ALL the research data and breaking EVERYWHERE in the most toxic and cringe manner possible. Until they get banned for this behaviour, its better to cut this from spreading to others and implement a proper system so its not gamed like this again. If other roles deserve the trait the PR is quite clear on how to add it, and can easily be done so on request.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
engineer:

<img width="342" height="324" alt="image" src="https://github.com/user-attachments/assets/cea50bd3-22c1-46a8-bae2-01c211cc6bdb" />

clf archmender:

<img width="790" height="719" alt="image" src="https://github.com/user-attachments/assets/c6576327-a8bb-4332-b980-8567c13aab6b" />

medical researcher:

<img width="625" height="606" alt="image" src="https://github.com/user-attachments/assets/3dd866c7-f9e4-48a6-945e-ba08a072ee87" />


</details>

## Changelog
:cl:
balance:Makes Research tools use the research trait, which is job exclusive to research jobs (CMO (CLF and SOM too), Researcher, Scientists, non combat synthetics), instead of medical 4.
/:cl:
