### PR TITLE
Freaky stripper

### DIFF
--- a/_maps/map_files/BigRed_v2/BigRed_v2.dmm
+++ b/_maps/map_files/BigRed_v2/BigRed_v2.dmm
@@ -8071,8 +8071,6 @@
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "cZU" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/air_alarm{
 	dir = 4
@@ -8163,8 +8161,6 @@
 	},
 /area/bigredv2/outside/marshal_office)
 "dkJ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/cargo)
 "dnx" = (
@@ -8434,8 +8430,6 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/bigredv2/caves/southwest)
 "dSP" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/bigredv2/outside/bar)
 "dVz" = (
@@ -10244,8 +10238,6 @@
 /area/bigredv2/caves/south)
 "hOL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/marshal_office)
 "hPq" = (
@@ -11571,8 +11563,6 @@
 /area/bigredv2/outside/nanotrasen_lab/inside/garbledradio)
 "kvX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "kxw" = (
@@ -12628,8 +12618,6 @@
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
 "mZU" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grimy,
 /area/bigredv2/outside/marshal_office)
 "mZZ" = (
@@ -13895,8 +13883,6 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/outside/c)
 "pRP" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 4
 	},
@@ -14492,8 +14478,6 @@
 /turf/open/floor,
 /area/bigredv2/outside/hydroponics)
 "rkx" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "rlw" = (
@@ -17142,8 +17126,6 @@
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/virology)
 "wQm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor,
 /area/bigredv2/outside/filtration_plant)
 "wSJ" = (

--- a/_maps/map_files/Blue_Moon/bluemoon.dmm
+++ b/_maps/map_files/Blue_Moon/bluemoon.dmm
@@ -3082,7 +3082,7 @@
 /turf/open/floor/wood,
 /area/bluemoon/caves/facility/lambda/s)
 "dxw" = (
-/obj/effect/landmark/start/job/survivor,
+/obj/effect/,
 /turf/open/floor/plating,
 /area/bluemoon/outside/building/cargo)
 "dxx" = (

--- a/_maps/map_files/Blue_Moon/bluemoon.dmm
+++ b/_maps/map_files/Blue_Moon/bluemoon.dmm
@@ -3082,7 +3082,6 @@
 /turf/open/floor/wood,
 /area/bluemoon/caves/facility/lambda/s)
 "dxw" = (
-/obj/effect/,
 /turf/open/floor/plating,
 /area/bluemoon/outside/building/cargo)
 "dxx" = (
@@ -3187,7 +3186,6 @@
 /turf/open/floor/wood/fancy,
 /area/bluemoon/outside/building/dorms/chapel)
 "dDV" = (
-/obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -7938,7 +7936,6 @@
 /turf/open/urbanshale/layer2,
 /area/bluemoon/caves/se)
 "jcW" = (
-/obj/effect/landmark/start/job/survivor,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer0,
 /area/bluemoon/outside/n)
@@ -9096,7 +9093,6 @@
 /turf/open/floor/wood,
 /area/bluemoon/outside/building/dorms/eat)
 "klg" = (
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor,
 /area/bluemoon/outside/building/toolshed)
 "kmS" = (
@@ -12078,7 +12074,6 @@
 /area/bluemoon/caves/facility/eta/xeno)
 "nCJ" = (
 /obj/structure/closet/firecloset/full,
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/tile/brown{
 	dir = 5
 	},
@@ -15512,7 +15507,6 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/bluemoon/caves/facility/eta/xeno)
 "rUl" = (
-/obj/effect/landmark/start/job/survivor,
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 4
 	},
@@ -19654,7 +19648,6 @@
 /turf/open/floor/prison,
 /area/bluemoon/caves/facility/omicron)
 "wMT" = (
-/obj/effect/landmark/start/job/survivor,
 /turf/open/floor/wood/fancy,
 /area/bluemoon/outside/building/dorms/chapel)
 "wNd" = (

--- a/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
+++ b/_maps/map_files/Ice_Colony_v2/Ice_Colony_v2.dmm
@@ -19367,8 +19367,7 @@
 /turf/closed/mineral/smooth/darkfrostwall,
 /area/ice_colony/exterior/underground/caves/rock)
 "eIV" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/yellow2/corner,
 /area/ice_colony/surface/engineering/tool)
 "eKa" = (
@@ -19897,8 +19896,7 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/hallway/north_west)
 "fry" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/darkgreen/darkgreen2{
 	dir = 8
 	},
@@ -20820,8 +20818,7 @@
 /turf/open/floor/wood,
 /area/ice_colony/surface/bar/bar)
 "gIW" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/yellow2,
 /area/ice_colony/surface/substation/smes)
 "gJe" = (
@@ -21161,8 +21158,7 @@
 /turf/open/floor/plating/ground/snow/layer1,
 /area/ice_colony/exterior/surface/clearing/south)
 "hit" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/shuttle/dropship/five,
 /area/ice_colony/underground/responsehangar)
 "hiV" = (
@@ -22404,8 +22400,7 @@
 /turf/open/floor/tile/dark/brown2/corner,
 /area/ice_colony/surface/garage/one)
 "jdf" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/bar)
 "jdB" = (
@@ -22989,8 +22984,7 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/garage/one)
 "jRI" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/spawner/random/engineering/toolbox,
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_w)
@@ -23468,8 +23462,7 @@
 /turf/open/floor/tile/chapel,
 /area/ice_colony/underground/crew/chapel)
 "kvM" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/green/whitegreen{
 	dir = 10
 	},
@@ -24039,8 +24032,7 @@
 /turf/open/floor/freezer,
 /area/ice_colony/surface/bar/canteen)
 "lqO" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/command)
 "lrc" = (
@@ -25132,8 +25124,7 @@
 "mBR" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/yellow2{
 	dir = 5
 	},
@@ -26811,8 +26802,7 @@
 	},
 /area/ice_colony/surface/clinic/lobby)
 "oIi" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/icefloor,
 /area/ice_colony/exterior/surface/container_yard)
 "oIy" = (
@@ -28761,8 +28751,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/shuttle/dropship/fourteen,
 /area/ice_colony/surface/hangar/beta)
 "rsg" = (
@@ -29000,8 +28989,7 @@
 /turf/open/floor/tile/dark2,
 /area/ice_colony/underground/storage)
 "rFJ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark2,
 /area/ice_colony/surface/disposals)
 "rFS" = (
@@ -29922,8 +29910,7 @@
 /turf/open/floor/plating/ground/snow/layer2,
 /area/ice_colony/exterior/surface/valley/south/excavation)
 "sKY" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	on = 1
@@ -29973,8 +29960,7 @@
 /turf/open/floor/tile/dark/brown2,
 /area/ice_colony/underground/hallway/north_west/garbledradio)
 "sQn" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/ice_colony/surface/dorms)
 "sQr" = (
@@ -33336,8 +33322,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/freezer,
 /area/ice_colony/surface/dorms/restroom_e)
 "xjj" = (

--- a/_maps/map_files/LV624/LV624bases.dmm
+++ b/_maps/map_files/LV624/LV624bases.dmm
@@ -11490,8 +11490,7 @@
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/quartstorage/dome)
 "jOu" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -20348,8 +20347,7 @@
 	ceiling = 6
 	})
 "sDw" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/lv624/ground/jungle8{
 	outside = 0

--- a/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
+++ b/_maps/map_files/Magmoor_Digsite_IV/Magmoor_Digsite_IV.dmm
@@ -321,8 +321,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/purple,
 /area/magmoor/civilian/dorms)
 "alG" = (
@@ -1083,8 +1082,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/magmoor/cave/northwest)
 "aMv" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/blue/corner{
 	dir = 1
 	},
@@ -3203,8 +3201,7 @@
 	},
 /area/magmoor/command/lobby)
 "cgv" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/magmoor/civilian/rnr)
 "cgC" = (
@@ -6980,8 +6977,7 @@
 /area/magmoor/mining)
 "eHP" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/toilet)
 "eIj" = (
@@ -8210,8 +8206,7 @@
 	},
 /area/magmoor/cargo/storage/south)
 "fAJ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/blue/taupeblue,
 /area/magmoor/civilian/dorms)
 "fAY" = (
@@ -8564,8 +8559,7 @@
 /turf/open/floor/plating/ground/mars/random/dirt,
 /area/magmoor/compound/southeast)
 "fLe" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
@@ -9160,8 +9154,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/blue/taupeblue{
 	dir = 1
 	},
@@ -11152,8 +11145,7 @@
 /area/magmoor/cave/north)
 "hHK" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/freezer,
 /area/magmoor/civilian/clean/shower)
 "hHU" = (
@@ -15844,8 +15836,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/magmoor/command/office)
 "kPQ" = (
@@ -17858,8 +17849,7 @@
 /turf/open/floor/tile/red/redtaupe,
 /area/magmoor/security/lobby)
 "mlZ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/magmoor/civilian/bar)
 "mmf" = (
@@ -21136,8 +21126,7 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/tile/bar,
 /area/magmoor/civilian/clean)
@@ -25441,8 +25430,7 @@
 	},
 /area/magmoor/landing/two)
 "rHK" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/magmoor/command/lobby)
@@ -27155,8 +27143,7 @@
 /turf/open/floor/mainship/mono,
 /area/magmoor/engi/storage)
 "sSk" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/magmoor/cargo/processing/south)
 "sSX" = (
@@ -30452,8 +30439,7 @@
 	dir = 9
 	},
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/freezer,
 /area/magmoor/cargo/freezer)
 "vcB" = (
@@ -32112,8 +32098,7 @@
 /turf/open/floor/plating/ground/mars/random/cave/rock,
 /area/magmoor/cave/northwest)
 "wqc" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/blue/taupebluecorner,
 /area/magmoor/civilian/dorms)
 "wqD" = (
@@ -32124,8 +32109,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/magmoor/medical/breakroom)

--- a/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
+++ b/_maps/map_files/Orion_Military_Outpost/orionoutpost.dmm
@@ -445,8 +445,7 @@
 /turf/open/floor/mainship/ntlogo/nt3,
 /area/orion_outpost/ground/underground/caveS)
 "ct" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/engineering)
 "cw" = (
@@ -8099,8 +8098,7 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/administration)
 "Nd" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/canteen)
 "Ne" = (
@@ -9956,8 +9954,7 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/breakroom)
 "VU" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/administration)
 "VV" = (
@@ -10604,8 +10601,7 @@
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/bunker)
 "Zb" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/orion_outpost/surface/building/brig)
 "Zc" = (

--- a/_maps/map_files/Research_Outpost/Research_Outpost.dmm
+++ b/_maps/map_files/Research_Outpost/Research_Outpost.dmm
@@ -3151,8 +3151,7 @@
 /area/outpost/caves/south)
 "oC" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/brown2{
 	dir = 6
 	},
@@ -4198,8 +4197,7 @@
 /turf/open/floor/tile/dark/red2,
 /area/outpost/cargo/security)
 "tk" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/brown2/corner{
 	dir = 1
@@ -5096,8 +5094,7 @@
 /area/outpost/caves/north_east)
 "xq" = (
 /obj/structure/bed/chair/office/dark,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/outpost/cargo/office)
 "xs" = (
@@ -5232,8 +5229,7 @@
 	},
 /area/outpost/lz1)
 "yd" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/dark/blue2{
 	dir = 8
@@ -5362,8 +5358,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
@@ -5970,8 +5965,7 @@
 	},
 /area/outpost/yard/central)
 "Bz" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
 "BB" = (
@@ -6240,8 +6234,7 @@
 /area/outpost/hallway/south_cent)
 "CT" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "CU" = (
@@ -6328,8 +6321,7 @@
 	},
 /area/outpost/yard/north_east)
 "Dt" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/outpost/medbay)
 "Du" = (
@@ -8548,8 +8540,7 @@
 /area/outpost/caves/east)
 "NJ" = (
 /obj/structure/bed/chair,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/brown2,
 /area/outpost/arrivals)
 "NK" = (
@@ -8717,8 +8708,7 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/outpost/yard/south)
 "Ov" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/yellow2{
 	dir = 4
 	},
@@ -9757,8 +9747,7 @@
 /area/outpost/science/research)
 "Tj" = (
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -10203,8 +10192,7 @@
 /turf/open/floor/plating,
 /area/outpost/engineering/engine)
 "Vm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark2,
 /area/outpost/cargo)
 "Vo" = (

--- a/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
+++ b/_maps/map_files/Vapor_Processing/Vapor_Processing.dmm
@@ -3709,8 +3709,7 @@
 /turf/closed/mineral/smooth/indestructible,
 /area/lv624/ground/caves/central1)
 "uU" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/ground,
 /area/vapor_processing/west_compound)
 "uV" = (
@@ -3769,8 +3768,7 @@
 /turf/open/floor,
 /area/maintenance/substation)
 "vE" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grass,
 /area/lv624/ground/compound/c)
 "vM" = (
@@ -3948,8 +3946,7 @@
 /turf/closed/mineral/smooth,
 /area/lv624/ground/caves/west1)
 "yH" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/light{
 	dir = 1
 	},
@@ -4276,8 +4273,7 @@
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/medbay)
 "Dr" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5309,13 +5305,11 @@
 /turf/open/floor/prison/yellow,
 /area/lv624/lazarus/engineering)
 "Th" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/prison/yellow,
 /area/lv624/lazarus/engineering)
@@ -5464,8 +5458,7 @@
 /turf/open/floor,
 /area/shuttle/drop1/lz1)
 "VC" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
@@ -5571,8 +5564,7 @@
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/caves/central2)
 "WQ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grass,
 /area/lv624/ground/compound/se)
 "WR" = (

--- a/_maps/map_files/corsat/corsat.dmm
+++ b/_maps/map_files/corsat/corsat.dmm
@@ -2614,8 +2614,6 @@
 /area/corsat/gamma/hangar/flightcontrol)
 "blT" = (
 /obj/structure/bed,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/item/bedsheet/brown,
 /turf/open/floor/wood,
 /area/corsat/sigma/dorms)
@@ -5104,8 +5102,6 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/corsat/gamma/residential/east)
 "cph" = (
@@ -7505,8 +7501,6 @@
 /turf/open/floor/grayscale/white,
 /area/corsat/gamma/hangar/checkpoint)
 "dpU" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/turf_decal/tile/corsatcorner/lighpurple{
 	dir = 4
 	},
@@ -7999,8 +7993,6 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/omega/hangar/office)
 "dBL" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/residential/east)
 "dBN" = (
@@ -11036,8 +11028,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/wood,
 /area/corsat/gamma/residential/east)
 "eUi" = (
@@ -11125,8 +11115,6 @@
 /turf/open/floor/grayscale/white,
 /area/corsat/omega/complex)
 "eWu" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1
 	},
@@ -11255,8 +11243,6 @@
 /turf/open/floor/grayscale/round,
 /area/corsat/gamma/sigmaremote)
 "faZ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -12743,8 +12729,6 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -13026,8 +13010,6 @@
 /turf/open/floor/grayscale/round,
 /area/corsat/omega/hallways)
 "fOH" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 9
 	},
@@ -18238,8 +18220,6 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/sigma/dorms)
 "iiO" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -19285,8 +19265,6 @@
 /area/corsat/gamma/medbay/morgue)
 "iJg" = (
 /obj/structure/bed/chair/comfy/beige,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /turf/open/floor/carpet,
 /area/corsat/gamma/residential/lounge)
 "iJr" = (
@@ -21351,8 +21329,6 @@
 /turf/closed/wall/r_wall/unmeltable,
 /area/corsat/sigma/cargo)
 "jEs" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/turf_decal/tile/full/black,
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/sigmaremote)
@@ -24714,8 +24690,6 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/cargo/disposal)
 "lah" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
 /obj/effect/turf_decal/tile/corsatstraight/brown,
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/cargo/disposal)
@@ -25205,8 +25179,7 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/cargo/disposal)
 "llg" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue/whitebluefull,
 /area/corsat/gamma/residential/showers)
@@ -30563,8 +30536,7 @@
 /turf/open/floor/dark2,
 /area/corsat/emergency_access)
 "nwi" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grayscale/darkgray,
 /area/corsat/theta/airlock/east)
 "nwt" = (
@@ -30765,8 +30737,7 @@
 /turf/open/floor/grayscale/round/lightgray,
 /area/corsat/omega/complex)
 "nAm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/blue/whitebluefull,
 /area/corsat/gamma/residential/lavatory)
 "nAD" = (
@@ -37880,8 +37851,7 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/gamma/engineering)
 "qFe" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/grayscale/round/black,
 /area/corsat/gamma/engineering)
@@ -38336,8 +38306,7 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/sigma/south/engineering)
 "qPb" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grayscale/round/black,
 /area/corsat/gamma/airlock/north)
 "qPM" = (
@@ -38372,8 +38341,7 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/sigma/cargo)
 "qQv" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grayscale/round,
 /area/corsat/gamma/medbay)
 "qQz" = (
@@ -39461,8 +39429,7 @@
 /turf/open/floor/grayscale/white,
 /area/corsat/sigma/hangar/monorail)
 "rrX" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grayscale/darkgray,
 /area/corsat/sigma/southeast/datalab)
 "rse" = (
@@ -43169,8 +43136,7 @@
 /turf/open/floor/grayscale/round/black,
 /area/corsat/sigma/southeast/datalab)
 "sUT" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/bar,
 /area/corsat/gamma/canteen)
 "sUX" = (
@@ -46651,8 +46617,7 @@
 /turf/open/floor/grayscale/black,
 /area/corsat/theta/airlock/east/id)
 "unK" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grayscale/darkgray,
 /area/corsat/sigma/southeast/dataoffice)
 "unX" = (

--- a/_maps/map_files/deltastation/deltastation.dmm
+++ b/_maps/map_files/deltastation/deltastation.dmm
@@ -5951,8 +5951,7 @@
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/deltastation/asteroidcaves/westerncaves)
 "bkZ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/engineering/supermatter/room)
 "bla" = (
@@ -14430,8 +14429,7 @@
 /area/deltastation/service/chapel/office)
 "cZM" = (
 /obj/effect/turf_decal/tile/transparent/neutral/fourcorners,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/cargo/lobby)
 "cZO" = (
@@ -16679,8 +16677,7 @@
 "dxn" = (
 /obj/effect/turf_decal/tile/transparent/neutral/fourcorners,
 /obj/structure/cable,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/science/research)
 "dxx" = (
@@ -45776,8 +45773,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/engineering/storage/tech)
 "jnf" = (
@@ -48737,8 +48733,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/deltastation/service/library/abandoned)
 "jUA" = (
@@ -59808,8 +59803,7 @@
 /obj/effect/turf_decal/tile/transparent/yellow,
 /obj/effect/turf_decal/tile/transparent/yellow,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/engineering/supermatter/room)
 "mgW" = (
@@ -60555,8 +60549,7 @@
 /turf/open/floor/iron,
 /area/deltastation/commons/storage/primary)
 "mpK" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron/grimy,
 /area/deltastation/service/library)
 "mpL" = (
@@ -61090,8 +61083,7 @@
 /obj/effect/turf_decal/tile/transparent/red/half/contrasted{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/security/brig)
 "mwe" = (
@@ -83355,8 +83347,7 @@
 /turf/open/floor/iron/dark,
 /area/deltastation/command/bridge)
 "qUT" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/iron,
 /area/deltastation/hallway/primary/fore)
 "qVu" = (

--- a/_maps/map_files/desertdam/desertdam.dmm
+++ b/_maps/map_files/desertdam/desertdam.dmm
@@ -1665,8 +1665,7 @@
 	},
 /area/desert_dam/interior/lab_northeast/east_lab_biology)
 "alx" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/building/warehouse/loading)
 "aly" = (
@@ -5652,8 +5651,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_wilderness)
 "aJq" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/prison/bright_clean,
@@ -27941,8 +27939,7 @@
 /turf/closed/mineral/smooth,
 /area/desert_dam/building/administration/control_room)
 "dRB" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/hanger)
@@ -29250,8 +29247,7 @@
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/office1)
 "evS" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30547,8 +30543,7 @@
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/primary_tool_storage)
 "flm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison,
 /area/desert_dam/building/water_treatment_one/lobby)
 "flo" = (
@@ -34413,8 +34408,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/lobby)
 "hKC" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -36421,8 +36415,7 @@
 /turf/open/floor/asteroidfloor,
 /area/desert_dam/exterior/landing/landing_pad_one_external)
 "iZN" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/desert_dam/building/church)
 "iZW" = (
@@ -37498,8 +37491,7 @@
 /turf/open/floor/prison/marked,
 /area/desert_dam/building/hydroponics/hydroponics_storage)
 "jHQ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/hangar_storage)
@@ -37757,8 +37749,7 @@
 	},
 /area/desert_dam/exterior/landing/landing_pad_three_external)
 "jSF" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -38050,8 +38041,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/dam_interior/hangar_storage)
 "jZD" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -38589,8 +38579,7 @@
 /turf/closed/wall/r_wall,
 /area/desert_dam/building/medical/office1)
 "krc" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -40767,8 +40756,7 @@
 /turf/open/floor/bcircuit,
 /area/desert_dam/interior/dam_interior/smes_main)
 "lLh" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -41513,8 +41501,7 @@
 	},
 /area/desert_dam/interior/dam_interior/atmos_storage)
 "mnV" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/neutral,
 /area/desert_dam/interior/dam_interior/engine_room)
 "mnX" = (
@@ -43569,8 +43556,7 @@
 /turf/open/floor/plating/asteroidplating,
 /area/desert_dam/exterior/valley/valley_crashsite)
 "nHr" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/lv624/fog_blocker,
 /turf/open/floor/prison/whitegreen{
 	dir = 1
@@ -44935,8 +44921,7 @@
 /turf/closed/wall/r_wall,
 /area/desert_dam/interior/east_engineering)
 "oAh" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/desert_dam/building/security/courtroom)
 "oAx" = (
@@ -45156,8 +45141,7 @@
 /turf/open/floor/plating,
 /area/desert_dam/interior/lab_northeast/east_lab_containment)
 "oJi" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/green/whitegreen,
 /area/desert_dam/building/lab_northwest/west_lab_xenoflora)
 "oJq" = (
@@ -45337,8 +45321,7 @@
 /turf/open/floor/tile/whiteyellow/full,
 /area/desert_dam/interior/lab_northeast/east_lab_lobby)
 "oNP" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45765,8 +45748,7 @@
 /turf/open/floor/wood,
 /area/desert_dam/building/dorms/hallway_westwing)
 "oZA" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
@@ -47421,8 +47403,7 @@
 /area/desert_dam/exterior/valley/valley_labs)
 "pVe" = (
 /obj/item/trash/pistachios,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating,
 /area/desert_dam/interior/dam_interior/disposals)
 "pVj" = (
@@ -47520,8 +47501,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/building/hydroponics/hydroponics_loading)
 "pYo" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/whiteyellow/corner{
 	dir = 4
@@ -48000,8 +47980,7 @@
 	},
 /area/desert_dam/building/medical/east_wing_hallway)
 "qna" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison,
@@ -50360,8 +50339,7 @@
 /turf/open/floor/prison/bright_clean,
 /area/desert_dam/interior/lab_northeast/east_lab_security_armory)
 "rNG" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/desert_dam/interior/dam_interior/engine_east_wing)
@@ -53094,8 +53072,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_crashsite)
 "tuG" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/whitegreen/corner{
 	dir = 4
 	},
@@ -53194,8 +53171,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/bar_valley_dam)
 "tyi" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/wood,
 /area/desert_dam/interior/dam_interior/east_tunnel_entrance)
@@ -54518,8 +54494,7 @@
 /turf/open/floor/prison/kitchen,
 /area/desert_dam/building/cafeteria/cafeteria)
 "uot" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/prison/sterilewhite,
 /area/desert_dam/building/medical/office1)
@@ -56557,8 +56532,7 @@
 /turf/open/floor/prison/whitegreen/full,
 /area/desert_dam/interior/east_engineering)
 "vAT" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison,
 /area/desert_dam/building/telecommunication)
 "vBg" = (
@@ -56874,8 +56848,7 @@
 /area/desert_dam/building/medical/west_wing_hallway)
 "vKX" = (
 /obj/structure/bed/chair,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 1;
 	on = 1
@@ -57241,8 +57214,7 @@
 	},
 /area/desert_dam/exterior/valley/valley_medical)
 "vXm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 8;
 	on = 1
@@ -59607,8 +59579,7 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/desert_dam/exterior/valley/valley_wilderness)
 "xso" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
@@ -60986,8 +60957,7 @@
 	},
 /area/desert_dam/building/medical/north_wing_hallway)
 "yjm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison/bright_clean,

--- a/_maps/map_files/desparity/desparity.dmm
+++ b/_maps/map_files/desparity/desparity.dmm
@@ -477,8 +477,7 @@
 /turf/open/floor/tile/green/full,
 /area/lv624/lazarus/hydroponics)
 "cB" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/green/greentaupe{
 	dir = 10
 	},
@@ -2079,8 +2078,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "kN" = (
@@ -3603,8 +3601,7 @@
 	},
 /area/lv624/lazarus/medbay)
 "sy" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/fitness)
 "sA" = (
@@ -4367,8 +4364,7 @@
 /obj/structure/bed/chair/pew{
 	dir = 9
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/lv624/lazarus/chapel)
 "wF" = (
@@ -5423,8 +5419,7 @@
 "BL" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/lv624/lazarus/bar)
 "BM" = (
@@ -5909,8 +5904,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "Et" = (
@@ -6006,8 +6000,7 @@
 /turf/closed/wall/wood,
 /area/lv624/lazarus/bar)
 "ER" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "EU" = (

--- a/_maps/map_files/desparity/desparity2.dmm
+++ b/_maps/map_files/desparity/desparity2.dmm
@@ -512,8 +512,7 @@
 /turf/open/floor/tile/green/full,
 /area/lv624/lazarus/hydroponics/aux)
 "cB" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/green/greentaupe{
 	dir = 10
 	},
@@ -2353,8 +2352,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/lv624/lazarus/engineering)
 "kN" = (
@@ -4020,8 +4018,7 @@
 	},
 /area/lv624/lazarus/medbay)
 "sy" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/white,
 /area/lv624/lazarus/fitness)
 "sA" = (
@@ -4815,8 +4812,7 @@
 /obj/structure/bed/chair/pew{
 	dir = 9
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/lv624/lazarus/chapel)
 "wF" = (
@@ -5910,8 +5906,7 @@
 "BL" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -6457,8 +6452,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/bar,
 /area/lv624/lazarus/canteen)
 "Et" = (
@@ -6560,8 +6554,7 @@
 /turf/closed/wall/wood,
 /area/lv624/lazarus/bar)
 "ER" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/ground/dirt,
 /area/lv624/ground/jungle7)
 "ET" = (

--- a/_maps/map_files/gelida_iv/gelida_iv.dmm
+++ b/_maps/map_files/gelida_iv/gelida_iv.dmm
@@ -379,8 +379,7 @@
 	dir = 5;
 	name = "bedroll"
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "anL" = (
@@ -2120,8 +2119,7 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "bva" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -3625,8 +3623,7 @@
 	dir = 4;
 	name = "bedroll"
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "cBr" = (
@@ -4333,8 +4330,7 @@
 	},
 /area/gelida/indoors/a_block/dorm_north)
 "cYy" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue{
 	dir = 6
 	},
@@ -5010,8 +5006,7 @@
 /area/gelida/indoors/a_block/bridges/op_centre)
 "dxx" = (
 /obj/structure/bed/chair/comfy,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "dxy" = (
@@ -5888,8 +5883,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "ebg" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/plate,
 /area/gelida/indoors/a_block/admin)
 "ebr" = (
@@ -8213,8 +8207,7 @@
 /turf/open/floor/plating/ground/snow/layer0,
 /area/gelida/outdoors/colony_streets/north_street)
 "fGk" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
 "fGo" = (
@@ -12762,8 +12755,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/open/floor/prison,
@@ -12875,8 +12867,7 @@
 /obj/structure/bed/chair/comfy{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "iLM" = (
@@ -15150,8 +15141,7 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "kom" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/plating_catwalk/prison,
 /area/gelida/indoors/a_block/admin)
@@ -16228,8 +16218,7 @@
 /area/gelida/indoors/a_block/garden)
 "lcm" = (
 /obj/item/reagent_containers/food/drinks/flask/marine,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -16788,8 +16777,7 @@
 	pixel_y = 19
 	},
 /obj/item/shard,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},
@@ -16829,8 +16817,7 @@
 /turf/open/shuttle/dropship/three,
 /area/gelida/landing_zone_forecon/UD6_Tornado)
 "lwd" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "lwk" = (
@@ -17458,8 +17445,7 @@
 /obj/structure/bed/chair/comfy{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
 "lSo" = (
@@ -20320,8 +20306,7 @@
 /area/gelida/indoors/a_block/fitness)
 "nNU" = (
 /obj/item/shard,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue{
 	dir = 1
 	},
@@ -20633,8 +20618,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/a_block/fitness)
 "nZi" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 5
 	},
@@ -20810,8 +20794,7 @@
 	dir = 4;
 	name = "bedroll"
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue{
 	dir = 8
 	},
@@ -21646,8 +21629,7 @@
 /turf/open/floor/prison/whitegreenfull2,
 /area/gelida/indoors/a_block/fitness)
 "oIO" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/prison,
 /area/gelida/indoors/a_block/admin)
@@ -21922,8 +21904,7 @@
 /turf/open/floor/prison,
 /area/gelida/indoors/c_block/mining)
 "oSL" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue{
 	dir = 9
 	},
@@ -22229,8 +22210,7 @@
 	dir = 9;
 	name = "bedroll"
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue{
 	dir = 4
 	},
@@ -24459,8 +24439,7 @@
 /turf/open/floor/prison/kitchen,
 /area/gelida/indoors/a_block/kitchen)
 "qBz" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
@@ -26649,8 +26628,7 @@
 /obj/structure/inflatable/wall{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating{
 	dir = 8
 	},
@@ -30779,8 +30757,7 @@
 /turf/open/floor/wood,
 /area/gelida/indoors/b_block/bar)
 "uVl" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue,
 /area/gelida/indoors/a_block/admin)
 "uVp" = (
@@ -33183,8 +33160,7 @@
 /area/gelida/landing_zone_2)
 "wHJ" = (
 /obj/structure/bed/roller,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/blue/plate{
 	dir = 1
 	},

--- a/_maps/map_files/lavaoutpost/LavaOutpost.dmm
+++ b/_maps/map_files/lavaoutpost/LavaOutpost.dmm
@@ -7,8 +7,7 @@
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/engine)
 "ae" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/south)
 "af" = (
@@ -1621,8 +1620,7 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/west)
 "qB" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark2,
 /area/lavaland/civilian)
 "qF" = (
@@ -3409,8 +3407,7 @@
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/refine)
 "Il" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/refine)
 "Im" = (
@@ -3635,8 +3632,7 @@
 /area/lavaland/security/storage)
 "Kr" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/structure/cable,
 /turf/open/floor/tile/dark2,
 /area/lavaland/engie/engine)
@@ -3879,8 +3875,7 @@
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/central)
 "MW" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/structure/cable,
 /turf/open/floor/marking,
 /area/lava_outpost_v1/disused_landing_pad)
@@ -3952,8 +3947,7 @@
 /turf/open/floor/tile/white,
 /area/lavaland/medical)
 "Oi" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/asteroidfloor,
 /area/lavaland/cave/northeast)
 "Ok" = (
@@ -3983,8 +3977,7 @@
 /turf/open/liquid/lava/autosmoothing/catwalk,
 /area/lavaland/cave/central)
 "Os" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/lavaland/basalt,
 /area/lavaland/cave/east)

--- a/_maps/map_files/riptide/riptide.dmm
+++ b/_maps/map_files/riptide/riptide.dmm
@@ -2359,8 +2359,7 @@
 /turf/open/floor/tile/lightred/full,
 /area/riptide/inside/abandonedsec)
 "bHm" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood/thatch,
 /area/riptide/inside/tikihut)
 "bHr" = (
@@ -6347,8 +6346,7 @@
 	pixel_x = 4;
 	pixel_y = -3
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood/alt_three,
 /area/riptide/inside/beachmotel)
 "erK" = (
@@ -13831,8 +13829,7 @@
 /turf/open/floor/wood,
 /area/riptide/outside/southislands)
 "jJc" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/freezer,
 /area/riptide/inside/medical/offices)
 "jJg" = (
@@ -14754,8 +14751,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/trash,
 /obj/item/trash/cigbutt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grimy,
 /area/riptide/inside/syndicatestarboard)
 "kog" = (
@@ -20628,8 +20624,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/riptide/inside/tikihut)
 "ooc" = (
@@ -21682,8 +21677,7 @@
 	},
 /area/riptide/inside/warehouse)
 "oVL" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/ground/concrete,
 /area/riptide/inside/warehouse)
 "oWL" = (
@@ -29447,8 +29441,7 @@
 /area/riptide/inside/arena)
 "tSX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/manifold/green/hidden{
 	dir = 8
 	},
@@ -33335,8 +33328,7 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/ground,
 /area/riptide/outside/northislands)
 "wHe" = (

--- a/_maps/map_files/slumbridge/slumbridge.dmm
+++ b/_maps/map_files/slumbridge/slumbridge.dmm
@@ -4064,8 +4064,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
 "cYO" = (
@@ -7615,8 +7614,7 @@
 	dir = 4;
 	on = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/tile/bar,
 /area/slumbridge/inside/houses/recreational)
@@ -11826,8 +11824,7 @@
 /obj/structure/bed/chair/comfy{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/tile/purple/whitepurple{
 	dir = 4
@@ -13110,8 +13107,7 @@
 /obj/structure/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/tile/lightred/full,
 /area/slumbridge/inside/colony/southerndome)
@@ -21708,8 +21704,7 @@
 	},
 /area/slumbridge/inside/prison/outerringsouth)
 "pTG" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/plating/ground/snow/layer2,
 /area/slumbridge/outside/southwest)
@@ -22757,8 +22752,7 @@
 	},
 /area/slumbridge/inside/prison/outerringsouth)
 "qFB" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/prison/kitchen,
 /area/slumbridge/inside/colony/kitchen)
 "qFG" = (

--- a/_maps/modularmaps/big_red/barracks.dmm
+++ b/_maps/modularmaps/big_red/barracks.dmm
@@ -158,16 +158,14 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
 "fY" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
 	dir = 4
 	},
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
 "gj" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grimy,
 /area/bigredv2/outside/admin_building)
 "gk" = (

--- a/_maps/modularmaps/big_red/bigredchapelvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredchapelvar1.dmm
@@ -144,8 +144,7 @@
 /obj/structure/bed/chair/wood/normal{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/chapel{
 	dir = 4
 	},

--- a/_maps/modularmaps/big_red/bigredchapelvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredchapelvar2.dmm
@@ -61,8 +61,7 @@
 /turf/open/floor/tile/chapel,
 /area/bigredv2/outside/chapel)
 "nQ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/structure/bed/chair/wood/wings{
 	dir = 8
 	},

--- a/_maps/modularmaps/big_red/bigreddormvar1.dmm
+++ b/_maps/modularmaps/big_red/bigreddormvar1.dmm
@@ -33,8 +33,7 @@
 /area/bigredv2/outside/dorms)
 "hT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grimy,
 /area/bigredv2/outside/dorms)
 "iG" = (
@@ -297,8 +296,7 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/dorms)
 "RW" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar1.dmm
@@ -239,8 +239,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "lE" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "mo" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar2.dmm
@@ -628,8 +628,7 @@
 /turf/open/floor/plating/ground/mars/random/sand,
 /area/bigredv2/caves/southwest)
 "Gp" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "Gv" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar3.dmm
@@ -525,8 +525,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/engineering)
 "vw" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "vR" = (

--- a/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
+++ b/_maps/modularmaps/big_red/bigredengineeringvar4.dmm
@@ -501,8 +501,7 @@
 	},
 /area/bigredv2/caves/southwest)
 "Aq" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/engineering/east)
 "Au" = (

--- a/_maps/modularmaps/big_red/bigredgeneralstorevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredgeneralstorevar1.dmm
@@ -591,8 +591,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "Gp" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "Gw" = (

--- a/_maps/modularmaps/big_red/bigredgeneralstorevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredgeneralstorevar2.dmm
@@ -593,8 +593,7 @@
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "IV" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/general_store)
 "Jm" = (

--- a/_maps/modularmaps/big_red/bigredofficevar1.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar1.dmm
@@ -235,8 +235,7 @@
 /turf/open/floor/grimy,
 /area/bigredv2/outside/office_complex)
 "ld" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -268,8 +267,7 @@
 /area/bigredv2/outside/office_complex)
 "mh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "mq" = (

--- a/_maps/modularmaps/big_red/bigredofficevar2.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar2.dmm
@@ -1665,8 +1665,7 @@
 /turf/open/floor/mainship/mono,
 /area/bigredv2/outside/office_complex/crashed_ship)
 "Yo" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},

--- a/_maps/modularmaps/big_red/bigredofficevar3.dmm
+++ b/_maps/modularmaps/big_red/bigredofficevar3.dmm
@@ -829,8 +829,7 @@
 /turf/open/floor/asteroidfloor,
 /area/bigredv2/outside/c)
 "OJ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/red/redtaupecorner{
 	dir = 8
 	},
@@ -899,8 +898,7 @@
 /area/bigredv2/outside/office_complex)
 "Sh" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor,
 /area/bigredv2/outside/office_complex)
 "Sk" = (

--- a/_maps/modularmaps/big_red/operation.dmm
+++ b/_maps/modularmaps/big_red/operation.dmm
@@ -547,8 +547,7 @@
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
 "wQ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating,
 /area/bigredv2/outside/admin_building)
 "wR" = (
@@ -1185,8 +1184,7 @@
 	},
 /area/bigredv2/outside/admin_building)
 "PN" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark,
 /area/bigredv2/outside/admin_building)
 "Qc" = (
@@ -1315,8 +1313,7 @@
 /turf/open/floor/wood,
 /area/bigredv2/outside/admin_building)
 "UC" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/white,
 /area/bigredv2/outside/admin_building)
 "UF" = (

--- a/_maps/modularmaps/corsatdome/corsatdomebigred.dmm
+++ b/_maps/modularmaps/corsatdome/corsatdomebigred.dmm
@@ -686,8 +686,7 @@
 /turf/open/floor/plating/ground/mars,
 /area/corsat/sigma/biodome)
 "nw" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/grayscale/black,
 /area/corsat/sigma/airlock/control)
 "nJ" = (
@@ -1721,8 +1720,7 @@
 	},
 /area/corsat/sigma/biodome)
 "GT" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/corsat/sigma/biodome/scrapyard)
 "Hg" = (

--- a/_maps/modularmaps/groundhq/ntcgroundhq.dmm
+++ b/_maps/modularmaps/groundhq/ntcgroundhq.dmm
@@ -4378,8 +4378,7 @@
 	always_unpowered = 0
 	})
 "eSX" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/mainship/mono,
 /area/mainship/groundhq/ntf/living/grunt_rnr)
 "eSY" = (

--- a/_maps/modularmaps/lv624/atmospherics.dmm
+++ b/_maps/modularmaps/lv624/atmospherics.dmm
@@ -284,8 +284,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/dark/brown2{
 	dir = 4
 	},

--- a/_maps/modularmaps/lv624/auxbotany.dmm
+++ b/_maps/modularmaps/lv624/auxbotany.dmm
@@ -310,8 +310,7 @@
 /obj/effect/turf_decal/warning_stripes/thin{
 	dir = 8
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/green/whitegreen{
 	dir = 8
 	},

--- a/_maps/modularmaps/lv624/internal_affairs.dmm
+++ b/_maps/modularmaps/lv624/internal_affairs.dmm
@@ -187,8 +187,7 @@
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
 "qp" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/blue/whiteblue{
 	dir = 1
 	},
@@ -208,8 +207,7 @@
 	},
 /area/lv624/lazarus/internal_affairs)
 "sS" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/lv624/lazarus/internal_affairs)
 "tF" = (

--- a/_maps/modularmaps/lv624/medbayone.dmm
+++ b/_maps/modularmaps/lv624/medbayone.dmm
@@ -451,8 +451,7 @@
 	},
 /area/lv624/lazarus/medbay)
 "MQ" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 2
 	},
@@ -469,8 +468,7 @@
 	},
 /area/lv624/lazarus/medbay)
 "NL" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/landmark/weed_node,
 /turf/open/floor/tile/blue/whitebluecorner{
 	dir = 2

--- a/_maps/modularmaps/lv624/robotics.dmm
+++ b/_maps/modularmaps/lv624/robotics.dmm
@@ -175,8 +175,7 @@
 	},
 /area/lv624/lazarus/robotics)
 "uR" = (
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /obj/effect/ai_node,
 /turf/open/floor/tile/vault{
 	dir = 8

--- a/_maps/modularmaps/lv624/telecomms.dmm
+++ b/_maps/modularmaps/lv624/telecomms.dmm
@@ -162,8 +162,7 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/tile/brown{
 	dir = 9
 	},

--- a/_maps/modularmaps/oscaroutpost/oscarsouthvar7.dmm
+++ b/_maps/modularmaps/oscaroutpost/oscarsouthvar7.dmm
@@ -393,8 +393,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/landmark/start/job/survivor,
-/obj/effect/landmark/start/latejoinsurvivor,
+
 /turf/open/floor/wood,
 /area/oscar_outpost/village/abandonedbase)
 "lx" = (

--- a/ntf_modular/code/datums/jobs/job/survivor.dm
+++ b/ntf_modular/code/datums/jobs/job/survivor.dm
@@ -18,10 +18,6 @@
 
 /datum/skills/civilian/survivor/stripper
 	name = "Stripper"
-	engineer = SKILL_ENGINEER_ENGI //to hack airlocks so they're never stuck in a room.
-	combat = SKILL_COMBAT_DEFAULT
-	construction = SKILL_CONSTRUCTION_METAL
-	medical = SKILL_MEDICAL_NOVICE
 	sex = SKILL_SEX_MASTER // They gotta have an upside for being bad!
 
 //Maid Survivor

--- a/ntf_modular/code/datums/jobs/job/survivor.dm
+++ b/ntf_modular/code/datums/jobs/job/survivor.dm
@@ -13,8 +13,16 @@
 //Stripper Survivor
 /datum/job/survivor/stripper
 	title = "Stripper Colonist"
-	skills_type = /datum/skills/civilian/survivor
+	skills_type = /datum/skills/civilian/survivor/stripper
 	outfit = /datum/outfit/job/survivor/stripper
+
+/datum/skills/civilian/survivor/stripper
+	name = "Stripper"
+	engineer = SKILL_ENGINEER_ENGI //to hack airlocks so they're never stuck in a room.
+	combat = SKILL_COMBAT_DEFAULT
+	construction = SKILL_CONSTRUCTION_METAL
+	medical = SKILL_MEDICAL_NOVICE
+	sex = SKILL_SEX_MASTER // They gotta have an upside for being bad!
 
 //Maid Survivor
 /datum/job/survivor/maid


### PR DESCRIPTION

## About The Pull Request
Gives stripper survivor the sex skill it deserves
## Why It's Good For The Game
Strippers should be good at what they do damn it!!! They need this bonus to facilitate their niche-as a xeno's undercarriage ornament 
## Proof of Testing
It compiled but I cannot test the changes to the survivor maps, I'm pretty sure I caught and removed all instances of them from all maps; what this means is that survivors will no longer
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
fix: Survivors shouldn't spawn on the planet anymore, unless it is colony fall
qol: stripper survivors have sex skill now
/:cl:
