### PR TITLE
KHM4 damage tweak

### DIFF
--- a/code/modules/projectiles/guns/rifles.dm
+++ b/code/modules/projectiles/guns/rifles.dm
@@ -1054,8 +1054,8 @@
 	recoil_unwielded = 7
 	wield_delay = 0.6 SECONDS
 	movement_acc_penalty_mult = 2
-	damage_mult = 1.05
-	damage_falloff_mult = 1
+	damage_mult = 1
+	damage_falloff_mult = 1.2
 
 /obj/item/weapon/gun/rifle/khm4/operator
 	starting_attachment_types = list(/obj/item/attachable/reddot, /obj/item/attachable/verticalgrip, /obj/item/attachable/suppressor)


### PR DESCRIPTION
## About The Pull Request

The most important thing to realize is that no matter what you do, you will never appease or please certain people no matter what you do. You have to know this.

## Why It's Good For The Game

Necessary after some discussion on the discord. Because if not, somewhere along the way **those** people will start kicking your throat in over what you made. But there's always a chance that even when you try to make things right, you will still get it, that's just the way things are. Right Colfer?

## Proof of Testing

This is just a simple value change.

<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: KHM4 damage switched from 1.05 to 1, damage falloff mult from 1 to 1.2.