### PR TITLE
Nerfs WP flames

### DIFF
--- a/code/game/objects/items/explosives/grenades/phosphorus_grenades.dm
+++ b/code/game/objects/items/explosives/grenades/phosphorus_grenades.dm
@@ -20,8 +20,8 @@
 	playsound(loc, 'sound/effects/smoke.ogg', 25, 1, 4)
 	smoke.set_up(6, loc, 7)
 	smoke.start()
-	flame_radius(4, get_turf(src), burn_intensity = 20, burn_duration = 20, burn_damage = 20, fire_stacks = 10)
-	flame_radius(1, get_turf(src), burn_intensity = 70, burn_duration = 40, burn_damage = 15, fire_stacks = 70)	//The closer to the middle you are the more it hurts
+	flame_radius(4, get_turf(src), burn_intensity = 20, burn_duration = 20, burn_damage = 15, fire_stacks = 10)
+	flame_radius(1, get_turf(src), burn_intensity = 50, burn_duration = 40, burn_damage = 10, fire_stacks = 50)	//The closer to the middle you are the more it hurts
 	qdel(src)
 
 /obj/item/explosive/grenade/phosphorus/activate(mob/user)

--- a/code/modules/projectiles/ammo_types/rocket_ammo.dm
+++ b/code/modules/projectiles/ammo_types/rocket_ammo.dm
@@ -185,7 +185,7 @@
 	smoke_system = null
 	target_turf.visible_message(span_danger("The rocket explodes into white gas!") )
 	playsound(target_turf, 'sound/weapons/guns/fire/flamethrower2.ogg', 50, 1, 4)
-	flame_radius(effect_radius, target_turf, 27, 27, 27, 17)
+	flame_radius(effect_radius - 1, target_turf, 20, 20, 15, 10)
 
 /datum/ammo/rocket/wp/quad/som
 	name = "white phosphorous RPG"


### PR DESCRIPTION

## About The Pull Request
Reduces intensity of flames from white phosphorous
## Why It's Good For The Game
People keep complaining about it being overpowered
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: HPDP phosphorous grenades and 84mm phosphorous rockets now produce less intense flames.
/:cl:
