### PR TITLE
Fix factory, xeno, mech, and runtime issues

### DIFF
--- a/code/controllers/subsystem/advanced_pathfinding.dm
+++ b/code/controllers/subsystem/advanced_pathfinding.dm
@@ -12,10 +12,6 @@ SUBSYSTEM_DEF(advanced_pathfinding)
 	var/list/datum/ai_behavior/node_pathfinding_to_do = list()
 
 /datum/controller/subsystem/advanced_pathfinding/Initialize()
-	var/list/nodes = list()
-	for(var/obj/effect/ai_node/ai_node AS in GLOB.all_nodes)
-		nodes += list(ai_node.serialize())
-	rustg_register_nodes_astar(json_encode(nodes))
 	return SS_INIT_SUCCESS
 
 #ifdef TESTING
@@ -173,7 +169,6 @@ GLOBAL_LIST_EMPTY(goal_nodes)
 
 /obj/effect/ai_node/goal/LateInitialize()
 	make_adjacents(TRUE)
-	rustg_add_node_astar(json_encode(serialize()))
 
 /obj/effect/ai_node/goal/Destroy()
 	GLOB.goal_nodes -= faction

--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -128,6 +128,8 @@ SUBSYSTEM_DEF(points)
 		supply_shuttle = SSshuttle.getShuttle("supplyicc")
 	if(O.faction == FACTION_NEUTRAL)
 		supply_shuttle = SSshuttle.getShuttle("supplycolony")
+	if(!supply_shuttle)
+		return
 	if(length(shoppinglist[O.faction]) >= supply_shuttle.return_number_of_turfs())
 		return
 	requestlist -= "[O.id]"

--- a/code/controllers/subsystem/sounds.dm
+++ b/code/controllers/subsystem/sounds.dm
@@ -133,12 +133,20 @@ SUBSYSTEM_DEF(sounds)
 
 /// Random available channel, returns text.
 /datum/controller/subsystem/sounds/proc/random_available_channel_text()
+	if(!length(channel_list))
+		setup_available_channels()
+	if(channel_reserve_high < 1)
+		return
 	if(channel_random_low > channel_reserve_high)
 		channel_random_low = 1
 	. = "[channel_list[channel_random_low++]]"
 
 /// Random available channel, returns number
 /datum/controller/subsystem/sounds/proc/random_available_channel()
+	if(!length(channel_list))
+		setup_available_channels()
+	if(channel_reserve_high < 1)
+		return
 	if(channel_random_low > channel_reserve_high)
 		channel_random_low = 1
 	. = channel_list[channel_random_low++]

--- a/code/datums/actions/ability_actions.dm
+++ b/code/datums/actions/ability_actions.dm
@@ -162,7 +162,7 @@
 	if(cooldown_timer || !cooldown_length) // stop doubling up or waiting on zero
 		return
 	cooldown_timer = addtimer(CALLBACK(src, PROC_REF(on_cooldown_finish)), cooldown_length, TIMER_STOPPABLE)
-	countdown.start()
+	countdown?.start()
 	update_button_icon()
 
 ///Time remaining on cooldown
@@ -172,7 +172,7 @@
 ///override this for cooldown completion
 /datum/action/ability/proc/on_cooldown_finish()
 	cooldown_timer = null
-	countdown.stop()
+	countdown?.stop()
 	if(!button)
 		return
 	update_button_icon()

--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -226,7 +226,7 @@
 	var/datum/browser/modal/alert/A = new(User, Message, Title, Button1, Button2, Button3, StealFocus, Timeout)
 	A.open()
 	A.wait()
-	switch(A.selectedbutton)
+	switch(A?.selectedbutton)
 		if(1)
 			return Button1
 		if(2)

--- a/code/datums/components/blur_protection.dm
+++ b/code/datums/components/blur_protection.dm
@@ -22,6 +22,9 @@
 /datum/component/blur_protection/proc/equipped_to_slot(datum/source, mob/user, slot)
 	SIGNAL_HANDLER
 	RegisterSignal(user, COMSIG_LIVING_UPDATE_PLANE_BLUR, PROC_REF(cancel_blur))
+	if(isliving(user))
+		var/mob/living/living_user = user
+		living_user.update_eye_blur()
 
 /datum/component/blur_protection/proc/cancel_blur()
 	return COMPONENT_CANCEL_BLUR

--- a/code/datums/jobs/job/job.dm
+++ b/code/datums/jobs/job/job.dm
@@ -343,10 +343,10 @@ GLOBAL_PROTECT(exp_specialmap)
 	for(var/datum/outfit/variant AS in assigned_role.outfits)
 		if(ispath(variant))
 			variant = new variant
-		if((src.species.species_type) in variant.species)
+		if(src.species && (src.species.species_type in variant.species))
 			valid_outfits += variant
 	if(!length(valid_outfits))
-		log_runtime("Failed to find valid outfit when applying [assigned_role.title]([assigned_role.type]) to [logdetails(src)](Species: [src.species.name]([src.species.type]))")
+		log_runtime("Failed to find valid outfit when applying [assigned_role.title]([assigned_role.type]) to [logdetails(src)](Species: [src.species ? "[src.species.name]([src.species.type])" : "null"])")
 		assigned_role.outfit.equip(src)
 		return
 	var/datum/outfit/chosen_variant = pick(valid_outfits)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -244,6 +244,8 @@
 			return FALSE
 
 	var/datum/limb/affecting = .
+	if(!istype(affecting))
+		return FALSE
 	if(M == user && ((!user.hand && affecting.body_part == ARM_RIGHT) || (user.hand && affecting.body_part == ARM_LEFT)))
 		user.balloon_alert(user, "you're using that arm!")
 		return

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -397,6 +397,9 @@
 
 ///throws an item held by a user up or down a ladder
 /obj/structure/ladder/proc/throw_object(obj/item/item, mob/user, going_up=TRUE)
+	if((item.item_flags & ITEM_ABSTRACT) || HAS_TRAIT(item, TRAIT_NODROP))
+		use(user, going_up)
+		return
 	if(going_up && !up)
 		balloon_alert(user, "no stairs above!")
 		return

--- a/code/game/turfs/liquid_turfs.dm
+++ b/code/game/turfs/liquid_turfs.dm
@@ -18,6 +18,7 @@
 	return ..()
 
 /turf/open/liquid/Destroy(force)
+	UnregisterSignal(src, list(COMSIG_TURF_JUMP_ENDED_HERE, COMSIG_TURF_THROW_ENDED_HERE))
 	if(!(get_submerge_height() - mob_liquid_height) && !(get_submerge_depth() - mob_liquid_depth))
 		RemoveElement(/datum/element/submerge)
 	return ..()
@@ -352,4 +353,3 @@ ww
 	if(!(my_catwalk.atom_flags & INITIALIZED))
 		my_catwalk.Initialize(mapload)
 	. = ..()
-

--- a/code/modules/ai/ai_behaviors/ai_behavior.dm
+++ b/code/modules/ai/ai_behaviors/ai_behavior.dm
@@ -360,9 +360,11 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 		return
 	//we blacklist our current node in case its orphaned or otherwise not linked to our goal. This is not foolproof for mapping issues however
 	var/previous_current_node = current_node
-	var/goal_nodes_serialized = rustg_generate_path_astar("[current_node.unique_id]", "[goal_node.unique_id]")
-	if(rustg_json_is_valid(goal_nodes_serialized))
-		goal_nodes = json_decode(goal_nodes_serialized)
+	var/list/obj/effect/ai_node/node_path = get_path(current_node, goal_node)
+	if(length(node_path))
+		goal_nodes = list()
+		for(var/obj/effect/ai_node/node AS in node_path)
+			goal_nodes += node.unique_id
 	else
 		goal_nodes = list()
 		set_current_node(null)
@@ -385,6 +387,8 @@ Registers signals, handles the pathfinding element addition/removal alongside ma
 
 //Generic process(), this is used for mainly looking at the world around the AI and determining if a new action must be considered and executed
 /datum/ai_behavior/process()
+	if(!mob_parent)
+		return
 	if(!escorted_atom || (get_dist(mob_parent, escorted_atom) > AI_ESCORTING_BREAK_DISTANCE) || mob_parent.z != escorted_atom.z || isainode(escorted_atom))
 		set_escort()
 	var/atom/next_target = get_nearest_target(mob_parent, target_distance, TARGET_HOSTILE, mob_parent.faction, mob_parent.get_xeno_hivenumber(), TRUE)
@@ -557,6 +561,8 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 
 ///Finds the most suitable thing to escort
 /datum/ai_behavior/proc/get_atom_to_escort()
+	if(!mob_parent)
+		return
 	var/list/goal_list = list()
 	if(GLOB.goal_nodes[mob_parent.faction] && (fail_goal_path_count < AI_MAX_GOAL_PATH_FAILS))
 		goal_list[GLOB.goal_nodes[mob_parent.faction]] = AI_ESCORT_RATING_FACTION_GOAL
@@ -669,4 +675,3 @@ These are parameter based so the ai behavior can choose to (un)register the sign
 		atom_to_walk_to = null
 		if(current_action == MOVING_TO_ATOM && need_new_state)
 			look_for_new_state()
-

--- a/code/modules/ai/ai_node.dm
+++ b/code/modules/ai/ai_node.dm
@@ -34,8 +34,6 @@
 
 /obj/effect/ai_node/LateInitialize()
 	make_adjacents()
-	if(SSadvanced_pathfinding.initialized)
-		rustg_add_node_astar(json_encode(serialize()))
 
 /// Serialize nodes information
 /obj/effect/ai_node/proc/serialize()
@@ -59,7 +57,6 @@
 
 /obj/effect/ai_node/Destroy()
 	GLOB.all_nodes[unique_id + 1] = null
-	rustg_remove_node_astar("[unique_id]")
 	//Remove our reference to self from nearby adjacent node's adjacent nodes
 	for(var/direction AS in adjacent_nodes)
 		var/obj/effect/ai_node/node = adjacent_nodes[direction]

--- a/code/modules/clothing/modular_armor/attachments.dm
+++ b/code/modules/clothing/modular_armor/attachments.dm
@@ -112,6 +112,8 @@
 
 /// Called when the module is removed from the armor.
 /obj/item/armor_module/proc/on_detach(obj/item/detaching_from, mob/user)
+	if(!parent)
+		return
 	SEND_SIGNAL(detaching_from, COMSIG_ARMOR_MODULE_DETACHED, user, src)
 	parent.set_light_range(parent.light_range - light_mod)
 	parent.hard_armor = parent.hard_armor.detachArmor(hard_armor)

--- a/code/modules/events/supply_drop.dm
+++ b/code/modules/events/supply_drop.dm
@@ -18,7 +18,7 @@
 
 	for(var/z in z_levels)
 		while(!target_turf)
-			var/turf/potential_turf = locate(rand(0, world.maxx), rand(0,world.maxy), z)
+			var/turf/potential_turf = locate(rand(1, world.maxx), rand(1,world.maxy), z)
 			if(isclosedturf(potential_turf) || isspaceturf(potential_turf))
 				continue
 			target_turf = potential_turf
@@ -27,6 +27,8 @@
 
 ///sets the target for this event, and notifies the hive
 /datum/round_event/supply_drop/proc/set_target(turf/target_turf)
+	if(!target_turf)
+		return
 	var/supplying_faction = pick(SSticker.mode.factions)
 	priority_announce("Friendly supply drop arriving in AO in [drop_delay / 600] minutes. Drop zone at [target_turf.loc].", "Bluespace Tactical Scanner Status", sound = 'sound/AI/distressreceived.ogg', receivers = (GLOB.alive_human_list_faction[supplying_faction] + GLOB.observer_list))
 	addtimer(CALLBACK(src, PROC_REF(alert_hostiles), target_turf, supplying_faction), alert_delay)

--- a/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hivelord/castedatum_hivelord.dm
@@ -18,7 +18,6 @@
 	// *** Plasma *** //
 	plasma_max = 2400
 	plasma_gain = 80
-	plasma_regen_limit = 0.5
 	plasma_icon_state = "hivelord_plasma"
 
 	// *** Health *** //

--- a/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/sentinel/abilities_sentinel.dm
@@ -201,6 +201,9 @@
 /datum/action/ability/activable/xeno/drain_sting/use_ability(atom/A)
 	var/mob/living/carbon/human/human_target = A
 	var/datum/status_effect/stacking/intoxicated/debuff = human_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
+	if(!debuff)
+		human_target.balloon_alert(owner, "Not intoxicated")
+		return FALSE
 
 	var/potency = get_potency(human_target)
 	var/potency_in_sets = round(potency / SENTINEL_DRAIN_MULTIPLIER)
@@ -234,6 +237,8 @@
 /// Returns the potency of Drain Sting which accounts for: base potency, Intoxicated stacks, xeno-chemicals, and range effectiveness.
 /datum/action/ability/activable/xeno/drain_sting/proc/get_potency(mob/living/carbon/human/human_target)
 	var/datum/status_effect/stacking/intoxicated/debuff = human_target.has_status_effect(STATUS_EFFECT_INTOXICATED)
+	if(!debuff)
+		return 0
 	var/potency = base_potency + (debuff.stacks * SENTINEL_DRAIN_MULTIPLIER)
 	if(chemical_potency)
 		for(var/datum/reagent/target_reagent AS in human_target.reagents.reagent_list)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -664,9 +664,10 @@
 /mob/living/proc/update_eye_blur()
 	if(!client)
 		return
-	if(SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_PLANE_BLUR) & COMPONENT_CANCEL_BLUR)
-		return
 	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	if(SEND_SIGNAL(src, COMSIG_LIVING_UPDATE_PLANE_BLUR) & COMPONENT_CANCEL_BLUR)
+		game_plane_master_controller.remove_filter("eye_blur")
+		return
 	if(eye_blurry <= 0)
 		game_plane_master_controller.remove_filter("eye_blur")
 	else

--- a/code/modules/projectiles/ammo_types/sniper_ammo.dm
+++ b/code/modules/projectiles/ammo_types/sniper_ammo.dm
@@ -104,6 +104,7 @@
 	name = "high velocity incendiary sniper bullet"
 	handful_icon_state = "ptrs"
 	handful_icon = 'ntf_modular/icons/obj/items/ammo/handful.dmi'
+	handful_amount = 5
 	ammo_behavior_flags = AMMO_BALLISTIC|AMMO_INCENDIARY|AMMO_BETTER_COVER_RNG|AMMO_SNIPER
 	hud_state = "sniper_fire"
 	accurate_range_min = 4

--- a/code/modules/reagents/chemistry/reagents/toxin.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin.dm
@@ -776,7 +776,7 @@
 	debuff_owner.update_eye_blur()
 	debuff_owner.reagents.remove_reagent(/datum/reagent/toxin/xeno_aphrotoxin, 15)
 	debuff_owner.reagents.remove_reagent(/datum/reagent/consumable/larvajelly, 6)
-	debuff_owner.sexcon.ejaculate(debuff_owner)
+	debuff_owner.sexcon?.ejaculate(debuff_owner)
 	if(debuff_owner.getStaminaLoss() > 120)
 		if(prob(5))
 			debuff_owner.visible_message(span_warning("[debuff_owner] manages to black out from cumming too hard..."), 4)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -82,6 +82,8 @@
 
 //returns a text listing the reagents (and their volume) in the atom. Used by Attack logs for reagents in pills
 /obj/item/reagent_containers/proc/get_reagent_list_text()
+	if(!reagents)
+		return "No reagents"
 	if(reagents.reagent_list && length(reagents.reagent_list))
 		var/datum/reagent/R = reagents.reagent_list[1]
 		. = "[R.name]([R.volume]u)"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -64,7 +64,7 @@
 
 		log_combat(user, M, "fed", src, "Reagents: [rgt_list_text]")
 
-		if(reagents.total_volume)
+		if(reagents?.total_volume)
 			record_reagent_consumption(reagents.total_volume, reagents.reagent_list, user, M)
 			reagents.reaction(M, INGEST)
 			reagents.trans_to(M, reagents.total_volume)

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	. = ..()
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(conveyable_enter),
+		COMSIG_ATOM_INITIALIZED_ON = PROC_REF(conveyable_enter),
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	if(newdir)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -45,7 +45,7 @@
 	log_message("Took [damage_taken] points of damage. Damage type: [damage_type]", LOG_MECHA)
 	if(damage_taken < 5)
 		return damage_taken //its only a scratch
-	spark_system.start()
+	spark_system?.start()
 	try_deal_internal_damage(damage_taken)
 	to_chat(occupants, "[icon2html(src, occupants)][span_userdanger("Taking damage!")]")
 

--- a/code/modules/vehicles/mecha/mecha_movement.dm
+++ b/code/modules/vehicles/mecha/mecha_movement.dm
@@ -122,13 +122,15 @@
 	. = ..()
 	if(phasing) //Theres only one cause for phasing canpass fails
 		to_chat(occupants, "[icon2html(src, occupants)][span_warning("A dull, universal force is preventing you from [phasing] here!")]")
-		spark_system.start()
+		spark_system?.start()
 		return
 	if(.) //mech was thrown/door/whatever
 		return
 	if(bumpsmash) //Need a pilot to push the PUNCH button.
 		if(COOLDOWN_FINISHED(src, mecha_bump_smash))
 			var/list/mob/mobster = return_drivers()
+			if(!length(mobster))
+				return
 			obstacle.mech_melee_attack(src, mobster[1])
 			COOLDOWN_START(src, mecha_bump_smash, smashcooldown)
 			if(!obstacle || obstacle.CanPass(src, get_dir(obstacle, src) || dir)) // The else is in case the obstacle is in the same turf.

--- a/ntf_modular/code/datums/sexcon/sexcon_helpers.dm
+++ b/ntf_modular/code/datums/sexcon/sexcon_helpers.dm
@@ -48,6 +48,9 @@
 		to_chat(user, span_warning("Unsuitable target."))
 		return
 	var/datum/sex_controller/usersexcon = user.sexcon
+	if(!usersexcon)
+		to_chat(user, span_warning("Unsuitable user."))
+		return
 	usersexcon.start(target)
 
 /* obsolete now

--- a/ntf_modular/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
+++ b/ntf_modular/code/game/objects/structures/stool_bed_chair_nest/xeno_nest.dm
@@ -364,25 +364,37 @@
 	if(isxeno(user) && istype(attacking_item, /obj/item/grab))
 		var/obj/item/grab/attacker_grab = attacking_item
 		var/mob/living/carbon/xenomorph/user_as_xenomorph = user
-		user_as_xenomorph.do_nesting_host(attacker_grab.grabbed_thing, src)
-		return
+		if(user_as_xenomorph.can_wall_nest_with_intent())
+			user_as_xenomorph.do_nesting_host(attacker_grab.grabbed_thing, src)
+			return TRUE
+		if(user_as_xenomorph.a_intent != INTENT_HARM)
+			return TRUE
 	. = ..()
 
 /obj/alien/weeds/weedwall/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(isxeno(user) && istype(attacking_item, /obj/item/grab))
 		var/obj/item/grab/attacking_grab = attacking_item
 		var/mob/living/carbon/xenomorph/user_as_xenomorph = user
-		user_as_xenomorph.do_nesting_host(attacking_grab.grabbed_thing, src)
-		return
+		if(user_as_xenomorph.can_wall_nest_with_intent())
+			user_as_xenomorph.do_nesting_host(attacking_grab.grabbed_thing, src)
+			return TRUE
+		if(user_as_xenomorph.a_intent != INTENT_HARM)
+			return TRUE
 	. = ..()
 
 /turf/closed/wall/resin/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(isxeno(user) && istype(attacking_item, /obj/item/grab))
 		var/obj/item/grab/attacking_grab = attacking_item
 		var/mob/living/carbon/xenomorph/user_as_xenomorph = user
-		user_as_xenomorph.do_nesting_host(attacking_grab.grabbed_thing, src)
-		return
+		if(user_as_xenomorph.can_wall_nest_with_intent())
+			user_as_xenomorph.do_nesting_host(attacking_grab.grabbed_thing, src)
+			return TRUE
+		if(user_as_xenomorph.a_intent != INTENT_HARM)
+			return TRUE
 	. = ..()
+
+/mob/living/carbon/xenomorph/proc/can_wall_nest_with_intent()
+	return a_intent == INTENT_HELP || a_intent == INTENT_GRAB
 
 /mob/living/carbon/xenomorph/proc/do_nesting_host(mob/current_mob, nest_structural_base)
 	var/list/xeno_hands = list(get_active_held_item(), get_inactive_held_item())

--- a/ntf_modular/code/modules/mob/living/living_verbs.dm
+++ b/ntf_modular/code/modules/mob/living/living_verbs.dm
@@ -33,18 +33,13 @@
 
 	mob.stop_sound_channel(CHANNEL_MIDI)
 
-/mob/living/verb/toggle_quicksex()
+/client/verb/toggle_quicksex()
 	set name = "Toggle Quicksex"
 	set desc = "Prevents you from dragging yourself to people for quicksex actions."
 	set category = "Preferences"
-	set src = usr
 
-	if(QDELETED(usr))
+	if(!prefs)
 		return
-	if(!isliving(usr))
-		return
-	if(!client?.prefs)
-		return
-	client.prefs.quick_sex_toggle = !client.prefs.quick_sex_toggle
-	balloon_alert(usr, "QK Sex [client.prefs.quick_sex_toggle ? "ON" : "OFF"]")
-	client.prefs.save_preferences()
+	prefs.quick_sex_toggle = !prefs.quick_sex_toggle
+	mob?.balloon_alert(mob, "QK Sex [prefs.quick_sex_toggle ? "ON" : "OFF"]")
+	prefs.save_preferences()


### PR DESCRIPTION
## About The Pull Request

Fixes a batch of reported gameplay bugs and runtime issues:

- Factory conveyors now detect newly-created factory parts dropped onto active belts.
- Hivelord plasma can regenerate up to its displayed max plasma instead of stopping at the normal 1200 plasma threshold.
- 14x5mm ammo handfuls now use the expected world sprite amount.
- Xeno nest interactions now use intent:
  - Help/grab intent nests the target.
  - Harm intent wall-slams the dragged target.
- Flashbang blur protection now clears blur more reliably after stagger/stun effects.
- Ripley cargo/mech arms are protected from being thrown off while climbing ladders.
- Quicksex preference toggle now works from the preference tab.
- Added defensive null checks for several reported runtimes involving sounds, points, supply drops, mechs, AI behavior, reagents, splints, modular armor lights, sexcon, browser buttons, and job/species checks.
- Swaps missing RustG A* pathing calls to safer fallback behavior when the RustG symbols are unavailable.

## Why It's Good For The Game

This fixes several broken or confusing mechanics that players were directly running into: factory conveyors failing to move produced items, hivelords appearing to have more plasma than they could actually regenerate, xenos losing their wall-slam interaction, permanent blur after flashbangs, and mech equipment being dropped by ladders.

The runtime fixes also reduce noisy server errors and help prevent broken edge cases from interrupting gameplay.

## Proof of Testing

Compiled successfully after pulling latest upstream and resolving conflicts.

<details>
<summary>Screenshots/Videos</summary>

DM compile completed with:

`0 errors, 0 warnings`

</details>

## Changelog

:cl:
fix: Fixed active factory conveyors not picking up newly-produced factory parts.
fix: Fixed hivelords not naturally regenerating to their displayed maximum plasma.
fix: Fixed 14x5mm ammo handfuls using the wrong world sprite amount.
fix: Fixed xeno wall slams/nesting behavior so intent determines whether a dragged target is nested or slammed.
fix: Fixed some flashbang blur cases persisting longer than intended.
fix: Fixed Ripley cargo arms being dropped when climbing ladders.
qol: Fixed the Quicksex preference toggle not toggling properly.
code: Added safeguards for several reported runtimes.
/:cl: