### PR TITLE
Fixes thermoberic by removing it

### DIFF
--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -360,14 +360,14 @@
 /datum/ammo/rocket/som/thermobaric/drop_nade(turf/target_turf, atom/movable/projectile/proj)
 	explosion(target_turf, 0, 4, 5, 0, 4, 4, explosion_cause = proj)
 
-/datum/ammo/rocket/oneuse/thermobaric // disposable thermobaric
+/*/datum/ammo/rocket/oneuse/thermobaric // disposable thermobaric
 	name = "thermobaric Rocket"
 	hud_state = "rpg_thermobaric"
 	damage = 30
 
 
 /datum/ammo/rocket/oneuse/thermobaric/drop_nade(turf/target_turf, atom/movable/projectile/proj)
-	explosion(target_turf, 0, 4, 5, 0, 4, 4, explosion_cause = proj)
+	explosion(target_turf, 0, 4, 5, 0, 4, 4, explosion_cause = proj)*/// Until fixed by its developer, this is just a better disposable
 
 /datum/ammo/rocket/som/heat //Anti tank, or mech
 	name = "HEAT RPG"

--- a/code/modules/projectiles/magazines/specialist.dm
+++ b/code/modules/projectiles/magazines/specialist.dm
@@ -228,7 +228,7 @@
 
 //RPO Thermobaric
 
-/obj/item/ammo_magazine/rocket/oneuse/thermobaric
+/*/obj/item/ammo_magazine/rocket/oneuse/thermobaric
 	name = "\improper 93mm thermobaric Rocket"
 	desc = "A rocket used to reload a one use rocket once returned to an armory."
 	caliber = CALIBER_93MM
@@ -236,7 +236,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	max_rounds = 1
 	default_ammo = /datum/ammo/rocket/oneuse/thermobaric
-	reload_delay = 30
+	reload_delay = 30*/// Until fixed by its developer, this is being turned off. Its just a better disposable launcher.
 
 //-------------------------------------------------------
 //M5 RPG'S MEAN FUCKING COUSIN

--- a/code/modules/reqs/supplypacks/weapons_packs.dm
+++ b/code/modules/reqs/supplypacks/weapons_packs.dm
@@ -572,11 +572,11 @@ WEAPONS
 	cost = 100
 	available_against_xeno_only = TRUE
 
-/datum/supply_packs/weapons/rpgoneuse/thermobaric
+/*/datum/supply_packs/weapons/rpgoneuse/thermobaric
 	name = "RPO-S Disposable Rocket Flamethrower"
 	contains = list(/obj/item/weapon/gun/launcher/rocket/oneuse/thermobaric)
 	cost = 150
-	available_against_xeno_only = TRUE
+	available_against_xeno_only = TRUE*/
 
 /datum/supply_packs/weapons/mateba
 	name = "Mateba Autorevolver belt"

--- a/ntf_modular/code/modules/projectiles/guns/other.dm
+++ b/ntf_modular/code/modules/projectiles/guns/other.dm
@@ -20,7 +20,7 @@
 
 // RPO-S, old VSD disposable rocket launcher, thermobaric firing.
 
-/obj/item/weapon/gun/launcher/rocket/oneuse/thermobaric
+/*/obj/item/weapon/gun/launcher/rocket/oneuse/thermobaric
 	name = "\improper RPO-S Disposable Rocket Flamethrower"
 	desc = "An old design still in circulation after being produced by the millions back in the day as the relatively simple, inexpensive design allowed it to be issued in mass and thrown around like candy."
 	icon = 'icons/obj/items/guns/special64.dmi'
@@ -39,6 +39,6 @@
 	reload_sound = 'sound/weapons/guns/interact/launcher_reload.ogg'
 	unload_sound = 'sound/weapons/guns/interact/launcher_reload.ogg'
 	attachable_offset = list("muzzle_x" = 33, "muzzle_y" = 18,"rail_x" = 6, "rail_y" = 19, "under_x" = 19, "under_y" = 14, "stock_x" = 19, "stock_y" = 14)
-	fire_delay = 1 SECONDS
+	fire_delay = 1 SECONDS*/
 
 


### PR DESCRIPTION

## About The Pull Request
The thermobaric launcher is supposed to just be a big fire, unfortunately, the developer of it does not test their code, so its actually just a disposable anti-tank launcher that ALSO sets things on max fire. 
## Why It's Good For The Game
No more powercreep, stop powercreeping. We don't need backpack portable anti-everything launchers
## Proof of Testing
Its a numbers change basically, it compiles, though due to recent updates my testing environment is obliterated and borderline unusable
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: removes the thermoberic launcher
/:cl:
