### PR TITLE
nerfs the chainsaw

### DIFF
--- a/code/game/objects/items/weapons/two_handed/chainsaws.dm
+++ b/code/game/objects/items/weapons/two_handed/chainsaws.dm
@@ -11,7 +11,7 @@
 	worn_icon_state = "chainsaw"
 	attack_verb = list("gores", "tears", "rips", "shreds", "slashes", "cuts")
 	force = 20
-	force_activated = 75
+	force_activated = 50
 	throwforce = 30
 	attack_speed = 20
 	w_class = WEIGHT_CLASS_NORMAL
@@ -26,7 +26,7 @@
 	///amount of fuel used per hit
 	var/fuel_used = 5
 	///additional damage when weapon is active
-	var/additional_damage = 75
+	var/additional_damage = 25
 
 /obj/item/weapon/twohanded/chainsaw/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

The chainsaw previously did 75 damage, + another 75 while **active**. And yes it worked with melee skill.

150 damage melee weapon + whatever sort of buff having melee skill gives you resulted in literal instakills. Which are bad!

Damage nerfed to 50 + 25 while active, so 75, maybe 100 if you have melee skill.
## Why It's Good For The Game

Literal 1 shot instakill weapons are not fun
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Chainsaw damage nerfed from 150 to 75
/:cl:
