### PR TITLE
AGLS gets aim mode again, scope reaches out to max range

### DIFF
--- a/code/modules/projectiles/gun_attachables/scope.dm
+++ b/code/modules/projectiles/gun_attachables/scope.dm
@@ -171,6 +171,15 @@
 	scope_delay = 2 SECONDS
 	zoom_tile_offset = 7
 
+/obj/item/attachable/scope/unremovable/aim_atgun
+	name = "PAG-37 long range scope"
+	desc = "An integral 2.7x magnification scope mounted on the Kauser AGLS-37, which allows it to fire at the maximum range of it's aurburst grenades. Requires time to aim."
+	icon_state = "sniper_invisible"
+	scope_delay = 1 SECONDS
+	zoom_tile_offset = 9
+	zoom_viewsize = 7
+	add_aim_mode = TRUE
+
 /obj/item/attachable/scope/unremovable/hsg_102
 	name = "HSG-102 smart sight"
 	desc = "An unremovable smart sight built for use with the HSG-102, it does nearly all the aiming work for the gun's integrated IFF systems."

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -665,11 +665,11 @@
 	gun_firemode_list = list(GUN_FIREMODE_AUTOMATIC)
 
 	attachable_allowed = list(
-		/obj/item/attachable/scope/unremovable/standard_atgun,
+		/obj/item/attachable/scope/unremovable/aim_atgun,
 	)
 
 	starting_attachment_types = list(
-		/obj/item/attachable/scope/unremovable/standard_atgun,
+		/obj/item/attachable/scope/unremovable/aim_atgun,
 	)
 
 	allowed_ammo_types = list(
@@ -680,7 +680,7 @@
 		/obj/item/ammo_magazine/standard_agls/cloak,
 	)
 
-	deploy_time = 6 SECONDS
+	deploy_time = 5 SECONDS
 	undeploy_time = 3 SECONDS
 	deployable_item = /obj/machinery/deployable/mounted
 


### PR DESCRIPTION

## About The Pull Request
Returns the ability to enter aim mode with the Kauser AGLS-37. The emplaced weapon is pretty much unusable without it as it's grenades will detonate at ANYTHING (and I do mean anything) in it's flight path including friendlies, barricades, stray boxes, stray anything dropped on the floor and especially in the vicinity of innocent civilians. This change makes it both able to deploy and aim faster (in line with the HSG-102) and allows it to make full use of it's grenades to their maximum range of 21 tiles (since they detonate where you click, can't just offscreen). Fragmentation from detonations will still hurt friendlies, even with aim mode, still requiring users to be careful where they shoot.

## Why It's Good For The Game
Allows an emplaced utility weapon which was nerfed to the ground by main TGMC nerfs due to salt to be usable again. High potential damage but incredibly risky if allies are in the vicinity.

## Proof of Testing
It builds and runs and works... Very kino.
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Gives AGLS it's aim mode back and allows it's scope to look at the maximum range of it's grenades.
/:cl:
