### PR TITLE
Reenables synth restrictions, loosens them to allow all nonlethals

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -82,7 +82,8 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 
 //Human sub-species
 #define isrobot(H) (is_species(H, /datum/species/robot))
-#define issynth(H) (is_species(H, /datum/species/synthetic) || is_species(H, /datum/species/early_synthetic))
+#define issynthspecies(H) (is_species(H, /datum/species/synthetic) || is_species(H, /datum/species/early_synthetic))
+#define issynth(H) (issynthspecies(H) || (isrobot(H) && H:job && issynthjob(H:job)))
 #define isspeciessynthetic(H) (H.species.species_flags & IS_SYNTHETIC)
 #define islizard(H) (is_species(H, /datum/species/lizard))
 #define ismoth(H) (is_species(H, /datum/species/moth))
@@ -115,6 +116,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define issurvivorjob(J) (istype(J, /datum/job/survivor))
 #define ischaplainjob(J) (istype(J, /datum/job/survivor/chaplain))
 #define isxenosjob(J) (istype(J, /datum/job/xenomorph))
+#define issynthjob(J) (istype(J, /datum/job) && findtext((J):rank, "Synthetic"))
 
 //Monkey sub-species
 

--- a/code/datums/components/jump.dm
+++ b/code/datums/components/jump.dm
@@ -106,7 +106,7 @@
 		if(living_jumper.status_flags & INCORPOREAL)
 			return FALSE
 		if(stamina_cost && (living_jumper.getStaminaLoss() > -stamina_cost))
-			if(isrobot(living_jumper) || issynth(living_jumper))
+			if(isrobot(living_jumper) || issynthspecies(living_jumper))
 				to_chat(living_jumper, span_warning("Your leg servos do not allow you to jump!"))
 				return FALSE
 			to_chat(living_jumper, span_warning("Catch your breath!"))

--- a/code/datums/health_scan/advice/species_notes.dm
+++ b/code/datums/health_scan/advice/species_notes.dm
@@ -24,7 +24,7 @@
 	))
 
 /datum/scanner_advice/species/synthetic/can_show(mob/living/carbon/human/patient, mob/user)
-	return issynth(patient)
+	return issynthspecies(patient)
 
 /datum/scanner_advice/species/synthetic/get_data(mob/living/carbon/human/patient, mob/user)
 	. = list()

--- a/code/datums/health_scan/health_scan.dm
+++ b/code/datums/health_scan/health_scan.dm
@@ -206,7 +206,7 @@
 		"species" = list(
 			"name" = patient.species?.name || "Unknown Species",
 			// species types
-			"is_synthetic" = issynth(patient),
+			"is_synthetic" = issynthspecies(patient),
 			"is_combat_robot" = isrobot(patient),
 			// for the robot umbrella which shares a lot of traits
 			"is_robotic_species" = !!(patient.species?.species_flags & ROBOTIC_LIMBS),

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -690,7 +690,7 @@
 ///Calls slash proc
 /datum/status_effect/xeno_carnage/proc/carnage_slash(datum/source, mob/living/target, damage)
 	SIGNAL_HANDLER
-	if(!ishuman(target) || issynth(target))
+	if(!ishuman(target) || issynthspecies(target))
 		return
 	UnregisterSignal(owner, COMSIG_XENOMORPH_ATTACK_LIVING)
 	INVOKE_ASYNC(src, PROC_REF(do_carnage_slash), source, target, damage)

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -138,7 +138,7 @@
 	if(istype(I, /obj/item/explosive/grenade))
 		var/obj/item/explosive/grenade/G = I
 
-		if(issynth(user) && G.dangerous && !CONFIG_GET(flag/allow_synthetic_gun_use))
+		if(issynth(user) && G.lethal && !CONFIG_GET(flag/allow_synthetic_gun_use))
 			to_chat(user, span_warning("Your programming prevents you from doing this."))
 			return
 

--- a/code/game/objects/effects/acid_hole.dm
+++ b/code/game/objects/effects/acid_hole.dm
@@ -138,7 +138,7 @@
 	if(istype(I, /obj/item/explosive/grenade))
 		var/obj/item/explosive/grenade/G = I
 
-		if(issynth(user) && G.lethal && !CONFIG_GET(flag/allow_synthetic_gun_use))
+		if(issynth(user) && G.lethal && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 			to_chat(user, span_warning("Your programming prevents you from doing this."))
 			return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -572,9 +572,9 @@
 		if(!is_type_in_list(H.species, species_exception))
 			return FALSE
 
-	if(issynth(H) && CHECK_BITFIELD(item_flags, SYNTH_RESTRICTED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+	/*if(issynth(H) && CHECK_BITFIELD(item_flags, SYNTH_RESTRICTED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 		to_chat(H, span_warning("Your programming prevents you from wearing this."))
-		return FALSE
+		return FALSE*/ //Not a single item with this flag actually seems worth restricting.
 
 	var/obj/item/selected_slot //the item in the specific slot we're trying to insert into
 	var/equip_to_slot = FALSE

--- a/code/game/objects/items/devices/mirage.dm
+++ b/code/game/objects/items/devices/mirage.dm
@@ -4,6 +4,7 @@
 	icon_state = "delivery"
 	worn_icon_state = "delivery"
 	dangerous = FALSE
+	lethal = FALSE
 	///the parent to be copied
 	var/mob/living/current_user
 	///How long the illusory fakes last

--- a/code/game/objects/items/explosives/bombvest.dm
+++ b/code/game/objects/items/explosives/bombvest.dm
@@ -28,7 +28,7 @@
 ///Overwrites the parent function for activating a light. Instead it now detonates the bomb.
 /obj/item/clothing/suit/storage/marine/boomvest/attack_self(mob/user)
 	var/mob/living/carbon/human/activator = user
-	if(issynth(activator) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+	if(issynth(activator) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 		balloon_alert(user, "against your programming!")
 		return TRUE
 	if(user.alpha != 255)

--- a/code/game/objects/items/explosives/grenades/chem_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/chem_grenade.dm
@@ -22,6 +22,7 @@
 	var/threatscale = 1 // Used by advanced grenades to make them slightly more worthy.
 	var/no_splash = FALSE //If the grenade deletes even if it has no reagents to splash with. Used for slime core reactions.
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10°K upon ignition." // Appears when examining empty casings.
+	lethal = FALSE
 
 
 /obj/item/explosive/grenade/chem_grenade/Initialize(mapload)

--- a/code/game/objects/items/explosives/grenades/flares.dm
+++ b/code/game/objects/items/explosives/grenades/flares.dm
@@ -7,6 +7,7 @@
 	det_time = 0
 	throwforce = 1
 	dangerous = FALSE
+	lethal = FALSE
 	w_class = WEIGHT_CLASS_TINY
 	hud_state = "grenade_frag"
 	light_system = MOVABLE_LIGHT

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -46,7 +46,7 @@
 		balloon_alert(user, "not enough dexterity!")
 		return
 
-	if(issynth(user) && lethal && !CONFIG_GET(flag/allow_synthetic_gun_use))
+	if(issynth(user) && dangerous && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 		balloon_alert(user, "against your programming!")
 		return
 

--- a/code/game/objects/items/explosives/grenades/grenade.dm
+++ b/code/game/objects/items/explosives/grenades/grenade.dm
@@ -20,8 +20,10 @@
 	///bonus impact damage if launched from a UGL/grenade launcher
 	var/launchforce = 10
 	var/det_time = 4 SECONDS
-	///Does it make a danger overlay for humans? Can synths use it?
+	///Does it make a danger overlay for humans?
 	var/dangerous = TRUE
+	//Can synths use it?
+	var/lethal = TRUE
 	var/arm_sound = 'sound/weapons/armbomb.ogg'
 	var/hud_state = "grenade_he"
 	var/hud_state_empty = "grenade_empty"
@@ -44,7 +46,7 @@
 		balloon_alert(user, "not enough dexterity!")
 		return
 
-	if(issynth(user) && dangerous && !CONFIG_GET(flag/allow_synthetic_gun_use))
+	if(issynth(user) && lethal && !CONFIG_GET(flag/allow_synthetic_gun_use))
 		balloon_alert(user, "against your programming!")
 		return
 

--- a/code/game/objects/items/explosives/grenades/smoke_grenades.dm
+++ b/code/game/objects/items/explosives/grenades/smoke_grenades.dm
@@ -6,6 +6,7 @@
 	det_time = 2 SECONDS
 	hud_state = "grenade_smoke"
 	dangerous = FALSE
+	lethal = FALSE
 	icon_state_mini = "grenade_blue"
 	/// smoke type created when the grenade is primed
 	var/datum/effect_system/smoke_spread/smoketype = /datum/effect_system/smoke_spread/bad
@@ -58,6 +59,7 @@
 	hud_state = "grenade_acid"
 	det_time = 4 SECONDS
 	dangerous = TRUE
+	lethal = TRUE
 	smoketype = /datum/effect_system/smoke_spread/xeno/acid/opaque
 	smokeradius = 5
 

--- a/code/game/objects/items/explosives/grenades/training_grenade.dm
+++ b/code/game/objects/items/explosives/grenades/training_grenade.dm
@@ -5,6 +5,7 @@
 	worn_icon_state = "training_grenade"
 	hud_state = "grenade_dummy"
 	dangerous = FALSE
+	lethal = FALSE
 	icon_state_mini = "grenade_white"
 
 /obj/item/explosive/grenade/training/prime()

--- a/code/game/objects/items/power_cells.dm
+++ b/code/game/objects/items/power_cells.dm
@@ -76,7 +76,7 @@
 	if(!rigged)
 		return ..()
 
-	if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+	if(issynth(user) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 		to_chat(user, span_warning("Your programming restricts using rigged power cells."))
 		return
 	log_bomber(user, "primed a rigged", src)
@@ -103,7 +103,7 @@
 	if(istype(I, /obj/item/reagent_containers/syringe))
 		var/obj/item/reagent_containers/syringe/S = I
 
-		if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+		if(issynth(user) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 			to_chat(user, span_warning("Your programming restricts rigging of power cells."))
 			return
 
@@ -114,7 +114,7 @@
 		S.reagents.clear_reagents()
 
 	else if(ismultitool(I))
-		if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+		if(issynth(user) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 			to_chat(user, span_warning("Your programming restricts rigging of power cells."))
 			return
 		var/skill = user.skills.getRating(SKILL_ENGINEER)

--- a/code/game/objects/machinery/artillery/mortar.dm
+++ b/code/game/objects/machinery/artillery/mortar.dm
@@ -357,9 +357,23 @@
 	if(!Adjacent(user) || user.incapacitated() || !ishuman(user))
 		return
 
+	var/amount_to_fire = fire_amount
+	if(!amount_to_fire)
+		amount_to_fire = length(chamber_items)
+	if(amount_to_fire > length(chamber_items))
+		amount_to_fire = length(chamber_items)
+
 	if(issynth(user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
-		user.balloon_alert(user, "you can't operate this!")
-		return
+		var/contains_lethal = FALSE
+		if(amount_to_fire)
+			for(var/i = 1 to amount_to_fire)
+				var/obj/item/mortal_shell/arty_shell = chamber_items[i]
+				if(istype(arty_shell) && arty_shell.lethal)
+					contains_lethal = TRUE
+					break
+			if(contains_lethal)
+				user.balloon_alert(user, "programming forbids lethal shells!")
+				return
 
 	if(firing)
 		user.balloon_alert(user, "the gun is still firing!")
@@ -402,11 +416,6 @@
 	var/list/turf_list = RANGE_TURFS(firing_spread, target)
 	var/obj/in_chamber
 	var/next_chamber_position = length(chamber_items)
-	var/amount_to_fire = fire_amount
-	if(!amount_to_fire)
-		amount_to_fire = length(chamber_items)
-	if(amount_to_fire > length(chamber_items))
-		amount_to_fire = length(chamber_items)
 	//Probably easier to declare and update a counter than it is to keep accessing a client and datum multiple times
 	var/shells_fired = 0
 	var/war_crimes_counter = 0

--- a/code/game/objects/machinery/artillery/shells.dm
+++ b/code/game/objects/machinery/artillery/shells.dm
@@ -13,6 +13,7 @@
 	atom_flags = CONDUCT
 	///Ammo datum typepath that the shell uses
 	var/ammo_type
+	var/lethal = TRUE
 
 /obj/item/mortal_shell/he
 	name = "\improper 80mm high explosive mortar shell"
@@ -31,18 +32,21 @@
 	desc = "An 80mm mortar shell, loaded with smoke dispersal agents. Can be fired at marines more-or-less safely. Way slimmer than your typical 80mm."
 	icon_state = "mortar_smk"
 	ammo_type = /datum/ammo/mortar/smoke
+	lethal = FALSE
 
 /obj/item/mortal_shell/plasmaloss
 	name = "\improper 80mm tangle mortar shell"
 	desc = "An 80mm mortar shell, loaded with plasma-draining Tanglefoot gas. Can be fired at marines more-or-less safely."
 	icon_state = "mortar_fsh"
 	ammo_type = /datum/ammo/mortar/smoke/plasmaloss
+	lethal = FALSE
 
 /obj/item/mortal_shell/flare
 	name = "\improper 80mm flare mortar shell"
 	desc = "An 80mm mortar shell, loaded with an illumination flare, far slimmer than your typical 80mm shell. Can be fired out of larger cannons."
 	icon_state = "mortar_flr"
 	ammo_type = /datum/ammo/mortar/flare
+	lethal = FALSE
 
 /obj/item/mortal_shell/howitzer
 	name = "\improper 150mm artillery shell"
@@ -60,6 +64,7 @@
 	desc = "An 150mm artillery shell, loaded with a toxic intoxicating gas, whatever is hit by this will have their abilities sapped slowly. Acommpanied by a small moderate explosion."
 	icon_state = "howitzer_plasmaloss"
 	ammo_type = /datum/ammo/mortar/smoke/howi/plasmaloss
+	lethal = FALSE
 
 /obj/item/mortal_shell/howitzer/incendiary
 	name = "\improper 150mm incendiary artillery shell"
@@ -99,6 +104,7 @@
 	desc = "A 60mm rocket loaded with cloak smoke that hides any friendlies inside of it with advanced chemical technology."
 	icon_state = "mlrs_cloak"
 	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs/cloak
+	lethal = FALSE
 
 /obj/item/mortal_shell/rocket/mlrs/incendiary
 	name = "\improper 60mm incendiary rocket"

--- a/code/game/objects/machinery/portable_reagent_tank.dm
+++ b/code/game/objects/machinery/portable_reagent_tank.dm
@@ -73,7 +73,7 @@
 
 ///Process for drinking reagents directly from the dispenser's nozzle
 /obj/machinery/deployable/reagent_tank/proc/drink_from_nozzle(mob/living/user, is_xeno = FALSE)
-	if(isrobot(user) || issynth(user))
+	if(isrobot(user) || issynthspecies(user))
 		balloon_alert(user, "you can't drink!")
 		return FALSE
 	if(reagents?.total_volume)

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -100,7 +100,7 @@
 		SSblackbox.ReportDeath(src)
 
 	//if((!SSticker.mode || CHECK_BITFIELD(SSticker.mode.round_type_flags2, MODE_2_NO_GHOSTS_STRICT)))
-	if(isrobot(src) || issynth(src))
+	if(isrobot(src) || issynthspecies(src))
 		overlay_fullscreen("death", /atom/movable/screen/fullscreen/dead/robot)
 	else
 		switch(faction)

--- a/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spitter/abilities_spitter.dm
@@ -382,6 +382,7 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	desc = "A rapidly melting ball of xeno taffy"
 	greyscale_colors = "#6808e6"
 	det_time = 1.5 SECONDS
+	lethal = FALSE
 	minetype = /obj/structure/xeno/acid_mine/resin_mine
 	select_message = "Detonates in a star pattern, spreading thin resin, and launching you in your direction, while randomly launching nearby marines."
 	mine_message = "Violently throws victims back, when detonated, and spreads thick sticky resin."
@@ -423,6 +424,7 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	desc = "A smoking ball of acid"
 	greyscale_colors = "#be340a"
 	det_time = 1.5 SECONDS
+	lethal = FALSE
 	minetype = /obj/structure/xeno/acid_mine/neuro_mine
 	select_message = "Spreads thin neurotoxin gas over a large area, when detonated."
 	mine_message = "Spreads thick neurotoxin gas when detonated, and injects its victim with neurotoxin."
@@ -442,6 +444,7 @@ GLOBAL_LIST_INIT(globadier_images_list, list(
 	desc = "A shimmering orb of gelatin that glows with life."
 	greyscale_colors = "#09ffde"
 	det_time = 4 SECONDS
+	lethal = FALSE
 	minetype = /obj/structure/xeno/acid_mine/drain_mine
 	select_message = "Detonates and heals nearby xenos, and applies melting to nearby humans."
 	mine_message = "Debuffs its victim with a effect that grants life to any xeno that damages the victim"

--- a/code/modules/projectiles/ammo_types/energy_ammo.dm
+++ b/code/modules/projectiles/ammo_types/energy_ammo.dm
@@ -50,6 +50,7 @@
 	ammo_behavior_flags = AMMO_ENERGY|AMMO_SPECIAL_PROCESS
 	shell_speed = 0.1
 	damage = 20
+	damage_type = STAMINA
 	penetration = 20
 	bullet_color = COLOR_TESLA_BLUE
 

--- a/code/modules/projectiles/gun_attachables/attachable.dm
+++ b/code/modules/projectiles/gun_attachables/attachable.dm
@@ -485,7 +485,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	if(source.Adjacent(object))
 		return
 	var/mob/living/user = master_gun.gun_user
-	if(user.incapacitated() || LAZYACCESS(user.do_actions, src) || !user.dextrous || (!(CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || (master_gun.ammo_datum_type && (master_gun.ammo_datum_type.damage_type == STAMINA || master_gun.ammo_datum_type.damage < 0))) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user)))
+	if(user.incapacitated() || LAZYACCESS(user.do_actions, src) || !user.dextrous || (!(CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || (master_gun.ammo_datum_type && (master_gun.ammo_datum_type.damage_type == STAMINA || master_gun.ammo_datum_type.damage < 0))) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user)))
 		return
 	var/active_hand = user.get_active_held_item()
 	var/inactive_hand = user.get_inactive_held_item()
@@ -529,6 +529,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		to_chat(user, span_warning("[src] beeps. Guns or shields in your hands are interfering with its targetting. Stopping fire."))
 		master_gun.stop_fire()
 		return
-	if(!user.incapacitated() && !LAZYACCESS(user.do_actions, src) && user.dextrous && (CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || (master_gun.ammo_datum_type && (master_gun.ammo_datum_type.damage_type == STAMINA || master_gun.ammo_datum_type.damage < 0)) || CONFIG_GET(flag/allow_synthetic_gun_use) || !issynth(user)))
+	if(!user.incapacitated() && !LAZYACCESS(user.do_actions, src) && user.dextrous && (CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || (master_gun.ammo_datum_type && (master_gun.ammo_datum_type.damage_type == STAMINA || master_gun.ammo_datum_type.damage < 0)) || CONFIG_GET(flag/allow_synthetic_gun_use) || (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) || !issynth(user)))
 		return
 	master_gun.stop_fire()

--- a/code/modules/projectiles/gun_attachables/attachable.dm
+++ b/code/modules/projectiles/gun_attachables/attachable.dm
@@ -485,7 +485,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	if(source.Adjacent(object))
 		return
 	var/mob/living/user = master_gun.gun_user
-	if(user.incapacitated() || LAZYACCESS(user.do_actions, src) || !user.dextrous || (!CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user)))
+	if(user.incapacitated() || LAZYACCESS(user.do_actions, src) || !user.dextrous || (!(CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || (master_gun.ammo_datum_type && (master_gun.ammo_datum_type.damage_type == STAMINA || master_gun.ammo_datum_type.damage < 0))) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user)))
 		return
 	var/active_hand = user.get_active_held_item()
 	var/inactive_hand = user.get_inactive_held_item()
@@ -529,6 +529,6 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 		to_chat(user, span_warning("[src] beeps. Guns or shields in your hands are interfering with its targetting. Stopping fire."))
 		master_gun.stop_fire()
 		return
-	if(!user.incapacitated() && !LAZYACCESS(user.do_actions, src) && user.dextrous && (CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || CONFIG_GET(flag/allow_synthetic_gun_use) || !issynth(user)))
+	if(!user.incapacitated() && !LAZYACCESS(user.do_actions, src) && user.dextrous && (CHECK_BITFIELD(master_gun.gun_features_flags, GUN_ALLOW_SYNTHETIC) || (master_gun.ammo_datum_type && (master_gun.ammo_datum_type.damage_type == STAMINA || master_gun.ammo_datum_type.damage < 0)) || CONFIG_GET(flag/allow_synthetic_gun_use) || !issynth(user)))
 		return
 	master_gun.stop_fire()

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1758,8 +1758,8 @@
 	if(!user.dextrous)
 		to_chat(user, span_warning("You don't have the dexterity to do this!"))
 		return FALSE
-	if(!(gun_features_flags & GUN_ALLOW_SYNTHETIC) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user))
-		to_chat(user, span_warning("Your program does not allow you to use this firearm."))
+	if(!((gun_features_flags & GUN_ALLOW_SYNTHETIC) || (ammo_datum_type && (ammo_datum_type.damage_type == STAMINA || ammo_datum_type.damage < 0)) ) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user))
+		to_chat(user, span_warning("Your program does not allow you to fire this ammunition."))
 		return FALSE
 	if(HAS_TRAIT(user, TRAIT_KNIGHT))
 		to_chat(user, span_warning("Your armor does not allow you to use this firearm!"))

--- a/code/modules/projectiles/gun_system.dm
+++ b/code/modules/projectiles/gun_system.dm
@@ -1758,7 +1758,7 @@
 	if(!user.dextrous)
 		to_chat(user, span_warning("You don't have the dexterity to do this!"))
 		return FALSE
-	if(!((gun_features_flags & GUN_ALLOW_SYNTHETIC) || (ammo_datum_type && (ammo_datum_type.damage_type == STAMINA || ammo_datum_type.damage < 0)) ) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user))
+	if(!((gun_features_flags & GUN_ALLOW_SYNTHETIC) || (ammo_datum_type && (ammo_datum_type.damage_type == STAMINA || ammo_datum_type.damage < 0)) ) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use) && issynth(user))
 		to_chat(user, span_warning("Your program does not allow you to fire this ammunition."))
 		return FALSE
 	if(HAS_TRAIT(user, TRAIT_KNIGHT))

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -123,7 +123,7 @@
 		return TRUE
 	if(human_user.interactee) //Make sure we're not manning two guns at once, tentacle arms.
 		human_user.unset_interaction()
-	if(issynth(human_user) && !CONFIG_GET(flag/allow_synthetic_gun_use))
+	if(issynth(human_user) && (SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_RED) && !CONFIG_GET(flag/allow_synthetic_gun_use))
 		to_chat(human_user, span_warning("Your programming restricts operating heavy weaponry."))
 		return TRUE
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -276,7 +276,7 @@ CACHE_ASSETS 0
 
 
 ##flags
-allow_synthetic_gun_use
+#allow_synthetic_gun_use
 log_whisper
 log_emote
 log_looc

--- a/ntf_modular/code/game/objects/machinery/artillery/shells.dm
+++ b/ntf_modular/code/game/objects/machinery/artillery/shells.dm
@@ -14,6 +14,7 @@
 	icon = 'ntf_modular/icons/obj/ammo/artillery.dmi'
 	icon_state = "mortar_ammo_sleep"
 	ammo_type = /datum/ammo/mortar/smoke/sleep
+	lethal = FALSE
 
 /datum/ammo/mortar/smoke/sleep
 	smoketype = /datum/effect_system/smoke_spread/sleepy
@@ -24,6 +25,7 @@
 	icon = 'ntf_modular/icons/obj/ammo/artillery.dmi'
 	icon_state = "mortar_ammo_aphro"
 	ammo_type = /datum/ammo/mortar/smoke/aphrotox
+	lethal = FALSE
 
 /datum/ammo/mortar/smoke/aphrotox
 	smoketype = /datum/effect_system/smoke_spread/xeno/aphrotoxin
@@ -34,6 +36,7 @@
 	icon = 'ntf_modular/icons/obj/ammo/artillery.dmi'
 	icon_state = "mortar_ammo_neuro"
 	ammo_type = /datum/ammo/mortar/smoke/neuro
+	lethal = FALSE
 
 /datum/ammo/mortar/smoke/neuro
 	smoketype = /datum/effect_system/smoke_spread/xeno/neuro/medium
@@ -52,6 +55,7 @@
 		0,0,0,0,
 	)
 	ammo_type = /datum/ammo/mortar/razorburn
+	lethal = FALSE
 
 /datum/ammo/mortar/razorburn
 	var/obj/item/reagent_containers/glass/beaker/large/B1
@@ -81,16 +85,19 @@
 		0,  0,0,0,
 	)
 	ammo_type = /datum/ammo/mortar/razorburn/metalfoam
+	lethal = FALSE
 
 /datum/ammo/mortar/razorburn/metalfoam
 	B1_chems = list(/datum/reagent/aluminum = 90)
 	B2_chems = list(/datum/reagent/foaming_agent = 30, /datum/reagent/toxin/acid/polyacid = 30)
+
 
 /obj/item/mortal_shell/rocket/mlrs/neuro
 	name = "\improper 60mm Neurotoxin rocket"
 	desc = "A 60mm rocket loaded with incapacitating neurotoxin gas."
 	icon_state = "mlrs_gas"
 	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs/neuro
+	lethal = FALSE
 
 /datum/ammo/mortar/rocket/smoke/mlrs/neuro
 	smoketype = /datum/effect_system/smoke_spread/xeno/neuro/medium
@@ -121,6 +128,7 @@
 	desc = "A 60mm rocket loaded with aphrotoxin gas."
 	icon_state = "mlrs_gas"
 	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs/aphro
+	lethal = FALSE
 
 /datum/ammo/mortar/rocket/smoke/mlrs/aphro
 	smoketype = /datum/effect_system/smoke_spread/xeno/aphrotoxin
@@ -151,6 +159,7 @@
 	desc = "A 60mm rocket loaded with soporific gas."
 	icon_state = "mlrs_gas"
 	ammo_type = /datum/ammo/mortar/rocket/smoke/mlrs/sleep
+	lethal = FALSE
 
 /datum/ammo/mortar/rocket/smoke/mlrs/sleep
 	smoketype = /datum/effect_system/smoke_spread/sleepy

--- a/ntf_modular/code/modules/projectiles/guns/pistols.dm
+++ b/ntf_modular/code/modules/projectiles/guns/pistols.dm
@@ -86,6 +86,7 @@
 	hud_state = "pistol_tranq"
 	armor_type = "bullet"
 	damage = 15
+	damage_type = STAMINA
 	shell_speed = 3.3
 	shrapnel_chance = 0.2
 	var/inject_amount_min = 5


### PR DESCRIPTION

## About The Pull Request
Reenables synth restrictions, loosens them to allow all nonlethals
## Why It's Good For The Game
Gives synth a cost to go with the benefits, encourages learning to use nonlethals.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="337" height="101" alt="image" src="https://github.com/user-attachments/assets/f2a185ca-de00-4cb2-b99f-9e253e9a7a4e" />

</details>

## Changelog
:cl:
balance: Synthetics can no longer fire lethal ammunition, except on red alert
/:cl:
