### PR TITLE
Ovipositor mutation tweaks

### DIFF
--- a/_ntf_modular/code/__DEFINES/traits.dm
+++ b/_ntf_modular/code/__DEFINES/traits.dm
@@ -10,5 +10,7 @@
 #define TRAIT_FRAIL_LARVABURSTS "frail_larvabursts"
 #define TRAIT_CULTIST "cultist"
 #define TRAIT_RESEARCHER "researcher"
+/// Can only store or throw latching huggers
+#define TRAIT_LATCHING_HUGGERS_ONLY "latching_huggers_only"
 
 #define TRAIT_EXOSUIT_NV "exosuit_nightvision" //Able to see in dark

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/abilities_carrier.dm
@@ -88,8 +88,10 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 		if(!xeno_owner.huggers)
 			to_chat(xeno_owner, span_warning("We don't have any facehuggers to use!"))
 			return fail_activate()
-
-		F = new xeno_owner.selected_hugger_type(get_turf(xeno_owner), xeno_owner.hivenumber, xeno_owner)
+		var/huggerpath = xeno_owner.selected_hugger_type
+		if(HAS_TRAIT(owner, TRAIT_LATCHING_HUGGERS_ONLY))
+			huggerpath = GLOB.hugger_to_latching[huggerpath] || huggerpath
+		F = new huggerpath(get_turf(xeno_owner), xeno_owner.hivenumber, xeno_owner)
 		xeno_owner.huggers--
 
 		xeno_owner.put_in_active_hand(F)
@@ -133,6 +135,9 @@ GLOBAL_LIST_INIT(hugger_images_list,  list(
 /mob/living/carbon/xenomorph/proc/store_hugger(obj/item/clothing/mask/facehugger/F, message = TRUE, forced = FALSE) //todo: wrap this into ability
 	if(istype(F, /obj/item/clothing/mask/facehugger/combat/harmless))
 		to_chat(src, span_notice("This fakehugger is useless to absorb."))
+		return FALSE
+	if(HAS_TRAIT(src, TRAIT_LATCHING_HUGGERS_ONLY) && !(istype(F, /obj/item/clothing/mask/facehugger/latching)))
+		to_chat(src, span_notice("We are currently not capable of absorbing non-latching facehuggers."))
 		return FALSE
 	if(huggers < xeno_caste.huggers_max)
 		if(F.stat == DEAD && !forced)

--- a/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/carrier/mutations_carrier.dm
@@ -266,9 +266,10 @@
 /datum/mutation_upgrade/veil/oviposition/get_desc_for_alert(new_amount)
 	if(!new_amount)
 		return ..()
-	return "Egg Lay now creates eggs with your selected type of hugger inside and can toggle into a new host-lingering series of huggers by right clicking onto the button. The plasma cost is set to [PERCENT(1 + get_multiplier(new_amount))]% of its their original value and its cooldown is set to 50% of its original value. You lose the ability, Spawn Huggers."
+	return "Egg Lay now creates eggs with your selected type of hugger inside and can toggle into a new host-lingering series of huggers by right clicking onto the button. The plasma cost is set to [PERCENT(1 + get_multiplier(new_amount))]% of its their original value and its cooldown is set to 50% of its original value. You lose the ability, Spawn Huggers. You can no longer store non-latching huggers."
 
 /datum/mutation_upgrade/veil/oviposition/on_mutation_enabled()
+	ADD_TRAIT(xenomorph_owner, TRAIT_LATCHING_HUGGERS_ONLY, "[type]")
 	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
 	if(!egg_ability)
 		return
@@ -284,6 +285,7 @@
 	return ..()
 
 /datum/mutation_upgrade/veil/oviposition/on_mutation_disabled()
+	REMOVE_TRAIT(xenomorph_owner, TRAIT_LATCHING_HUGGERS_ONLY, "[type]")
 	var/datum/action/ability/xeno_action/lay_egg/egg_ability = xenomorph_owner.actions_by_path[/datum/action/ability/xeno_action/lay_egg]
 	if(!egg_ability)
 		return

--- a/ntf_modular/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
+++ b/ntf_modular/code/modules/mob/living/carbon/xenomorph/facehuggers.dm
@@ -309,7 +309,7 @@
 	var/can_use_adv_huggers = FALSE
 	action_icon = 'ntf_modular/icons/Xeno/construction.dmi'
 
-	var/static/list/hugger_to_latching = list(
+GLOBAL_LIST_INIT(hugger_to_latching, list(
 		/obj/item/clothing/mask/facehugger/larval = /obj/item/clothing/mask/facehugger/latching,
 		/obj/item/clothing/mask/facehugger/combat/slash = /obj/item/clothing/mask/facehugger/latching/clawer,
 		/obj/item/clothing/mask/facehugger/combat/chem_injector/neuro = /obj/item/clothing/mask/facehugger/latching/chemical/neuro,
@@ -317,7 +317,7 @@
 		/obj/item/clothing/mask/facehugger/combat/chem_injector/aphrotoxin = /obj/item/clothing/mask/facehugger/latching/chemical/aphrotox,
 		/obj/item/clothing/mask/facehugger/combat/acid = /obj/item/clothing/mask/facehugger/latching/chemical/acid,
 		/obj/item/clothing/mask/facehugger/combat/resin = /obj/item/clothing/mask/facehugger/latching/chemical/resin,
-	)
+		))
 
 /datum/action/ability/xeno_action/lay_egg/alternate_action_activate()
 	. = ..()
@@ -335,7 +335,7 @@
 /datum/action/ability/xeno_action/lay_egg/proc/advanced_plant_egg(turf/current_turf, mob/living/carbon/xenomorph/xeno, mob/living/carbon/xenomorph/user)
 	var/the_hugger = hugger_to_use
 	if(use_selected_hugger && xeno.selected_hugger_type)
-		the_hugger = hugger_to_latching[xeno_owner.selected_hugger_type]
+		the_hugger = GLOB.hugger_to_latching[xeno_owner.selected_hugger_type]
 	new /obj/alien/egg/hugger(current_turf, xeno.get_xeno_hivenumber(), the_hugger, hand_attach_time_multiplier)
 
 //harmless corrupted special pet huggers


### PR DESCRIPTION

## About The Pull Request
Carriers with the ovipositor mutation no longer convert latching huggers to normal ones when storing them.  They can now only store latching huggers.  
## Why It's Good For The Game
Makes latching huggers less awkward to use, since now you can store them without losing the latching property.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
<img width="351" height="402" alt="image" src="https://github.com/user-attachments/assets/bff90d80-5eef-49dc-9f5a-7750ac235495" />

</details>

## Changelog
:cl:
add: Carriers with the ovipositor mutation no longer convert latching huggers to normal ones when storing them.  They can now only store latching huggers.  
/:cl:
