### PR TITLE
Makes the belt packs for the lMG-D way fucking cheaper because you CAN'T actually reload belt packs at all

### DIFF
--- a/code/modules/reqs/supplypacks/imports_packs.dm
+++ b/code/modules/reqs/supplypacks/imports_packs.dm
@@ -213,7 +213,7 @@ Imports
 /datum/supply_packs/imports/lmg_d/ammo/belt
 	name = "lMG-D Light Machine Gun Belt Pack"
 	contains = list(/obj/item/ammo_magazine/rifle/lmg_d/belt)
-	cost = 350
+	cost = 50
 
 /datum/supply_packs/imports/dp27
 	name = "Degtyaryov 'RP' Machine Gun"


### PR DESCRIPTION

## About The Pull Request

VERY self explanatory.

## Why It's Good For The Game

It's completely and utterly unsustainable to pay 350 bucks for an ammo box you can't re-use and has less ammo than a belt of mags.


## Proof of Testing
:3
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Reduced the price from the belt pack from 350 to 50 since they're UNABLE to be reloaded.
/:cl:
