### PR TITLE
[Balance / Fix] Removes ventcrawling from stealth suits

### DIFF
--- a/ntf_modular/code/modules/clothing/under/miscellaneous.dm
+++ b/ntf_modular/code/modules/clothing/under/miscellaneous.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/under/marine/sneaking
 	name = "NTF Infiltration Uniform"
-	desc = "An extremely expensive sneaking suit created by an Ninetails Corporation for high risk stealth missions, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. Only provided rarely to most successful Senior Operatives or higher. This uniform allows you to walk quietly and crawl through vents with ALT-CLICK. To change the variant of the suit, ALT-RIGHTCLICK on it."
+	desc = "An extremely expensive sneaking suit created by an Ninetails Corporation for high risk stealth missions, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. Only provided rarely to most successful Senior Operatives or higher. This uniform allows you to walk quietly ALT-CLICK. To change the variant of the suit, ALT-RIGHTCLICK on it."
 	icon = 'ntf_modular/icons/obj/clothing/uniforms/uniforms.dmi'
 	icon_state = "sneak"
 	armor_protection_flags = CHEST|GROIN|LEGS|ARMS|HANDS|FEET
@@ -13,12 +13,10 @@
 
 /obj/item/clothing/under/marine/sneaking/equipped(mob/user, i_clothing)
 	. = ..()
-	ADD_TRAIT(user, TRAIT_CAN_VENTCRAWL, ARMOR_TRAIT)
 	ADD_TRAIT(user, TRAIT_LIGHT_STEP, ARMOR_TRAIT)
 
 /obj/item/clothing/under/marine/sneaking/unequipped(mob/unequipper, i_clothing)
 	. = ..()
-	REMOVE_TRAIT(unequipper, TRAIT_CAN_VENTCRAWL, ARMOR_TRAIT)
 	REMOVE_TRAIT(unequipper, TRAIT_LIGHT_STEP, ARMOR_TRAIT)
 
 /obj/item/clothing/under/marine/sneaking/AltRightClick(mob/user)
@@ -34,16 +32,16 @@
 	switch(variant)
 		if(1)
 			name = "NTF Infiltration Uniform"
-			desc = "An extremely expensive sneaking suit created by an Ninetails Corporation for high risk stealth missions, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. Only provided rarely to most successful Senior Operatives or higher. This uniform allows you to walk quietly and crawl through vents with ALT-CLICK. To change the variant of the suit, ALT-CLICK on it."
+			desc = "An extremely expensive sneaking suit created by an Ninetails Corporation for high risk stealth missions, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. Only provided rarely to most successful Senior Operatives or higher. This uniform allows you to walk quietly with ALT-CLICK. To change the variant of the suit, ALT-CLICK on it."
 			icon_state = "sneak"
 		if(2)
 			name = "NTC Spec-Ops Tactical T-Back Leotard"
-			desc = "An extremely expensive sneaking leotard with extra skin-showing properties created by an Ninetails Corporation for high risk missions with high risk clothes, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. Only provided rarely to most successful Senior Operatives or higher. This leotard allows you to walk quietly and crawl through vents with ALT-CLICK"
+			desc = "An extremely expensive sneaking leotard with extra skin-showing properties created by an Ninetails Corporation for high risk missions with high risk clothes, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. Only provided rarely to most successful Senior Operatives or higher. This leotard allows you to walk quietly with ALT-CLICK"
 			icon_state = "sneak_leotard"
 			shows_butt = TRUE
 		if(3)
 			name = "NTC Spec-Ops Tactical String bikini"
-			desc = "An extremely expensive sneaking... string bikini? with ultra-extra skin-showing properties created by an Ninetails Corporation for high risk missions with highest risk clothes, made with several layers of a nano-fiber that, while light-- It doesn't even matter, it practically doesn't exist, guess the sneakiest suit of all so far. This bikini allows you to walk quietly and crawl through vents with ALT-CLICK"
+			desc = "An extremely expensive sneaking... string bikini? with ultra-extra skin-showing properties created by an Ninetails Corporation for high risk missions with highest risk clothes, made with several layers of a nano-fiber that, while light-- It doesn't even matter, it practically doesn't exist, guess the sneakiest suit of all so far. This bikini allows you to walk quietly with ALT-CLICK"
 			icon_state = "sneak_kini"
 			shows_butt = TRUE
 		if(4)
@@ -56,7 +54,7 @@
 			icon_state = "sneak_suitskirt"
 		if(6)
 			name = "sneaking harness"
-			desc = "You are pretty much naked for maximum stealth, almost a NAKED SNAKE through the vents and all, good luck. This uniform allows you to walk quietly and crawl through vents with ALT-CLICK. To change the variant of the suit, ALT-CLICK on it."
+			desc = "You are pretty much naked for maximum stealth, almost a NAKED SNAKE through the vents and all, good luck. This uniform allows you to walk quietly with ALT-CLICK. To change the variant of the suit, ALT-CLICK on it."
 			icon = 'ntf_modular/icons/obj/clothing/uniforms/lewdclothes.dmi'
 			icon_state = "gear_harness"
 			worn_icon_list = list(slot_w_uniform_str = 'ntf_modular/icons/mob/clothing/uniforms/lewdclothes.dmi')

--- a/ntf_modular/code/modules/clothing/under/miscellaneouskz.dm
+++ b/ntf_modular/code/modules/clothing/under/miscellaneouskz.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/under/marine/kzsneaking
 	name = "KZ Covert Outfit"
-	desc = "A costly stealth outfit devised by Kaizoku Zaibatsu Counterintelligence intended for covert operations. The uniform is created with layers of light nano-fibers, allowing the wearer to mold their body into tight spaces. Parts of the armor have light amounts of kevlar interweaving with nano-fibers, impacting the speed of the average NTF variant. The uniform allows you to walk quietly and crawl through vents with ALT-CLICK. To change the variant of the suit, ALT-RIGHTCLICK on it."
+	desc = "A costly stealth outfit devised by Kaizoku Zaibatsu Counterintelligence intended for covert operations. The uniform is created with layers of light nano-fibers. Parts of the armor have light amounts of kevlar interweaving with nano-fibers, impacting the speed of the average NTF variant. The uniform allows you to walk quietly with ALT-CLICK. To change the variant of the suit, ALT-RIGHTCLICK on it."
 	icon = 'ntf_modular/icons/obj/clothing/uniforms/uniforms.dmi'
 	icon_state = "sneak"
 	armor_protection_flags = CHEST|GROIN|LEGS|ARMS|HANDS|FEET
@@ -13,12 +13,10 @@
 
 /obj/item/clothing/under/marine/kzsneaking/equipped(mob/user, i_clothing)
 	. = ..()
-	ADD_TRAIT(user, TRAIT_CAN_VENTCRAWL, ARMOR_TRAIT)
 	ADD_TRAIT(user, TRAIT_LIGHT_STEP, ARMOR_TRAIT)
 
 /obj/item/clothing/under/marine/kzsneaking/unequipped(mob/unequipper, i_clothing)
 	. = ..()
-	REMOVE_TRAIT(unequipper, TRAIT_CAN_VENTCRAWL, ARMOR_TRAIT)
 	REMOVE_TRAIT(unequipper, TRAIT_LIGHT_STEP, ARMOR_TRAIT)
 
 /obj/item/clothing/under/marine/kzsneaking/AltRightClick(mob/user)
@@ -34,16 +32,16 @@
 	switch(variant)
 		if(1)
 			name = "KZ Covert Outfit"
-			desc = "A costly stealth outfit devised by the Kaizoku Zaibatsu Counterintelligence intended for covert operations. The uniform is created with layers of light nano-fibers, allowing the wearer to mold their body into tight spaces. Parts of the armor have light amounts of kevlar interweaving with nano-fibers, impacting the speed of the average NTF variant. The uniform allows you to walk quietly and crawl through vents with ALT-CLICK. To change the variant of the suit, ALT-RIGHTCLICK on it."
+			desc = "A costly stealth outfit devised by the Kaizoku Zaibatsu Counterintelligence intended for covert operations. The uniform is created with layers of light nano-fibers. Parts of the armor have light amounts of kevlar interweaving with nano-fibers, impacting the speed of the average NTF variant. The uniform allows you to walk quietly with ALT-CLICK. To change the variant of the suit, ALT-RIGHTCLICK on it."
 			icon_state = "sneak"
 		if(2)
 			name = "KZ Counterintel Tactical T-Back Leotard"
-			desc = "An extremely expensive sneaking leotard with extra skin-showing properties created by the Kaizoku Zaibatsu for high risk tasking with high risk clothes, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. This leotard allows you to walk quietly and crawl through vents with ALT-CLICK"
+			desc = "An extremely expensive sneaking leotard with extra skin-showing properties created by the Kaizoku Zaibatsu for high risk tasking with high risk clothes, made with several layers of a nano-fiber that, while light, molds to the wearer's body shape and hardens protecting them. This leotard allows you to walk quietly with ALT-CLICK"
 			icon_state = "sneak_leotard"
 			shows_butt = TRUE
 		if(3)
 			name = "KZ Counterintel Tactical String bikini"
-			desc = "An extremely expensive sneaking... string bikini? with ultra-extra skin-showing properties created by the Kaizoku Zaibatsu for high risk tasking with highest risk clothes, made with several layers of a nano-fiber that, while light-- It doesn't even matter, it practically doesn't exist, guess the sneakiest suit of all so far. This bikini allows you to walk quietly and crawl through vents with ALT-CLICK"
+			desc = "An extremely expensive sneaking... string bikini? with ultra-extra skin-showing properties created by the Kaizoku Zaibatsu for high risk tasking with highest risk clothes, made with several layers of a nano-fiber that, while light-- It doesn't even matter, it practically doesn't exist, guess the sneakiest suit of all so far. This bikini allows you to walk quietly with ALT-CLICK"
 			icon_state = "sneak_kini"
 			shows_butt = TRUE
 		if(4)
@@ -56,7 +54,7 @@
 			icon_state = "sneak_suitskirt"
 		if(6)
 			name = "sneaking harness"
-			desc = "You are pretty much naked for maximum stealth, almost a NAKED SNAKE through the vents and all, good luck. This uniform allows you to walk quietly and crawl through vents with ALT-CLICK. To change the variant of the suit, ALT-CLICK on it."
+			desc = "You are pretty much naked for maximum stealth, almost a NAKED SNAKE through the vents and all, good luck. This uniform allows you to walk quietly with ALT-CLICK. To change the variant of the suit, ALT-CLICK on it."
 			icon = 'ntf_modular/icons/obj/clothing/uniforms/lewdclothes.dmi'
 			icon_state = "gear_harness"
 			worn_icon_list = list(slot_w_uniform_str = 'ntf_modular/icons/mob/clothing/uniforms/lewdclothes.dmi')


### PR DESCRIPTION

## About The Pull Request
Removes Vent Crawling from stealth suits (both NTC and KZ ones)

## Why It's Good For The Game
Not only keeps the ability to move through vents to xenomorphs only, but also prevents a current TDI memory leak by having carbon users crawling on vents and thus dragging the server to a crawl through its abuse.

## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="662" height="910" alt="image" src="https://github.com/user-attachments/assets/c3149ad3-393e-41b6-b14b-ec943c1f6d6a" />


</details>

## Changelog
:cl:
balance: Removes Vent Crawling from stealth suits (both NTC and KZ ones)
/:cl:
