### PR TITLE
Reduce direct hit bonus damage for spray flamers by 70%

### DIFF
--- a/code/modules/projectiles/gun_attachables/flamer.dm
+++ b/code/modules/projectiles/gun_attachables/flamer.dm
@@ -51,6 +51,7 @@
 	stream_type = FLAMER_STREAM_CONE
 	burn_time_mod = 0.3
 	range_modifier = 1
+	mob_flame_damage_mod = 0.3
 
 ///Funny red wide nozzle that can fill entire screens with flames. Admeme only.
 /obj/item/attachable/flamer_nozzle/wide/red


### PR DESCRIPTION

## About The Pull Request
Reduces direct hit bonus damage for spray flamers by 70%.  (This has no effect on the damage from walking through the flames)
## Why It's Good For The Game
People are saying the spray nozzles are overpowered.
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  
</details>

## Changelog
:cl:
balance: Reduced direct hit bonus damage for spray flamers by 70%.  (This has no effect on the damage from walking through the flames)
/:cl:
