### PR TITLE
MINIB 9MM spec damage nerf by 2.5 and 0.25 sunder increase

### DIFF
--- a/code/modules/projectiles/guns/flamer.dm
+++ b/code/modules/projectiles/guns/flamer.dm
@@ -556,15 +556,12 @@ GLOBAL_LIST_EMPTY(flamer_particles)
 	icon_state = "c21"
 	worn_icon_state = "c21"
 	worn_icon_list = list(
-		slot_back_str = 'ntf_modular/icons/mob/clothing/back.dmi',
-	)
-	gun_features_flags = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_SHOWS_LOADED
-	worn_icon_list = list(
 		slot_s_store_str = 'ntf_modular/icons/mob/suit_slot.dmi',
 		slot_back_str = 'ntf_modular/icons/mob/clothing/back.dmi',
 		slot_l_hand_str = 'icons/mob/inhands/guns/special_left_1.dmi',
 		slot_r_hand_str = 'icons/mob/inhands/guns/special_right_1.dmi',
 	)
+	gun_features_flags = GUN_AMMO_COUNTER|GUN_WIELDED_FIRING_ONLY|GUN_WIELDED_STABLE_FIRING_ONLY|GUN_SHOWS_LOADED
 	lit_overlay_icon_state = "c21_lit"
 	lit_overlay_offset_x = 0
 	flame_max_range = 8

--- a/ntf_modular/code/modules/projectiles/guns/smgs.dm
+++ b/ntf_modular/code/modules/projectiles/guns/smgs.dm
@@ -72,7 +72,7 @@
 /datum/ammo/bullet/smg/minibap
 	name = "specialized armor-piercing machinepistol bullet"
 	hud_state = "smg_ap"
-	damage = 25
+	damage = 22.5
 	penetration = 12.5
 	sundering = 0.5
 	damage_falloff = 1

--- a/ntf_modular/code/modules/projectiles/guns/smgs.dm
+++ b/ntf_modular/code/modules/projectiles/guns/smgs.dm
@@ -74,6 +74,6 @@
 	hud_state = "smg_ap"
 	damage = 22.5
 	penetration = 12.5
-	sundering = 0.5
+	sundering = 0.75
 	damage_falloff = 1
 	accurate_range = 7


### PR DESCRIPTION
## About The Pull Request

MINIB is supposed to be an ambush weapon, it was a mistake giving the weapon as much damage as an AR12.

## Why It's Good For The Game

Keep its ambush-weapon status but still make it viable in close quarters.

## Proof of Testing

I've personally used it on a round and for NTF on the receiving end, it was brutal as hell to fight against. Not so much against xenos, it will however remain weak against T3 & T4s.

## Changelog
:cl:
balance: nerfs MINIB 9MM spec damage and slight buff to sunder
/:cl: