### PR TITLE
Increase pr412 akimbo scatter mod from 8 to 12

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -426,6 +426,7 @@
 	burst_amount = 3
 	aim_slowdown = 0.4
 	damage_mult = 1.05 //Has smaller magazines
+	akimbo_scatter_mod = 12
 
 /obj/item/weapon/gun/rifle/m412/freelancer
 	starting_attachment_types = list(/obj/item/attachable/magnetic_harness, /obj/item/weapon/gun/grenade_launcher/underslung, /obj/item/attachable/extended_barrel)


### PR DESCRIPTION

## About The Pull Request
Increases pr412 akimbo scatter mod from 8 to 12.
## Why It's Good For The Game
Apparently akimbo pr412s are really strong.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="549" height="234" alt="image" src="https://github.com/user-attachments/assets/c2229854-f13e-4723-b807-cc984af6111b" />

</details>

## Changelog
:cl:
balance: Increased pr412 akimbo scatter mod from 8 to 12.
/:cl:
