### PR TITLE
Let all (T1+) Xenos Corrupt Generators

### DIFF
--- a/code/modules/power/groundmap_geothermal.dm
+++ b/code/modules/power/groundmap_geothermal.dm
@@ -215,7 +215,7 @@ GLOBAL_VAR_INIT(corrupted_generators, 0)
 	if(SEND_SIGNAL(src, COMSIG_OBJ_ATTACK_ALIEN, xeno_attacker, damage_amount) & COMPONENT_NO_ATTACK_ALIEN)
 		return FALSE
 
-	if(is_corruptible && (CHECK_BITFIELD(xeno_attacker.xeno_caste.can_flags, CASTE_CAN_CORRUPT_GENERATOR) || (xeno_attacker.get_hive()?.living_xeno_ruler == xeno_attacker)))
+	if(is_corruptible && ((GLOB.tier_as_number[xeno_attacker.tier] >= 1) || CHECK_BITFIELD(xeno_attacker.xeno_caste.can_flags, CASTE_CAN_CORRUPT_GENERATOR) || (xeno_attacker.get_hive()?.living_xeno_ruler == xeno_attacker)))
 		to_chat(xeno_attacker, span_notice("You start to corrupt [src]"))
 		if(!do_after(xeno_attacker, 10 SECONDS, NONE, src, BUSY_ICON_HOSTILE))
 			return


### PR DESCRIPTION

## About The Pull Request
Lets all (T1+) Xenos corrupt generators
## Why It's Good For The Game
So the Regnant doesn't have to deal personally with a problem any human can cause.
## Proof of Testing
<img width="1165" height="633" alt="image" src="https://github.com/user-attachments/assets/788a0642-6f95-4ea0-936d-4438a63ea816" />
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
add: All (T1+) Xenos can now corrupt geothermal generators
/:cl:
