### PR TITLE
CM has another guardsman loadout that didnt get added

### DIFF
--- a/code/game/objects/machinery/vending/quick_vendor.dm
+++ b/code/game/objects/machinery/vending/quick_vendor.dm
@@ -125,6 +125,7 @@ GLOBAL_LIST_INIT(quick_loadouts, init_quick_loadouts())
 		/datum/outfit/quick/icc/guard/icc_autoshotgun,
 		/datum/outfit/quick/icc/guard/icc_m16fl240,
 		/datum/outfit/quick/icc/guard/icc_hpr,
+		/datum/outfit/quick/icc/guard/icc_mpar,
 		/datum/outfit/quick/icc/leader/icc_famas,
 		/datum/outfit/quick/icc/leader/icc_confrontationrifle,
 		/datum/outfit/quick/icc/leader/icc_m16masterkey,


### PR DESCRIPTION

## About The Pull Request

Was supposed to be included and listed in the last PR but wasn't.

Civilian MPAR & SMG25 CM guardsman.

## Why It's Good For The Game

A step up from the sharpshooter and marksman loadouts of the CM standard and CM medic, gains specialized ammo except for smart mags and EMP mags.

## Proof of Testing

Check the code.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog

:cl:
add: Adds the CM marksman loadout as intended.
/:cl:
