### PR TITLE
CM Autoshotgun Rework, Few other tweaks

### DIFF
--- a/code/datums/outfits/quick_load_outfits.dm
+++ b/code/datums/outfits/quick_load_outfits.dm
@@ -4184,13 +4184,13 @@
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_assaultcarbine, SLOT_IN_BELT)
 	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_assaultcarbine, SLOT_IN_BELT)
 
-/datum/outfit/quick/icc/standard/icc_autoshotgun
-	name = "ML-41ASG Autoshotgun CM Skirmisher"
-	desc = "Equipped with an ML-41ASG autoshotgun and a skorpion SMG, the weapons of choice for fast paced assaults. Loaded with flechette by default, but is sometimes swapped out for frag drums by the ICCAF to really bring on the pain."
-	suit_store = /obj/item/weapon/gun/rifle/icc_autoshotgun
+/datum/outfit/quick/icc/standard/icc_trenchgun
+	name = "L-4034 Trenchgun CM Skirmisher"
+	desc = "Equipped with an L-4034 trenchgun and a skorpion SMG, the weapons of choice for fast paced assaults. Loaded with buckshot by default, but is sometimes swapped out for flechettes by the ICCAF to pierce through hard targets."
+	suit_store = /obj/item/weapon/gun/shotgun/pump/trenchgun/icc_leader
 
 	w_uniform = /obj/item/clothing/under/marine/veteran/cm
-	belt = /obj/item/storage/belt/marine/icc
+	belt = /obj/item/storage/belt/shotgun/icc
 	shoes = /obj/item/clothing/shoes/marine/brown/full
 	wear_suit = /obj/item/clothing/suit/storage/marine/icc/guard
 	gloves = /obj/item/clothing/gloves/marine/veteran/pmc
@@ -4200,7 +4200,7 @@
 	l_pocket = /obj/item/storage/pouch/medical_injectors/icc/firstaid
 	back = /obj/item/storage/backpack/lightpack/cm
 
-/datum/outfit/quick/icc/standard/icc_autoshotgun/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/quick/icc/standard/icc_trenchgun/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	. = ..()
 
 	H.equip_to_slot_or_del(new /obj/item/reagent_containers/hypospray/autoinjector/oxycodone, SLOT_IN_HEAD)
@@ -4239,12 +4239,20 @@
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/bullet/hefa, SLOT_IN_R_POUCH)
 	H.equip_to_slot_or_del(new /obj/item/explosive/grenade/bullet/hefa, SLOT_IN_R_POUCH)
 
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_autoshotgun, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_autoshotgun, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_autoshotgun, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_autoshotgun, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_autoshotgun, SLOT_IN_BELT)
-	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/rifle/icc_autoshotgun, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/flechette, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
+	H.equip_to_slot_or_del(new /obj/item/ammo_magazine/handful/buckshot, SLOT_IN_BELT)
 
 /datum/outfit/quick/icc/medic // base, not to be used
 	name = "CM Medic"

--- a/code/game/objects/machinery/vending/quick_vendor.dm
+++ b/code/game/objects/machinery/vending/quick_vendor.dm
@@ -116,7 +116,7 @@ GLOBAL_LIST_INIT(quick_loadouts, init_quick_loadouts())
 		/datum/outfit/quick/icc/standard/icc_battlecarbine,
 		/datum/outfit/quick/icc/standard/icc_sharpshooter,
 		/datum/outfit/quick/icc/standard/icc_assaultcarbine,
-		/datum/outfit/quick/icc/standard/icc_autoshotgun,
+		/datum/outfit/quick/icc/standard/icc_trenchgun,
 		/datum/outfit/quick/icc/medic/icc_sharpshooter,
 		/datum/outfit/quick/icc/medic/icc_rifleman,
 		/datum/outfit/quick/icc/medic/icc_smg,

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -534,7 +534,7 @@
 	
 /obj/item/clothing/head/helmet/marine/cmfreelancer/heavy
 	name = "\improper CM3 pattern heavy helmet"
-	desc = "A sturdy freelancer's helmet with additional plates. Many years ago on the Terra, the sign of that helmet was inspiring hope, but now - only apathy."
+	desc = "A sturdy freelancer's helmet with additional plates. Many years ago on the Terra, the sign of that helmet was inspiring hope, but now - the need to protect."
 	icon_state = "freelancer_helmet_heavy"
 	soft_armor = list(MELEE = 60, BULLET = 80, LASER = 70, ENERGY = 50, BOMB = 65, BIO = 40, FIRE = 40, ACID = 45)
 	attachments_allowed = list(
@@ -547,7 +547,7 @@
 
 /obj/item/clothing/head/helmet/marine/cmfreelancer/specialist
 	name = "\improper CM3 pattern rocketeer helmet"
-	desc = "A sturdy freelancer's helmet with additional plates and protective riot visor. Many years ago on the Terra, the sign of that helmet was inspiring hope, but now - only apathy."
+	desc = "A sturdy freelancer's helmet with additional plates and protective riot visor. Many years ago on the Terra, the sign of that helmet was inspiring hope, but now - the need to quell the tide."
 	icon_state = "freelancer_helmet_specialist"
 	soft_armor = list(MELEE = 55, BULLET = 75, LASER = 60, ENERGY = 70, BOMB = 80, BIO = 40, FIRE = 55, ACID = 55)
 	attachments_allowed = list(

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -146,7 +146,7 @@
 	handful_icon_state = "shotgun_tracker"
 	hud_state = "shotgun_tracker"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	accuracy_variation = 8
+	accuracy_variation = 6
 	accuracy = -20
 	max_range = 15
 	damage = 10

--- a/code/modules/projectiles/ammo_types/shotgun_ammo.dm
+++ b/code/modules/projectiles/ammo_types/shotgun_ammo.dm
@@ -146,9 +146,6 @@
 	handful_icon_state = "shotgun_tracker"
 	hud_state = "shotgun_tracker"
 	ammo_behavior_flags = AMMO_BALLISTIC
-	bonus_projectiles_type = /datum/ammo/bullet/shotgun/frag/frag_spread
-	bonus_projectiles_amount = 2
-	bonus_projectiles_scatter = 6
 	accuracy_variation = 8
 	accuracy = -20
 	max_range = 15

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2923,7 +2923,7 @@
 
 /obj/item/weapon/gun/rifle/icc_autoshotgun
 	name = "\improper ML-41A autoshotgun"
-	desc = "The ML-41A Automatic Shotgun is used by the ICCAF in fast paced boarding assaults, fielding a wide variety of ammo for all situations. Takes 20-round 12 gauge drums."
+	desc = "The ML-41A Automatic Shotgun is used by the ICCAF in steadily paced boarding assaults, fielding a select variety of ammo for certain situations. Takes 20-round 12 gauge drums."
 	icon = 'icons/obj/items/guns/shotguns64.dmi'
 	icon_state = "ml41"
 	worn_icon_state = "ml41"

--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -2919,11 +2919,11 @@
 	starting_attachment_types = list(/obj/item/attachable/lasersight, /obj/item/attachable/magnetic_harness, /obj/item/attachable/extended_barrel)
 
 //-------------------------------------------------------
-//ML-41 Autoshotgun
+//ML-41A Autoshotgun
 
 /obj/item/weapon/gun/rifle/icc_autoshotgun
-	name = "\improper ML-41 autoshotgun"
-	desc = "The ML-41 Automatic Shotgun is used by the ICCAF in fast paced boarding assaults, fielding a wide variety of ammo for all situations. Takes 16-round 12 gauge drums."
+	name = "\improper ML-41A autoshotgun"
+	desc = "The ML-41A Automatic Shotgun is used by the ICCAF in fast paced boarding assaults, fielding a wide variety of ammo for all situations. Takes 20-round 12 gauge drums."
 	icon = 'icons/obj/items/guns/shotguns64.dmi'
 	icon_state = "ml41"
 	worn_icon_state = "ml41"
@@ -2966,13 +2966,19 @@
 	gun_skill_category = SKILL_SHOTGUNS
 
 	fire_delay = 0.7 SECONDS
-	accuracy_mult = 1.15
-	damage_mult = 0.5
-	aim_slowdown = 0.6
-	wield_delay = 0.75 SECONDS
+	accuracy_mult = 1.05
+	accuracy_mult_unwielded = 0.5
+	damage_mult = 0.7
+	damage_falloff_mult = 5.5
+	aim_slowdown = 1.05
+	wield_delay = 1 SECONDS
 	burst_amount = 1
-	scatter = 8
-	movement_acc_penalty_mult = 2
+	movement_acc_penalty_mult = 6
+	
+	min_scatter = 3
+	max_scatter = 15
+	scatter_increase = 1.5
+	scatter_decay = 4
 
 /obj/item/weapon/gun/rifle/icc_autoshotgun/guard
 	default_ammo_type = /obj/item/ammo_magazine/rifle/icc_autoshotgun/frag

--- a/code/modules/projectiles/magazines/rifles.dm
+++ b/code/modules/projectiles/magazines/rifles.dm
@@ -815,7 +815,7 @@
 	color = list(1,0,0,0, 0,1,0,0, 0,1.5,1,0, 0,0,0,1) //recolor it green.  New sprites would be better but too much work
 
 //-------------------------------------------------------
-//ML-41 Autoshotgun
+//ML-41A Autoshotgun
 /obj/item/ammo_magazine/rifle/icc_autoshotgun
 	name = "\improper ML-41 Autoshotgun flechette drum magazine (12G)"
 	desc = "A magazine filled with 12G flechette shells for the ML-41."
@@ -824,6 +824,8 @@
 	default_ammo = /datum/ammo/bullet/shotgun/flechette
 	max_rounds = 20
 	icon_state_mini = "mag_rifle"
+	aim_speed_mod = 0.2
+	wield_delay_mod = 0.2 SECONDS
 
 /obj/item/ammo_magazine/rifle/icc_autoshotgun/rubber
 	name = "\improper ML-41 Autoshotgun rubber pellet drum magazine (12G)"
@@ -837,7 +839,9 @@
 	caliber = CALIBER_12G
 	icon_state = "ml41_frag"
 	default_ammo = /datum/ammo/bullet/shotgun/frag
-	max_rounds = 12
+	max_rounds = 20
+	aim_speed_mod = 0.2
+	wield_delay_mod = 0.2 SECONDS
 
 //-------------------------------------------------------
 //L-88 Assault Carbine

--- a/ntf_modular/code/modules/reqs/supplypacks/imports_packs.dm
+++ b/ntf_modular/code/modules/reqs/supplypacks/imports_packs.dm
@@ -867,6 +867,12 @@
 	faction_lock = list(FACTION_SOM)
 	cost = 325
 
+/datum/supply_packs/imports/ml41afrag
+	name = " ML-41A Autoshotgun frag drum (Faction Supply)"
+	contains = list(/obj/item/ammo_magazine/rifle/icc_autoshotgun/frag)
+	faction_lock = list(FACTION_ICC)
+	cost = 50
+
 /datum/supply_packs/imports/m41a2/ammo/ap
 	name = "PR-412 Pulse Rifle Ammo AP Mag"
 	contains = list(/obj/item/ammo_magazine/rifle/ap)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The only time anyone on CM would ever use the autoshotgun is anyone sane enough to use frag rounds. You either had flechettes that were incapable of putting enough damage on the target or you were using explosive hybrid frag-buckshots that were either horribly inaccurate or downright OP over a game of chance.

I may or may not make the ML-41A autoshotgun a limited weapon, I need to see how this performs ingame on populated rounds then see where to take it next.

## Why It's Good For The Game

Rebalances the ML-41 Assault Autoshotgun to pack more of a punch up close but actually makes it actually horrifying to fight against in close quarters. 12G frag magazines have been balanced to no longer fire two extra projectiles, but makes them slugs instead with 20 shells per drum mag.

The end goal of this PR is so that the ML-41A autoshotgun actually matters as an assault weapon of the CM. Getting the ML-41A autoshotgun to where it's no longer just an underrated downgrade of an assault rifle, but actually a menace to fight against in close quarters is the purpose.

## Proof of Testing

Build compile was successful.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to manipulate the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!--Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents, don't be too verbose. -->

:cl:
balance: ML-41A renamed and rebalanced. Buffed the damage modifier in exchange for giving the gun itself fall-off damage
balance: CM standard autoshotgun loadout got replaced with a trenchgun for a suitable alternative
changes: A few CM helmets got slight tweaks to the description
add: ML-41A frag mags added to requisitions imports and only purchasable for CM
/:cl:
