### PR TITLE
Buff apc against melee

### DIFF
--- a/code/modules/vehicles/armored/apc.dm
+++ b/code/modules/vehicles/armored/apc.dm
@@ -13,7 +13,7 @@
 	pixel_x = -48
 	pixel_y = -40
 	max_integrity = 600
-	soft_armor = list(MELEE = 40, BULLET = 100 , LASER = 90, ENERGY = 60, BOMB = 60, BIO = 100, FIRE = 40, ACID = 40)
+	soft_armor = list(MELEE = 45, BULLET = 100 , LASER = 90, ENERGY = 60, BOMB = 60, BIO = 100, FIRE = 40, ACID = 40)
 	max_occupants = 20 //Clown car? Clown car.
 	enter_delay = 0.4 SECONDS
 	ram_damage = 300


### PR DESCRIPTION

## About The Pull Request
Buffs Athena APC against melee slightly (melee armor 40 -> 45)
## Why It's Good For The Game
It seems to a bit too quickly to slashes
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Athena APC melee armor increased from 40 to 45
/:cl:
