### PR TITLE
Gives Combat Escort Research Ability.

### DIFF
--- a/code/datums/jobs/job/vsd_squad.dm
+++ b/code/datums/jobs/job/vsd_squad.dm
@@ -162,5 +162,9 @@ and at the same time Kaizoku is pressured into playing along with SOM by their s
 /datum/job/vsd_squad/escort/get_spawn_message_information(mob/M)
 	. = ..()
 	. += separator_hr("[span_role_header("<b>[title] Information</b>")]")
-	. += {"\nYou are a chosen elite of the Kaizoku Corporation, handpicked for your exceptional combat skills and unwavering loyalty. Protect Valuable Corporate Assets, Relieve pressure from the frontline troops deployed alongside you and broker deals with the factions planetside, especially if it means using your body!"}
+	. += {"\nYou are a chosen elite of the Kaizoku Corporation, handpicked for your exceptional combat skills and unwavering loyalty. Protect Valuable Corporate Assets, Secure valuable resources, Relieve pressure from the frontline troops deployed alongside you and broker deals with the factions planetside, especially if it means using your body!"}
+
+/datum/job/vsd_squad/escort/after_spawn(mob/living/carbon/C, mob/M, latejoin = FALSE)
+	. = ..()
+	ADD_TRAIT(C, TRAIT_RESEARCHER, "[type]")
 


### PR DESCRIPTION

## About The Pull Request

Re-Adds the ability for KZ to perfom research through the use of their Combat Escort role, no longer making them them **singular** faction in the game unable to do-so whatsoever over some furry malding about it.

## Why It's Good For The Game

Role was supposed to have this in the first place. MFs removed it because of salt. Vide already massively nerfed research by making research a valid for instant escalation just like intel.


## Proof of Testing
Shit runs (I'm keeping it this vague bc it pisses some ppl off)
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Gives KZ Combat Escort their intended research ability, fixes an oversight in their join text.
/:cl:
