### PR TITLE
Adds a bit of failsafes to write buffer runtimes

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -515,8 +515,8 @@
 		slot = default_slot
 	slot = sanitize_integer(slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
 	if(slot != default_slot)
-		default_slot = slot
 		WRITE_FILE(S["default_slot"], slot)
+		default_slot = slot
 	S.cd = "/character[slot]"
 
 	READ_FILE(S["be_special"], be_special)

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -402,9 +402,25 @@
 			if(!choice)
 				return
 			if(!load_character(text2num(splittext(choice," - ")[1])))
-				random_character()
-				real_name = random_unique_name(gender)
-				save_character()
+				if(splittext(choice," - ")[2] == "\[empty\]")
+					slot = sanitize_integer(slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
+					if(slot != default_slot)
+						WRITE_FILE(S["default_slot"], slot)
+						default_slot = slot
+					S.cd = "/character[slot]"
+					random_character()
+					real_name = random_unique_name(gender)
+					save_character()
+				else
+					var/choice2 = tgui_alert(user,"Your character cannot be loaded at this time. Try again later, possibly reconnect, and if the issue persists, notify staff!", "Character Loading Error!", list("Retry" , "Cancel"))
+					switch(choice2)
+						if("Retry")
+							if(!load_character(text2num(splittext(choice," - ")[1])))
+								tgui_alert(user, "Nope, still nothing... try again later...")
+						if("Cancel")
+							return
+
+
 			update_preview_icon()
 
 		if("tab_change")

--- a/code/modules/client/preferences_ui.dm
+++ b/code/modules/client/preferences_ui.dm
@@ -401,13 +401,14 @@
 			var/choice = tgui_input_list(ui.user, "What slot do you want to load?", "Character slot choice", slots)
 			if(!choice)
 				return
-			if(!load_character(text2num(splittext(choice," - ")[1])))
+			var/slotchoice = text2num(splittext(choice," - ")[1])
+			if(!load_character(slotchoice))
 				if(splittext(choice," - ")[2] == "\[empty\]")
-					slot = sanitize_integer(slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
-					if(slot != default_slot)
-						WRITE_FILE(S["default_slot"], slot)
-						default_slot = slot
-					S.cd = "/character[slot]"
+					slotchoice = sanitize_integer(slotchoice, 1, MAX_SAVE_SLOTS, initial(default_slot))
+					if(slotchoice != default_slot)
+						WRITE_FILE(S["default_slot"], slotchoice)
+						default_slot = slotchoice
+					S.cd = "/character[slotchoice]"
 					random_character()
 					real_name = random_unique_name(gender)
 					save_character()


### PR DESCRIPTION

## About The Pull Request

If the save file slot cannot be loaded, then it will be asked if they want to retry it now or later INSTEAD of plain out deleting and overwriting whatever is in the slot with no input or remorse.

## Why It's Good For The Game

Failsafes so people's characters stop getting deleted while we figure out what is wrong


## Proof of Testing

No clue how to corrupt a slot but normal operation seems to work fine

## Changelog
:cl:
fix: Failsafes added to slot changes.
/:cl:
