### PR TITLE
xeno health buffs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/bull/castedatum_bull.dm
@@ -20,7 +20,7 @@
 	plasma_gain = 24
 
 	// *** Health *** //
-	max_health = 425
+	max_health = 445
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.9

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/castedatum_carrier.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 425
+	max_health = 445
 
 	// *** Evolution *** //
 	evolution_threshold = 225

--- a/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/defender/castedatum_defender.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 420
+	max_health = 460
 
 	// *** Evolution *** //
 	evolution_threshold = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/drone/castedatum_drone.dm
@@ -24,7 +24,7 @@
 	plasma_gain = 50
 
 	// *** Health *** //
-	max_health = 380
+	max_health = 415
 
 	// *** Evolution *** //
 	evolution_threshold = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -22,7 +22,7 @@
 	plasma_icon_state = "hivelord_plasma"
 
 	// *** Health *** //
-	max_health = 380
+	max_health = 395
 
 
 	// *** Evolution *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivemind/castedatum_hivemind.dm
@@ -18,7 +18,7 @@
 	plasma_gain = 80
 
 	// *** Health *** //
-	max_health = 100
+	max_health = 115
 
 	maximum_active_caste = 1
 	// *** Flags *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -26,7 +26,7 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 375
 
 	// *** Evolution *** //
 	evolution_threshold = 225

--- a/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/larva/castedatum_larva.dm
@@ -22,7 +22,7 @@
 	plasma_gain = 1
 
 	// *** Health *** //
-	max_health = 50
+	max_health = 60
 	crit_health = -25
 
 	// *** Evolution *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/puppeteer/castedatum_puppeteer.dm
@@ -16,7 +16,7 @@
 	plasma_gain = 3
 	plasma_regen_limit = 1
 	plasma_icon_state = "plasma"
-	max_health = 365
+	max_health = 380
 	upgrade_threshold = TIER_TWO_THRESHOLD
 	evolution_threshold = 225
 
@@ -68,7 +68,7 @@
 	speed = -0.8
 	melee_damage = 18
 	plasma_max = 750
-	max_health = 385
+	max_health = 400
 	soft_armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 20, BOMB = 10, BIO = 20, FIRE = 20, ACID = 20)
 	max_puppets = 3
 

--- a/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/pyrogen/castedatum_pyrogen.dm
@@ -24,7 +24,7 @@
 	plasma_gain = 30
 
 	// *** Health *** //
-	max_health = 380
+	max_health = 395
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_THRESHOLD

--- a/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/runner/castedatum_runner.dm
@@ -24,7 +24,7 @@
 	plasma_gain = 11
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 330
 
 	// *** Evolution *** //
 	evolution_threshold = 100
@@ -117,7 +117,7 @@
 	caste_flags = CASTE_ACID_BLOOD|CASTE_EVOLUTION_ALLOWED|CASTE_MUTATIONS_ALLOWED
 
 	// +50 health
-	max_health = 350
+	max_health = 385
 
 	// +5 armor across the board
 	soft_armor = list(MELEE = 35, BULLET = 35, LASER = 35, ENERGY = 35, BOMB = 5, BIO = 10, FIRE = 25, ACID = 10)

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/castedatum_sentinel.dm
@@ -22,7 +22,7 @@
 	plasma_gain = 20
 
 	// *** Health *** //
-	max_health = 370
+	max_health = 405
 
 	// *** Evolution *** //
 	evolution_threshold = 100

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/castedatum_spitter.dm
@@ -20,7 +20,7 @@
 	plasma_gain = 40
 
 	// *** Health *** //
-	max_health = 360
+	max_health = 375
 
 	// *** Evolution *** //
 	evolution_threshold = 225
@@ -100,7 +100,7 @@
 	speed = -0.8
 
 	// *** Health *** //
-	max_health = 320
+	max_health = 335
 
 	// *** Ablities *** //
 	actions = list(

--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/castedatum_warrior.dm
@@ -20,7 +20,7 @@
 	plasma_gain = 15
 
 	// *** Health *** //
-	max_health = 400
+	max_health = 420
 
 	// *** Sunder *** //
 	sunder_multiplier = 0.9

--- a/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/wraith/castedatum_wraith.dm
@@ -20,7 +20,7 @@
 	plasma_gain = 35
 
 	// *** Health *** //
-	max_health = 340
+	max_health = 355
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_TWO_THRESHOLD

--- a/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/facehugger/castedatum_facehugger.dm
+++ b/modular_RUtgmc/code/modules/mob/living/carbon/xenomorph/castes/facehugger/castedatum_facehugger.dm
@@ -22,7 +22,7 @@
 	plasma_max = 100
 
 	// *** Health *** //
-	max_health = 30
+	max_health = 35
 	crit_health = -25
 
 	// *** Flags *** //
@@ -59,7 +59,7 @@
 	melee_damage = 25
 	attack_delay = 7
 	speed = -1.3
-	max_health = 50
+	max_health = 55
 	plasma_max = 50
 
 /datum/xeno_caste/facehugger/neuro

--- a/ntf_modular/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
+++ b/ntf_modular/code/modules/mob/living/carbon/xenomorph/castes/hunter/castedatum_hunter.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 23
 
 	// *** Health *** //
-	max_health = 300
+	max_health = 315
 
 	stealth_break_threshold = 18
 

--- a/ntf_modular/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
+++ b/ntf_modular/code/modules/mob/living/carbon/xenomorph/castes/panther/castedatum_panther.dm
@@ -25,7 +25,7 @@
 	plasma_icon_state = "fury"
 
 	// *** Health *** //
-	max_health = 240
+	max_health = 260
 
 	// *** Flags *** //
 	caste_flags = CASTE_INNATE_PLASMA_REGEN|CASTE_PLASMADRAIN_IMMUNE|CASTE_EVOLUTION_ALLOWED|CASTE_MUTATIONS_ALLOWED


### PR DESCRIPTION

## About The Pull Request
Buffs t2 xeno health by up to 5% (rounded down) and t1 xeno health by up to 10%
## Why It's Good For The Game
Xenos keep getting stomped in war modes and some people say they're too fragile
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Bull health increased from 425 to 445
balance: Carrier health increased from 425 to 445
balance: Defender health increased from 420 to 460
balance: Drone health increased from 380 to 415
balance: Hivelord health increased from 380 to 395
balance: Hivemind health increased from 100 to 115
balance: Hunter health increased from 360 to 375
balance: Larva health increased from 50 to 60
balance: Puppeteer health increased from 365 to 380
balance: Primordial puppeteer health increased from 380 to 415
balance: Pyrogen health increased from 380 to 395
balance: Runner health increased from 300 to 330
balance: Melter health increased from 350 to 385
balance: Sentinel health increased from 370 to 405
balance: Spitter health increased from 360 to 375
balance: Globadier health increased from 320 to 335
balance: Warrior health increased from 400 to 420
balance: Wraith health increased from 340 to 355
balance: Player-controlled facehugger health increased from 30 to 35
balance: Player-controlled slash facehugger health increased from 50 to 55
balance: Assassain health increased from 300 to 315
balance: Panther health increased from 240 to 260
/:cl:
