### PR TITLE
Returns widow values to default

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/spiderling/castedatum_spiderling.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/spiderling/castedatum_spiderling.dm
@@ -22,7 +22,7 @@
 	plasma_gain = 1
 
 	// *** Health *** //
-	max_health = 75
+	max_health = 125
 
 	// *** Flags *** //
 	caste_flags = CASTE_NOT_IN_BIOSCAN|CASTE_DO_NOT_ANNOUNCE_DEATH|CASTE_DO_NOT_ALERT_LOW_LIFE|CASTE_IS_BUILDER|CASTE_IS_A_MINION

--- a/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/widow/castedatum_widow.dm
@@ -21,7 +21,7 @@
 	plasma_gain = 55
 
 	// *** Health *** //
-	max_health = 410
+	max_health = 450
 
 	// *** Evolution *** //
 	upgrade_threshold = TIER_THREE_THRESHOLD

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -13,12 +13,13 @@
 	ammo_behavior_flags = AMMO_SKIPS_ALIENS
 	ping = null
 	armor_type = BIO
+	accuracy = 500 // This has specific hand/leg targeting gimmicks and should never miss from targeting these areas
 	accurate_range = 15
 	max_range = 15
 	///For how long the victim will be blinded
 	var/hit_eye_blind = 1
 	///How long the victim will be snared for
-	var/hit_immobilize = 2 SECONDS
+	var/hit_immobilize = 6 SECONDS // To give some reason to ensnare over paralyzing
 	///How long the victim will be KO'd
 	var/hit_paralyze = 2 SECONDS
 	///List for bodyparts that upon being hit cause the target to become weakened

--- a/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
+++ b/code/modules/projectiles/ammo_types/xenos/widow_xenoammo.dm
@@ -19,7 +19,7 @@
 	///For how long the victim will be blinded
 	var/hit_eye_blind = 1
 	///How long the victim will be snared for
-	var/hit_immobilize = 6 SECONDS // To give some reason to ensnare over paralyzing
+	var/hit_immobilize = 5 SECONDS // To give some reason to ensnare over paralyzing
 	///How long the victim will be KO'd
 	var/hit_paralyze = 2 SECONDS
 	///List for bodyparts that upon being hit cause the target to become weakened


### PR DESCRIPTION

## About The Pull Request
One singular mag of a halter can kill every single spiderling and a widow, a tier 3 caste, maybe this wasn't a good idea
## Why It's Good For The Game
Widow is already weak in default TGMC, these nerfs were not necessary at all, adds some buffs ontop of it to make it the actual 1v1 caste its supposed to be, you are not supposed to be able to beat a widow in a 1v1
## Proof of Testing
Numbers changes
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: rebalanced some of widows stuff
/:cl:
