### PR TITLE
T3E & V8B Hotfix 2

### DIFF
--- a/_maps/map_files/Turkenden_3/Turkenden_3_Excluzone.dmm
+++ b/_maps/map_files/Turkenden_3/Turkenden_3_Excluzone.dmm
@@ -374,6 +374,10 @@
 	},
 /turf/open/floor/urban/wood/redwood,
 /area/turkenden3excluzone/indoors/diner)
+"azv" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/s)
 "azK" = (
 /obj/structure/closet/cabinet,
 /turf/open/floor/urban/carpet/carpetblue,
@@ -557,6 +561,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/purple/side,
 /area/turkenden3excluzone/indoors/medrsr/rsrdorms)
+"aHK" = (
+/obj/structure/window/framed/mainship/white,
+/turf/open/floor/mainship/sterile/dark,
+/area/turkenden3excluzone/indoors/medrsr/lab)
 "aIR" = (
 /obj/structure/sink{
 	dir = 8;
@@ -1119,10 +1127,6 @@
 /obj/item/storage/fancy/cigar,
 /turf/open/floor/carpet/edge2,
 /area/turkenden3excluzone/indoors/liquorstore)
-"btN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/s)
 "bvw" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -1207,10 +1211,6 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/westresidencies)
-"bAM" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/e)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -1908,6 +1908,10 @@
 "cqK" = (
 /turf/closed/wall/mainship/white,
 /area/turkenden3excluzone/indoors/medrsr/operatingtheatre)
+"cqY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/e)
 "cro" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -2576,6 +2580,10 @@
 	},
 /turf/open/floor/wood,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/commandpost)
+"dgF" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/west)
 "dhQ" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -2883,10 +2891,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/reqcargo)
-"dAL" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/resin_hard,
-/area/turkenden3excluzone/indoors/caves/e)
 "dAZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -2899,6 +2903,13 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roadse)
+"dBL" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/n)
 "dCk" = (
 /obj/structure/flora/desert/grass/heavy,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -3317,13 +3328,6 @@
 "eaF" = (
 /turf/closed/wall/mainship/white,
 /area/turkenden3excluzone/indoors/medrsr/jointfac)
-"eaO" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/se)
 "ebK" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -3458,6 +3462,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/tcomms,
 /area/turkenden3excluzone/indoors/serverbuilding/servstore)
+"eif" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/n)
 "eis" = (
 /obj/structure/table/reinforced,
 /obj/structure/paper_bin{
@@ -4106,10 +4114,6 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/turkenden3excluzone/indoors/serverbuilding/servstore)
-"eTU" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/ne)
 "eTW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/chapel{
@@ -4516,15 +4520,15 @@
 	color = "#969ba0"
 	},
 /area/turkenden3excluzone/indoors/mosque/halls)
-"fvj" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/s)
 "fvu" = (
 /obj/structure/table/wood,
 /obj/machinery/computer3/laptop,
 /turf/open/floor/urban/carpet/carpetfadedred,
 /area/turkenden3excluzone/indoors/reqcargo/seresidencies)
+"fvK" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/west)
 "fwc" = (
 /obj/structure/largecrate/random/case,
 /turf/open/floor/mainship/cargo,
@@ -4630,6 +4634,10 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/turkenden3excluzone/indoors/medrsr/rsrdorms)
+"fEd" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "fEr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1,
 /turf/open/floor/prison,
@@ -5093,10 +5101,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/medrsrgrounds)
-"giL" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/nw)
 "giM" = (
 /obj/machinery/conveyor{
 	id = "lower_garbage"
@@ -5189,6 +5193,11 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/indoors/swresidencies)
+"gqU" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/west)
 "grv" = (
 /obj/structure/flora/desert/grass/heavy,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -5226,10 +5235,6 @@
 	name = "reinforced metal wall"
 	},
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks1)
-"gtZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/se)
 "guF" = (
 /obj/structure/bed/chair/sofa/left{
 	dir = 8
@@ -5281,10 +5286,6 @@
 /obj/effect/landmark/patrol_point/tgmc_11,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/shuttle/drop1/lz1)
-"gxq" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/c)
 "gyq" = (
 /turf/closed/wall/r_wall/chigusa{
 	name = "reinforced metal wall"
@@ -5319,12 +5320,6 @@
 "gBR" = (
 /turf/closed/wall/mainship/white,
 /area/turkenden3excluzone/indoors/medrsr/chemistry)
-"gBX" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/turf/open/floor/cult,
-/area/turkenden3excluzone/indoors/caves/cult)
 "gCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/tile/lightred/full,
@@ -5391,10 +5386,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/medrsrgrounds)
-"gFG" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/resin_hard,
-/area/turkenden3excluzone/indoors/caves/n)
 "gFO" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/wood,
@@ -5577,6 +5568,13 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/desertw)
+"gZI" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/se)
 "hab" = (
 /turf/closed/wall/variable/adobe,
 /area/turkenden3excluzone/indoors/southouthouse)
@@ -5779,13 +5777,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/turkenden3excluzone/indoors/miningshack)
-"hrT" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/n)
 "hsA" = (
 /obj/structure/rack,
 /turf/open/floor/mainship/sterile/purple,
@@ -6315,6 +6306,7 @@
 /area/turkenden3excluzone/indoors/reqcargo/lobby)
 "igW" = (
 /obj/structure/table/mainship,
+/obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/urban_wood,
 /area/turkenden3excluzone/indoors/landing_zone_1/lz1_console{
 	icon_state = "t3ene_lz2"
@@ -6679,6 +6671,10 @@
 /obj/effect/spawner/random/machinery/random_broken_computer/intel,
 /turf/open/floor/mainship/mono,
 /area/turkenden3excluzone/indoors/miningfacility)
+"izj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/c)
 "iAI" = (
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/urban/carpet/carpetbeige,
@@ -6884,6 +6880,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/indoors/producemarket)
+"iMN" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/s)
 "iMP" = (
 /turf/closed/mineral/smooth/desertdamrockwall,
 /area/turkenden3excluzone/outdoors/landing_zone_2)
@@ -7217,13 +7217,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/westresidencies)
-"jjc" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/c)
 "jkB" = (
 /obj/machinery/door/window/secure{
 	dir = 2;
@@ -7241,6 +7234,11 @@
 	dir = 1
 	},
 /area/turkenden3excluzone/indoors/medrsr/lab)
+"jlW" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "jma" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer1{
 	dir = 4
@@ -7322,6 +7320,10 @@
 /obj/item/book,
 /turf/open/floor/mainship/mono,
 /area/turkenden3excluzone/indoors/miningfacility/fmquarters)
+"jpz" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/n)
 "jpY" = (
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/sresidencies)
@@ -7540,10 +7542,6 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roads)
-"jFt" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/se)
 "jFC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7797,10 +7795,6 @@
 /obj/structure/kitchenspike,
 /turf/open/floor/freezer,
 /area/turkenden3excluzone/indoors/serverbuilding/catering)
-"jVZ" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/sw)
 "jWn" = (
 /obj/structure/bed/bedroll,
 /obj/item/bedsheet/brown,
@@ -8032,10 +8026,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/secpoint)
-"knM" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/ne)
 "knN" = (
 /obj/structure/window/framed/chigusa{
 	color = "#8c6946"
@@ -8139,6 +8129,10 @@
 /obj/structure/cable,
 /turf/open/floor/urban/carpet/carpetred,
 /area/turkenden3excluzone/indoors/medrsr/seceast)
+"kwo" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/ne)
 "kwL" = (
 /obj/structure/flora/drought/grass,
 /obj/structure/prop/urban/vehicles/large/armored_trucks/nt_security/truck_1{
@@ -8631,6 +8625,10 @@
 	},
 /turf/open/floor/wood,
 /area/turkenden3excluzone/indoors/nwouthouses)
+"lac" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/resin_hard,
+/area/turkenden3excluzone/indoors/caves/e)
 "lbn" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
@@ -8716,6 +8714,10 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roadse)
+"lik" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/resin_hard,
+/area/turkenden3excluzone/indoors/caves/n)
 "liC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -8830,10 +8832,6 @@
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/campaign/tgmc_airfield/outside/desert/west)
-"los" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/e)
 "loQ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 8
@@ -8859,6 +8857,10 @@
 "lqh" = (
 /turf/open/floor/urban/carpet/carpetbeigedeco,
 /area/turkenden3excluzone/indoors/nresidencies)
+"lqp" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "lqt" = (
 /obj/structure/table/wood,
 /turf/open/floor/urban/carpet/carpetbeigedeco,
@@ -9143,6 +9145,10 @@
 	name = "reinforced metal wall"
 	},
 /area/turkenden3excluzone/indoors/militaryoutpost/fieldhospital/surgery)
+"lKs" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/se)
 "lKN" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/item/reagent_containers/food/snacks/meat,
@@ -9375,6 +9381,13 @@
 	dir = 4
 	},
 /area/turkenden3excluzone/indoors/medrsr/lab)
+"mbW" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "mcE" = (
 /obj/structure/sign/chemistry{
 	dir = 8
@@ -9962,12 +9975,6 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roadn)
-"mHp" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/turf/open/floor/plating/ground/desertdam/asphalt/tile,
-/area/turkenden3excluzone/indoors/nresidencies)
 "mHq" = (
 /obj/effect/ai_node{
 	pixel_x = 1
@@ -10246,6 +10253,13 @@
 	},
 /turf/open/floor/plating,
 /area/turkenden3excluzone/indoors/medrsr/generators)
+"mYF" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/c)
 "mYL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light/mainship{
@@ -10378,6 +10392,10 @@
 	},
 /turf/open/floor/mainship/floor,
 /area/turkenden3excluzone/indoors/nwgreenhouse)
+"niK" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/n)
 "niZ" = (
 /obj/structure/table/wood,
 /obj/item/tool/kitchen/knife{
@@ -10402,10 +10420,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/indoors/farmhouse)
-"njZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/e)
 "nkc" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -10444,10 +10458,6 @@
 "nlS" = (
 /turf/open/floor/mainship/floor,
 /area/turkenden3excluzone/indoors/nwgreenhouse)
-"nmu" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/nw)
 "nnk" = (
 /obj/structure/platform{
 	dir = 4
@@ -10914,6 +10924,11 @@
 	dir = 4
 	},
 /area/turkenden3excluzone/indoors/miningfacility)
+"nOA" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "nOP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -11713,10 +11728,6 @@
 	dir = 4
 	},
 /area/turkenden3excluzone/indoors/miningfacility)
-"oHF" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/s)
 "oHS" = (
 /obj/machinery/chem_master,
 /turf/open/floor/tile/bar,
@@ -11796,6 +11807,10 @@
 	},
 /turf/open/floor/prison,
 /area/turkenden3excluzone/indoors/serverbuilding/mainoffices)
+"oOo" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/ne)
 "oOy" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/simple/green/hidden{
@@ -12056,6 +12071,10 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roads)
+"pdA" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/sw)
 "pdE" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -12139,10 +12158,6 @@
 /obj/item/reagent_containers/cup/glass/coffee,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/serverbuilding/management)
-"pjY" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/west)
 "pkw" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -12341,13 +12356,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/turkenden3excluzone/indoors/reqcargo/reqmaints)
-"ptV" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/s)
 "ptY" = (
 /obj/structure/bed/chair/sofa/right{
 	dir = 8
@@ -12373,11 +12381,6 @@
 	dir = 4
 	},
 /area/turkenden3excluzone/indoors/medrsr/jointfac)
-"pvh" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/e)
 "pvi" = (
 /turf/closed/wall/r_wall/chigusa{
 	name = "reinforced metal wall";
@@ -12428,10 +12431,6 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/nmilitaryoutpost/road)
-"pxa" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/se)
 "pxi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12478,11 +12477,6 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/medrsrgrounds)
-"pyG" = (
-/obj/effect/landmark/xeno_tunnel_spawn,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/nw)
 "pyW" = (
 /obj/effect/spawner/random/misc/structure/large/car{
 	dir = 8;
@@ -12502,6 +12496,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/urban/carpet/carpetred,
 /area/turkenden3excluzone/indoors/medrsr/seceast)
+"pzs" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/se)
 "pzu" = (
 /obj/machinery/door/airlock/mainship/security{
 	dir = 8;
@@ -12690,6 +12688,10 @@
 	dir = 1
 	},
 /area/turkenden3excluzone/indoors/reqcargo)
+"pLS" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "pLZ" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -12780,10 +12782,6 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/turkenden3excluzone/indoors/serverbuilding/southhall)
-"pQY" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/se)
 "pQZ" = (
 /obj/effect/ai_node{
 	pixel_x = 1
@@ -13422,6 +13420,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/turkenden3excluzone/indoors/serverbuilding/driveinsouth)
+"qGJ" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "qGY" = (
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -13529,6 +13531,13 @@
 /obj/item/weapon/gun/rifle/icc_battlecarbine,
 /turf/open/floor/urban_wood,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks3)
+"qOK" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "qPs" = (
 /obj/structure/flora/desert/grass/heavy,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -13553,6 +13562,12 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roadnw)
+"qRs" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/turkenden3excluzone/indoors/nresidencies)
 "qRz" = (
 /obj/structure/flora/drought/grass,
 /obj/structure/flora/desert/grass/heavy,
@@ -13705,10 +13720,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/turkenden3excluzone/indoors/militaryoutpost/fieldhospital/surgery)
-"raW" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/n)
 "raY" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -13746,6 +13757,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/mosque/ground)
+"reY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/se)
 "rfJ" = (
 /obj/structure/bed/chair,
 /turf/open/floor/mainship/sterile/side{
@@ -13834,6 +13849,10 @@
 /obj/structure/flora/desert/grass/heavy,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/deserts)
+"rlE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/nw)
 "rlS" = (
 /obj/effect/ai_node{
 	pixel_x = 1
@@ -13878,10 +13897,6 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/serverbuilding/groundsw)
-"rpA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/s)
 "rpG" = (
 /turf/closed/wall/variable/adobe,
 /area/turkenden3excluzone/indoors/nwouthouses)
@@ -14357,11 +14372,6 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/desertdam/cave/inner_cave,
 /area/turkenden3excluzone/indoors/caves/n)
-"rXs" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/west)
 "rXF" = (
 /obj/structure/barricade/wooden{
 	max_integrity = 25;
@@ -14376,10 +14386,6 @@
 	},
 /turf/open/floor/urban/carpet,
 /area/turkenden3excluzone/indoors/miningfacility/secpost)
-"rYM" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/n)
 "rZE" = (
 /obj/structure/bed/bedroll,
 /obj/item/bedsheet/brown,
@@ -15072,10 +15078,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/turkenden3excluzone/indoors/swresidencies)
-"sMl" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/sw)
 "sMu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -15574,6 +15576,10 @@
 /obj/machinery/light/mainship,
 /turf/open/floor/urban/wood/redwood,
 /area/turkenden3excluzone/indoors/diner)
+"trK" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/sw)
 "trR" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -15710,13 +15716,6 @@
 "tCf" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/turkenden3excluzone/indoors/militaryoutpost/fieldhospital/mo)
-"tCj" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/nw)
 "tCs" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -16072,6 +16071,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/turkenden3excluzone/indoors/reqcargo/reqrigstorage)
+"uew" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/nw)
 "ueG" = (
 /turf/open/floor/plating/ground/dirt2{
 	color = "#ffe1b9"
@@ -16124,10 +16127,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/turkenden3excluzone/indoors/reqcargo)
-"uiI" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/e)
 "uiJ" = (
 /obj/structure/table/wood,
 /obj/item/tool/candle,
@@ -16521,14 +16520,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/indoors/sresidencies)
-"uDH" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/west)
-"uDJ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall,
-/area/turkenden3excluzone/indoors/caves/n)
 "uEa" = (
 /obj/machinery/computer/pod/old{
 	name = "Register"
@@ -16917,6 +16908,10 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/landing_zone_2)
+"vbG" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/sw)
 "vbQ" = (
 /obj/structure/table/reinforced/prison{
 	color = "#6b675e"
@@ -17026,6 +17021,10 @@
 	},
 /turf/open/floor/tile/lightred/full,
 /area/turkenden3excluzone/indoors/medrsr/secwest)
+"viA" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/se)
 "viE" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	name = "\improper Server Workplace Rooms"
@@ -17073,6 +17072,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/turkenden3excluzone/indoors/serverbuilding/gensroomn)
+"vml" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/s)
 "vmB" = (
 /turf/open/floor/mainship/sterile/purple/corner{
 	dir = 4
@@ -17232,6 +17235,10 @@
 /obj/structure/window/framed/chigusa,
 /turf/open/floor/prison,
 /area/turkenden3excluzone/indoors/serverbuilding/breakroom)
+"vtV" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/e)
 "vuw" = (
 /obj/structure/filingcabinet/nondense{
 	pixel_x = 8;
@@ -17507,6 +17514,10 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/mainship/mono,
 /area/turkenden3excluzone/indoors/miningfacility/fmquarters)
+"vOE" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/s)
 "vPj" = (
 /obj/structure/transmitter/colony_net/auto_id{
 	dir = 4;
@@ -18179,13 +18190,16 @@
 /obj/structure/cable,
 /turf/open/floor/urban/carpet/carpetred,
 /area/turkenden3excluzone/indoors/serverbuilding/secpost)
-"wGc" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/n)
 "wGI" = (
 /turf/open/floor/kutjevo/fake_wood,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks3)
+"wGL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/s)
 "wHb" = (
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/desertn)
@@ -18401,13 +18415,6 @@
 	},
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks1)
-"wVG" = (
-/obj/effect/ai_node{
-	pixel_x = 1
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/e)
 "wVT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18415,6 +18422,12 @@
 	},
 /turf/open/floor/mainship/sterile/dark,
 /area/turkenden3excluzone/indoors/medrsr/jointfac)
+"wWa" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/turf/open/floor/cult,
+/area/turkenden3excluzone/indoors/caves/cult)
 "wWw" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/mainship/sterile/side{
@@ -18666,10 +18679,6 @@
 "xpt" = (
 /turf/open/floor/prison,
 /area/turkenden3excluzone/indoors/serverbuilding/breakroom)
-"xpv" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/nw)
 "xpI" = (
 /obj/structure/platform{
 	dir = 6
@@ -18963,10 +18972,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/turkenden3excluzone/indoors/westresidencies)
-"xII" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
-/area/turkenden3excluzone/indoors/caves/sw)
 "xJd" = (
 /obj/structure/window/framed/chigusa{
 	color = "#8c6946"
@@ -19311,6 +19316,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/outdoors/mosque/paths)
+"ydz" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/n)
 "ydG" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -19434,10 +19443,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/dark,
 /area/turkenden3excluzone/indoors/serverbuilding/lobbysouth)
-"ylk" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
-/area/turkenden3excluzone/indoors/caves/nw)
 
 (1,1,1) = {"
 cwF
@@ -32989,12 +32994,12 @@ gFT
 jvB
 mDu
 mDu
-rXs
+gqU
 pZI
 pZI
 pZI
 pZI
-rXs
+gqU
 mDu
 jvB
 jvB
@@ -33643,7 +33648,7 @@ jvB
 jvB
 bKL
 bKL
-pjY
+dgF
 bKL
 jvB
 mDu
@@ -34749,7 +34754,7 @@ svp
 vMZ
 ofY
 dTb
-gBX
+wWa
 svp
 ofY
 dTb
@@ -34960,7 +34965,7 @@ jvB
 jvB
 aEj
 plj
-gBX
+wWa
 dTb
 dTb
 dTb
@@ -34974,7 +34979,7 @@ dTb
 dTb
 dTb
 dTb
-gBX
+wWa
 dTb
 plj
 vLL
@@ -35397,14 +35402,14 @@ plj
 dTb
 dTb
 dTb
-gBX
+wWa
 dTb
 dTb
 gzT
 dTb
 uST
 dTb
-gBX
+wWa
 dTb
 dTb
 dTb
@@ -35574,15 +35579,15 @@ gFT
 gFT
 gFT
 gFT
-nmu
-ylk
-nmu
-nmu
-nmu
-pyG
-giL
-nmu
-nmu
+rlE
+uew
+rlE
+rlE
+rlE
+nOA
+fEd
+rlE
+rlE
 amv
 amv
 gFT
@@ -35791,7 +35796,7 @@ gFT
 gFT
 gFT
 amv
-ylk
+uew
 gFT
 gFT
 drk
@@ -35799,7 +35804,7 @@ drk
 drk
 drk
 drk
-nmu
+rlE
 gFT
 gFT
 amv
@@ -36008,7 +36013,7 @@ gFT
 amv
 amv
 amv
-nmu
+rlE
 gFT
 drk
 drk
@@ -36016,7 +36021,7 @@ drk
 dry
 drk
 drk
-nmu
+rlE
 gFT
 gFT
 gFT
@@ -36047,11 +36052,11 @@ aEj
 plj
 plj
 plj
-gBX
+wWa
 dTb
 dTb
 dTb
-gBX
+wWa
 dEP
 caS
 dTb
@@ -36059,7 +36064,7 @@ dTb
 dTb
 dTb
 dTb
-gBX
+wWa
 plj
 plj
 bMw
@@ -36225,15 +36230,15 @@ amv
 amv
 gFT
 gFT
-nmu
+rlE
 drk
 drk
 drk
 drk
-xpv
+pLS
 drk
 gFT
-nmu
+rlE
 gFT
 gFT
 gFT
@@ -36442,7 +36447,7 @@ amv
 gFT
 gFT
 gFT
-giL
+fEd
 drk
 drk
 drk
@@ -36450,7 +36455,7 @@ nrf
 drk
 drk
 drk
-nmu
+rlE
 gFT
 gFT
 gFT
@@ -36488,7 +36493,7 @@ plj
 dTb
 dTb
 dTb
-gBX
+wWa
 plj
 plj
 jvB
@@ -36659,7 +36664,7 @@ amv
 gFT
 gFT
 gFT
-giL
+fEd
 drk
 drk
 drk
@@ -36667,7 +36672,7 @@ drk
 drk
 drk
 drk
-giL
+fEd
 gFT
 gFT
 drk
@@ -36876,7 +36881,7 @@ amv
 amv
 gFT
 gFT
-nmu
+rlE
 drk
 drk
 drk
@@ -36884,7 +36889,7 @@ drk
 drk
 drk
 drk
-giL
+fEd
 drk
 drk
 drk
@@ -37093,7 +37098,7 @@ gFT
 amv
 gFT
 gFT
-nmu
+rlE
 drk
 drk
 drk
@@ -37101,7 +37106,7 @@ drk
 drk
 drk
 drk
-giL
+fEd
 drk
 drk
 drk
@@ -37310,15 +37315,15 @@ gFT
 amv
 amv
 gFT
-nmu
-nmu
-giL
-giL
-nmu
-giL
-nmu
-giL
-tCj
+rlE
+rlE
+fEd
+fEd
+rlE
+fEd
+rlE
+fEd
+qOK
 drk
 gFT
 drk
@@ -37555,7 +37560,7 @@ mDu
 bKL
 bKL
 bKL
-pjY
+dgF
 bKL
 bKL
 pZI
@@ -37768,7 +37773,7 @@ jvB
 jvB
 aEj
 aEj
-uDH
+fvK
 bKL
 bKL
 bKL
@@ -37985,7 +37990,7 @@ aEj
 aEj
 aEj
 jvB
-uDH
+fvK
 aEj
 bKL
 bKL
@@ -38421,10 +38426,10 @@ nsM
 nsM
 nAX
 mDu
-uDH
-uDH
-uDH
-uDH
+fvK
+fvK
+fvK
+fvK
 mDu
 mDu
 jvB
@@ -38453,15 +38458,15 @@ vLL
 vLL
 bMw
 bMw
-sMl
-sMl
-sMl
-sMl
-sMl
-sMl
-sMl
-sMl
-sMl
+vbG
+vbG
+vbG
+vbG
+vbG
+vbG
+vbG
+vbG
+vbG
 vLL
 vLL
 vLL
@@ -38670,7 +38675,7 @@ vLL
 bMw
 bMw
 vLL
-sMl
+vbG
 vLL
 vLL
 vLL
@@ -38678,7 +38683,7 @@ drz
 drz
 vLL
 drz
-xII
+trK
 vLL
 vLL
 vLL
@@ -38887,7 +38892,7 @@ bMw
 bMw
 vLL
 vLL
-sMl
+vbG
 vLL
 tzY
 drz
@@ -38895,7 +38900,7 @@ drz
 drz
 drz
 drz
-xII
+trK
 drz
 vLL
 vLL
@@ -39104,15 +39109,15 @@ vLL
 vLL
 vLL
 vLL
-sMl
+vbG
 vLL
 drz
 noi
 drz
 drz
-jVZ
+pdA
 drz
-xII
+trK
 drz
 drz
 oVx
@@ -39321,7 +39326,7 @@ drz
 vLL
 vLL
 vLL
-sMl
+vbG
 drz
 drz
 drz
@@ -39329,7 +39334,7 @@ drz
 drz
 drz
 drz
-xII
+trK
 rqc
 drz
 vLL
@@ -39538,7 +39543,7 @@ cAd
 cAd
 cAd
 jIE
-rpA
+vOE
 cAd
 cAd
 cAd
@@ -39546,7 +39551,7 @@ cAd
 cAd
 cAd
 cAd
-rpA
+vOE
 cAd
 cAd
 cAd
@@ -39755,7 +39760,7 @@ jIE
 cAd
 cAd
 cAd
-rpA
+vOE
 cAd
 cAd
 jIE
@@ -39763,7 +39768,7 @@ cAd
 cAd
 cAd
 cAd
-rpA
+vOE
 cAd
 cAd
 cAd
@@ -39972,15 +39977,15 @@ cAd
 cAd
 jIE
 cAd
-btN
-btN
-rpA
-rpA
-btN
-btN
-rpA
-rpA
-btN
+vml
+vml
+vOE
+vOE
+vml
+vml
+vOE
+vOE
+vml
 cAd
 cAd
 cAd
@@ -41216,16 +41221,16 @@ jcM
 jcM
 jcM
 jcM
-uDJ
-uDJ
-uDJ
-gFG
-gFG
-gFG
-gFG
-uDJ
-uDJ
-uDJ
+eif
+eif
+eif
+lik
+lik
+lik
+lik
+eif
+eif
+eif
 jcM
 pHo
 aoU
@@ -41433,7 +41438,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 jcM
 pHo
 pHo
@@ -41442,7 +41447,7 @@ aoU
 pHo
 pHo
 jcM
-uDJ
+eif
 pHo
 pHo
 aoU
@@ -41650,7 +41655,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 pHo
 pHo
 aoU
@@ -41659,7 +41664,7 @@ aoU
 aoU
 pHo
 pHo
-uDJ
+eif
 pHo
 aoU
 aoU
@@ -41867,16 +41872,16 @@ jcM
 jcM
 jcM
 jcM
-gFG
+lik
 pHo
 aoU
 aoU
 aoU
-rYM
+jpz
 dUK
 aoU
 pHo
-gFG
+lik
 pHo
 aoU
 aoU
@@ -41897,7 +41902,7 @@ eWO
 dRu
 eWO
 eWO
-dIG
+eWO
 rtU
 rtU
 mGU
@@ -42084,7 +42089,7 @@ jcM
 jcM
 jcM
 jcM
-gFG
+lik
 aoU
 aoU
 aoU
@@ -42093,7 +42098,7 @@ aoU
 the
 aoU
 aoU
-raW
+ydz
 aoU
 aoU
 dUK
@@ -42301,7 +42306,7 @@ jcM
 jcM
 jcM
 jcM
-gFG
+lik
 pHo
 aoU
 dUK
@@ -42310,7 +42315,7 @@ aoU
 aoU
 aoU
 dUK
-raW
+ydz
 aoU
 aoU
 aoU
@@ -42518,7 +42523,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 pHo
 pHo
 aoU
@@ -42527,7 +42532,7 @@ aoU
 aoU
 aoU
 aoU
-raW
+ydz
 aoU
 mOG
 aoU
@@ -42545,7 +42550,7 @@ rtU
 rtU
 vmU
 rtU
-aPG
+eWO
 eWO
 eWO
 eWO
@@ -42587,13 +42592,13 @@ cAd
 wXe
 wXe
 wXe
-btN
-fvj
-fvj
-fvj
-fvj
-fvj
-fvj
+vml
+azv
+azv
+azv
+azv
+azv
+azv
 wXe
 wXe
 oEa
@@ -42735,7 +42740,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 jcM
 pHo
 pHo
@@ -42744,7 +42749,7 @@ aoU
 aoU
 pHo
 pHo
-gFG
+lik
 aoU
 aoU
 aoU
@@ -42804,13 +42809,13 @@ cAd
 cAd
 wXe
 wXe
-rpA
+vOE
 cAd
 cAd
 cAd
 cAd
 cAd
-fvj
+azv
 oEa
 oEa
 oEa
@@ -42952,16 +42957,16 @@ jcM
 jcM
 jcM
 jcM
-uDJ
-uDJ
-uDJ
-gFG
-gFG
-gFG
-gFG
-gFG
-gFG
-hrT
+eif
+eif
+eif
+lik
+lik
+lik
+lik
+lik
+lik
+dBL
 aoU
 aoU
 pHo
@@ -43021,13 +43026,13 @@ cAd
 cAd
 cAd
 cAd
-rpA
+vOE
 cAd
 cAd
 cAd
-oHF
+iMN
 cAd
-fvj
+azv
 wXe
 wXe
 wXe
@@ -43238,13 +43243,13 @@ jIE
 cAd
 cAd
 cAd
-ptV
+wGL
 cAd
 cAd
 cAd
 cAd
 cAd
-fvj
+azv
 wXe
 wXe
 wXe
@@ -43275,7 +43280,7 @@ bBt
 eVp
 hsX
 moe
-pUi
+moe
 oBu
 oBu
 oBu
@@ -43455,13 +43460,13 @@ cAd
 cAd
 jIE
 cAd
-rpA
+vOE
 cAd
 cAd
 cAd
 cAd
 cAd
-fvj
+azv
 wXe
 wXe
 wXe
@@ -43492,8 +43497,8 @@ tNv
 hMu
 slA
 aQs
-pUi
-pUi
+moe
+moe
 oBu
 oBu
 oBu
@@ -43651,7 +43656,7 @@ mGU
 oOk
 eWO
 eWO
-jjc
+mYF
 eWO
 jkP
 eWO
@@ -43672,13 +43677,13 @@ cAd
 cAd
 cAd
 cAd
-rpA
+vOE
 cAd
 cAd
 cAd
 cAd
 cAd
-fvj
+azv
 wXe
 wXe
 cAd
@@ -43710,8 +43715,8 @@ uuz
 tWB
 slA
 jTe
-pUi
-pUi
+moe
+moe
 oBu
 oBu
 oBu
@@ -43889,13 +43894,13 @@ cAd
 cAd
 dNL
 cAd
-rpA
-rpA
-ptV
-rpA
-rpA
-rpA
-fvj
+vOE
+vOE
+wGL
+vOE
+vOE
+vOE
+azv
 wXe
 wXe
 cAd
@@ -44134,7 +44139,7 @@ oEa
 iHW
 igr
 oBu
-moe
+aHK
 kKs
 tFl
 jZD
@@ -44146,7 +44151,7 @@ tWB
 lBZ
 slA
 jTe
-moe
+aHK
 oBu
 oBu
 pWm
@@ -44238,14 +44243,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
-uDJ
-uDJ
-uDJ
-uDJ
-uDJ
-uDJ
-wGc
+eif
+eif
+eif
+eif
+eif
+eif
+eif
+niK
 jcM
 jcM
 jcM
@@ -44286,7 +44291,7 @@ eWO
 eWO
 eWO
 eWO
-aPG
+eWO
 pbb
 rtU
 rtU
@@ -44455,14 +44460,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 jcM
 jcM
 mvE
 jcM
 jcM
 jcM
-wGc
+niK
 skq
 jcM
 jcM
@@ -44580,7 +44585,7 @@ tWB
 tWB
 aZt
 lbS
-moe
+aHK
 oBu
 oBu
 gXq
@@ -44672,14 +44677,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 jcM
 aoU
 aoU
 jcM
 jcM
 jcM
-uDJ
+eif
 skq
 jcM
 jcM
@@ -44785,8 +44790,8 @@ iHW
 hDa
 igr
 oBu
-pUi
-pUi
+moe
+moe
 noy
 uAO
 tFl
@@ -44889,14 +44894,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 aoU
 aoU
 aoU
-rYM
+jpz
 aoU
 jcM
-uDJ
+eif
 skq
 jcM
 jcM
@@ -45003,8 +45008,8 @@ iHW
 oBu
 rQJ
 oBu
-pUi
-pUi
+moe
+moe
 noy
 uAO
 vqX
@@ -45012,8 +45017,8 @@ tFl
 tWB
 aZt
 lbS
-pUi
-pUi
+moe
+moe
 oBu
 oBu
 oBu
@@ -45106,14 +45111,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 aoU
 aoU
 aoU
 aoU
 dUK
 jcM
-uDJ
+eif
 skq
 jcM
 jcM
@@ -45221,15 +45226,15 @@ oBu
 oBu
 oBu
 oBu
-pUi
-pUi
+moe
+moe
 cRG
 uAO
 lFy
 aZt
 lry
-pUi
-pUi
+moe
+moe
 oBu
 oBu
 rQJ
@@ -45323,14 +45328,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 aoU
 aoU
 aoU
 mOG
 aoU
 aoU
-uDJ
+eif
 jcM
 jcM
 jcM
@@ -45439,13 +45444,13 @@ oBu
 oBu
 oBu
 oBu
-pUi
+moe
 moe
 xfN
 jmX
 mbO
 moe
-pUi
+moe
 oBu
 igr
 oBu
@@ -45540,14 +45545,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 jcM
 aoU
 dUK
 aoU
 aoU
 aoU
-uDJ
+eif
 jcM
 jcM
 jcM
@@ -45658,9 +45663,9 @@ oBu
 igr
 oBu
 moe
-moe
+aHK
 gte
-moe
+aHK
 moe
 oBu
 oBu
@@ -45757,14 +45762,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
+eif
 jcM
 jcM
 aoU
 aoU
 jcM
 jcM
-uDJ
+eif
 jcM
 jcM
 aoU
@@ -45974,14 +45979,14 @@ aoU
 skq
 jcM
 jcM
-uDJ
-uDJ
-uDJ
-raW
-raW
-raW
-uDJ
-uDJ
+eif
+eif
+eif
+ydz
+ydz
+ydz
+eif
+eif
 jcM
 jcM
 aoU
@@ -46206,20 +46211,20 @@ aoU
 jcM
 jcM
 jcM
-uDJ
-uDJ
-uDJ
-raW
-raW
-raW
-raW
-raW
-raW
-uDJ
-uDJ
+eif
+eif
+eif
+ydz
+ydz
+ydz
+ydz
+ydz
+ydz
+eif
+eif
 jcM
 skq
-gFG
+lik
 jkP
 jkP
 jkP
@@ -46423,7 +46428,7 @@ aoU
 jcM
 jcM
 jcM
-uDJ
+eif
 jcM
 aoU
 aoU
@@ -46433,10 +46438,10 @@ aoU
 aoU
 aoU
 aoU
-uDJ
+eif
 jcM
 skq
-gFG
+lik
 eWO
 eWO
 eWO
@@ -46640,20 +46645,20 @@ mOG
 jcM
 jcM
 jcM
-uDJ
+eif
 aoU
 aoU
 dUK
 aoU
 aoU
-rYM
+jpz
 aoU
 dUK
 aoU
-uDJ
+eif
 jcM
 skq
-gFG
+lik
 eWO
 eWO
 eWO
@@ -46857,7 +46862,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 aoU
 aoU
 aoU
@@ -46867,10 +46872,10 @@ aoU
 aoU
 aoU
 skq
-wGc
+niK
 skq
 skq
-gFG
+lik
 eWO
 rDO
 eWO
@@ -47074,7 +47079,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 jcM
 aoU
 aoU
@@ -47084,10 +47089,10 @@ aoU
 aoU
 aoU
 skq
-uDJ
+eif
 jcM
 skq
-gFG
+lik
 rtU
 eWO
 eWO
@@ -47114,7 +47119,7 @@ mGU
 mGU
 mGU
 faA
-gxq
+izj
 eWO
 eWO
 eWO
@@ -47291,7 +47296,7 @@ jcM
 jcM
 jcM
 jcM
-uDJ
+eif
 skq
 skq
 aoU
@@ -47301,10 +47306,10 @@ aoU
 aoU
 aoU
 skq
-uDJ
+eif
 jcM
 skq
-wGc
+niK
 tMC
 rtU
 eWO
@@ -47331,7 +47336,7 @@ mGU
 mGU
 mGU
 mGU
-gxq
+izj
 eWO
 eWO
 eWO
@@ -47508,7 +47513,7 @@ hEW
 hEW
 hEW
 hEW
-knM
+kwo
 hEW
 vhF
 vhF
@@ -47518,10 +47523,10 @@ kUE
 kUE
 vhF
 vhF
-eTU
+oOo
 hEW
 hEW
-njZ
+vtV
 kBw
 tMC
 rtU
@@ -47548,7 +47553,7 @@ eiw
 eiw
 eiw
 mGU
-gxq
+izj
 eWO
 eWO
 eWO
@@ -47725,23 +47730,23 @@ hEW
 hEW
 hEW
 vhF
-eTU
-eTU
-eTU
-knM
-knM
-knM
-knM
-knM
-knM
-eTU
-eTU
+oOo
+oOo
+oOo
+kwo
+kwo
+kwo
+kwo
+kwo
+kwo
+oOo
+oOo
 hEW
 hEW
-uiI
-njZ
-njZ
-dAL
+cqY
+vtV
+vtV
+lac
 oOk
 oOk
 oOk
@@ -47765,10 +47770,10 @@ eWO
 mGU
 eiw
 mGU
-gxq
-gxq
-gxq
-gxq
+izj
+izj
+izj
+izj
 eiw
 eiw
 eiw
@@ -47970,7 +47975,7 @@ ifU
 ifU
 ifU
 ifU
-uiI
+cqY
 cDm
 ifU
 ifU
@@ -47980,7 +47985,7 @@ ifU
 ifU
 ifU
 lAw
-uiI
+cqY
 cDm
 cDm
 cDm
@@ -48187,7 +48192,7 @@ fIV
 ifU
 ifU
 fIV
-bAM
+lqp
 ifU
 ifU
 ifU
@@ -48197,7 +48202,7 @@ ifU
 ifU
 ifU
 ifU
-uiI
+cqY
 cDm
 cDm
 cDm
@@ -48404,17 +48409,17 @@ ifU
 ifU
 ifU
 muT
-bAM
+lqp
 ifU
 ifU
 fIV
 ifU
-los
+qGJ
 hQA
 ifU
 ifU
 muT
-uiI
+cqY
 cDm
 cDm
 kBw
@@ -48439,15 +48444,15 @@ mOw
 nOR
 nOR
 nOR
-jFt
-jFt
-pQY
-pQY
-pQY
-eaO
-pQY
-pQY
-jFt
+reY
+reY
+pzs
+pzs
+pzs
+gZI
+pzs
+pzs
+reY
 nOR
 nOR
 nOR
@@ -48621,7 +48626,7 @@ ifU
 cDm
 cDm
 ifU
-bAM
+lqp
 ifU
 ifU
 ifU
@@ -48631,7 +48636,7 @@ ifU
 ifU
 ifU
 cDm
-uiI
+cqY
 cDm
 kBw
 kBw
@@ -48656,7 +48661,7 @@ nOR
 nOR
 nOR
 edj
-pQY
+pzs
 edj
 edj
 edj
@@ -48664,7 +48669,7 @@ edj
 edj
 edj
 edj
-jFt
+reY
 nOR
 nOR
 mOw
@@ -48838,7 +48843,7 @@ cDm
 cDm
 cDm
 cDm
-bAM
+lqp
 ifU
 ifU
 ifU
@@ -48848,7 +48853,7 @@ ifU
 ifU
 cDm
 cDm
-uiI
+cqY
 cDm
 kBw
 cDm
@@ -48873,7 +48878,7 @@ nOR
 nOR
 edj
 edj
-eaO
+gZI
 edj
 hhF
 edj
@@ -48881,7 +48886,7 @@ edj
 edj
 hhF
 edj
-pQY
+pzs
 nOR
 nOR
 mOw
@@ -49055,7 +49060,7 @@ cDm
 cDm
 cDm
 cDm
-bAM
+lqp
 ifU
 ifU
 ifU
@@ -49065,7 +49070,7 @@ ifU
 cDm
 cDm
 cDm
-njZ
+vtV
 kBw
 cDm
 cDm
@@ -49090,7 +49095,7 @@ edj
 edj
 edj
 edj
-pQY
+pzs
 edj
 edj
 edj
@@ -49098,7 +49103,7 @@ edj
 edj
 edj
 edj
-pQY
+pzs
 nOR
 mOw
 mOw
@@ -49272,17 +49277,17 @@ cDm
 cDm
 cDm
 cDm
-uiI
-bAM
-pvh
-wVG
-bAM
-bAM
-uiI
-uiI
-uiI
-njZ
-njZ
+cqY
+lqp
+jlW
+mbW
+lqp
+lqp
+cqY
+cqY
+cqY
+vtV
+vtV
 cDm
 cDm
 cDm
@@ -49307,15 +49312,15 @@ edj
 edj
 edj
 edj
-pQY
+pzs
 hhF
 edj
 edj
 edj
-pxa
+viA
 edj
 edj
-pQY
+pzs
 mOw
 mOw
 nOR
@@ -49524,7 +49529,7 @@ hhF
 edj
 edj
 edj
-pQY
+pzs
 edj
 edj
 edj
@@ -49532,7 +49537,7 @@ edj
 edj
 edj
 hhF
-gtZ
+lKs
 mOw
 nOR
 nOR
@@ -49741,7 +49746,7 @@ dUr
 edj
 hhF
 nOR
-jFt
+reY
 edj
 edj
 edj
@@ -49749,7 +49754,7 @@ edj
 edj
 edj
 edj
-gtZ
+lKs
 nOR
 nOR
 nOR
@@ -49958,7 +49963,7 @@ edj
 edj
 mMb
 nOR
-jFt
+reY
 nOR
 edj
 edj
@@ -49966,7 +49971,7 @@ edj
 edj
 edj
 mOw
-gtZ
+lKs
 nOR
 nOR
 nOR
@@ -50175,7 +50180,7 @@ edj
 nOR
 nOR
 nOR
-jFt
+reY
 nOR
 edj
 edj
@@ -50183,7 +50188,7 @@ edj
 edj
 mOw
 mOw
-jFt
+reY
 nOR
 nOR
 nOR
@@ -50392,15 +50397,15 @@ nOR
 nOR
 nOR
 nOR
-jFt
-jFt
-jFt
-gtZ
-gtZ
-gtZ
-gtZ
-jFt
-jFt
+reY
+reY
+reY
+lKs
+lKs
+lKs
+lKs
+reY
+reY
 nOR
 nOR
 nOR
@@ -52033,7 +52038,7 @@ wHb
 mke
 cid
 cid
-mHp
+qRs
 cid
 cid
 ieq
@@ -52468,7 +52473,7 @@ mke
 cid
 tYf
 cid
-mHp
+qRs
 aqc
 mke
 mke
@@ -53117,7 +53122,7 @@ wHb
 wHb
 mke
 cid
-mHp
+qRs
 cid
 cid
 ieq
@@ -55505,7 +55510,7 @@ lcS
 mke
 csT
 cid
-mHp
+qRs
 jLn
 bGw
 lcS

--- a/_maps/map_files/Turkenden_3/Turkenden_3_Excluzone.dmm
+++ b/_maps/map_files/Turkenden_3/Turkenden_3_Excluzone.dmm
@@ -1119,6 +1119,10 @@
 /obj/item/storage/fancy/cigar,
 /turf/open/floor/carpet/edge2,
 /area/turkenden3excluzone/indoors/liquorstore)
+"btN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/s)
 "bvw" = (
 /obj/structure/bed/chair/wood/normal{
 	dir = 1
@@ -1203,6 +1207,10 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/westresidencies)
+"bAM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "bAQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -2875,6 +2883,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/reqcargo)
+"dAL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/resin_hard,
+/area/turkenden3excluzone/indoors/caves/e)
 "dAZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -3305,6 +3317,13 @@
 "eaF" = (
 /turf/closed/wall/mainship/white,
 /area/turkenden3excluzone/indoors/medrsr/jointfac)
+"eaO" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/se)
 "ebK" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/mars/random/cave,
@@ -4087,6 +4106,10 @@
 	},
 /turf/open/floor/mainship/tcomms,
 /area/turkenden3excluzone/indoors/serverbuilding/servstore)
+"eTU" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/ne)
 "eTW" = (
 /obj/machinery/atmospherics/pipe/simple/green/hidden,
 /turf/open/floor/tile/chapel{
@@ -4493,6 +4516,10 @@
 	color = "#969ba0"
 	},
 /area/turkenden3excluzone/indoors/mosque/halls)
+"fvj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/s)
 "fvu" = (
 /obj/structure/table/wood,
 /obj/machinery/computer3/laptop,
@@ -5066,6 +5093,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/medrsrgrounds)
+"giL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "giM" = (
 /obj/machinery/conveyor{
 	id = "lower_garbage"
@@ -5195,6 +5226,10 @@
 	name = "reinforced metal wall"
 	},
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks1)
+"gtZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/se)
 "guF" = (
 /obj/structure/bed/chair/sofa/left{
 	dir = 8
@@ -5246,6 +5281,10 @@
 /obj/effect/landmark/patrol_point/tgmc_11,
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/shuttle/drop1/lz1)
+"gxq" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/c)
 "gyq" = (
 /turf/closed/wall/r_wall/chigusa{
 	name = "reinforced metal wall"
@@ -5280,6 +5319,12 @@
 "gBR" = (
 /turf/closed/wall/mainship/white,
 /area/turkenden3excluzone/indoors/medrsr/chemistry)
+"gBX" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/turf/open/floor/cult,
+/area/turkenden3excluzone/indoors/caves/cult)
 "gCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/tile/lightred/full,
@@ -5346,6 +5391,10 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/medrsrgrounds)
+"gFG" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/resin_hard,
+/area/turkenden3excluzone/indoors/caves/n)
 "gFO" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/wood,
@@ -5730,6 +5779,13 @@
 /obj/effect/ai_node,
 /turf/open/floor/urban/carpet/carpetbeige,
 /area/turkenden3excluzone/indoors/miningshack)
+"hrT" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/n)
 "hsA" = (
 /obj/structure/rack,
 /turf/open/floor/mainship/sterile/purple,
@@ -6259,7 +6315,6 @@
 /area/turkenden3excluzone/indoors/reqcargo/lobby)
 "igW" = (
 /obj/structure/table/mainship,
-/obj/machinery/computer/shuttle/shuttle_control/dropship,
 /turf/open/floor/urban_wood,
 /area/turkenden3excluzone/indoors/landing_zone_1/lz1_console{
 	icon_state = "t3ene_lz2"
@@ -7162,6 +7217,13 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/westresidencies)
+"jjc" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/c)
 "jkB" = (
 /obj/machinery/door/window/secure{
 	dir = 2;
@@ -7478,6 +7540,10 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roads)
+"jFt" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/se)
 "jFC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -7731,6 +7797,10 @@
 /obj/structure/kitchenspike,
 /turf/open/floor/freezer,
 /area/turkenden3excluzone/indoors/serverbuilding/catering)
+"jVZ" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/sw)
 "jWn" = (
 /obj/structure/bed/bedroll,
 /obj/item/bedsheet/brown,
@@ -7962,6 +8032,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/cement_sunbleached,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/secpoint)
+"knM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/ne)
 "knN" = (
 /obj/structure/window/framed/chigusa{
 	color = "#8c6946"
@@ -8756,6 +8830,10 @@
 /obj/structure/flora/desert/grass,
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/campaign/tgmc_airfield/outside/desert/west)
+"los" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "loQ" = (
 /obj/machinery/door/airlock/multi_tile/mainship/generic{
 	dir = 8
@@ -9884,6 +9962,12 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/roadn)
+"mHp" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/turf/open/floor/plating/ground/desertdam/asphalt/tile,
+/area/turkenden3excluzone/indoors/nresidencies)
 "mHq" = (
 /obj/effect/ai_node{
 	pixel_x = 1
@@ -10318,6 +10402,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/indoors/farmhouse)
+"njZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/e)
 "nkc" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
@@ -10356,6 +10444,10 @@
 "nlS" = (
 /turf/open/floor/mainship/floor,
 /area/turkenden3excluzone/indoors/nwgreenhouse)
+"nmu" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/nw)
 "nnk" = (
 /obj/structure/platform{
 	dir = 4
@@ -11621,6 +11713,10 @@
 	dir = 4
 	},
 /area/turkenden3excluzone/indoors/miningfacility)
+"oHF" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/s)
 "oHS" = (
 /obj/machinery/chem_master,
 /turf/open/floor/tile/bar,
@@ -12043,6 +12139,10 @@
 /obj/item/reagent_containers/cup/glass/coffee,
 /turf/open/floor/urban/carpet/carpetblue,
 /area/turkenden3excluzone/indoors/serverbuilding/management)
+"pjY" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/west)
 "pkw" = (
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -12241,6 +12341,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/turkenden3excluzone/indoors/reqcargo/reqmaints)
+"ptV" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/s)
 "ptY" = (
 /obj/structure/bed/chair/sofa/right{
 	dir = 8
@@ -12266,6 +12373,11 @@
 	dir = 4
 	},
 /area/turkenden3excluzone/indoors/medrsr/jointfac)
+"pvh" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "pvi" = (
 /turf/closed/wall/r_wall/chigusa{
 	name = "reinforced metal wall";
@@ -12316,6 +12428,10 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/nmilitaryoutpost/road)
+"pxa" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/se)
 "pxi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -12362,6 +12478,11 @@
 	},
 /turf/open/floor/plating/ground/mars/random/cave,
 /area/turkenden3excluzone/outdoors/medrsrgrounds)
+"pyG" = (
+/obj/effect/landmark/xeno_tunnel_spawn,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "pyW" = (
 /obj/effect/spawner/random/misc/structure/large/car{
 	dir = 8;
@@ -12659,6 +12780,10 @@
 /obj/structure/cable,
 /turf/open/floor/prison,
 /area/turkenden3excluzone/indoors/serverbuilding/southhall)
+"pQY" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/se)
 "pQZ" = (
 /obj/effect/ai_node{
 	pixel_x = 1
@@ -13580,6 +13705,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/sterile/dark,
 /area/turkenden3excluzone/indoors/militaryoutpost/fieldhospital/surgery)
+"raW" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/n)
 "raY" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -13749,6 +13878,10 @@
 	color = "#ffe1b9"
 	},
 /area/turkenden3excluzone/outdoors/serverbuilding/groundsw)
+"rpA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/s)
 "rpG" = (
 /turf/closed/wall/variable/adobe,
 /area/turkenden3excluzone/indoors/nwouthouses)
@@ -14224,6 +14357,11 @@
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/desertdam/cave/inner_cave,
 /area/turkenden3excluzone/indoors/caves/n)
+"rXs" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/west)
 "rXF" = (
 /obj/structure/barricade/wooden{
 	max_integrity = 25;
@@ -14238,6 +14376,10 @@
 	},
 /turf/open/floor/urban/carpet,
 /area/turkenden3excluzone/indoors/miningfacility/secpost)
+"rYM" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/n)
 "rZE" = (
 /obj/structure/bed/bedroll,
 /obj/item/bedsheet/brown,
@@ -14930,6 +15072,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/turkenden3excluzone/indoors/swresidencies)
+"sMl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/sw)
 "sMu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable,
@@ -15564,6 +15710,13 @@
 "tCf" = (
 /turf/open/floor/mainship/sterile/dark,
 /area/turkenden3excluzone/indoors/militaryoutpost/fieldhospital/mo)
+"tCj" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "tCs" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -15971,6 +16124,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/turkenden3excluzone/indoors/reqcargo)
+"uiI" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/e)
 "uiJ" = (
 /obj/structure/table/wood,
 /obj/item/tool/candle,
@@ -16364,6 +16521,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt/tile,
 /area/turkenden3excluzone/indoors/sresidencies)
+"uDH" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/west)
+"uDJ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall,
+/area/turkenden3excluzone/indoors/caves/n)
 "uEa" = (
 /obj/machinery/computer/pod/old{
 	name = "Register"
@@ -18014,6 +18179,10 @@
 /obj/structure/cable,
 /turf/open/floor/urban/carpet/carpetred,
 /area/turkenden3excluzone/indoors/serverbuilding/secpost)
+"wGc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/n)
 "wGI" = (
 /turf/open/floor/kutjevo/fake_wood,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks3)
@@ -18232,6 +18401,13 @@
 	},
 /turf/open/floor/urban/tile/tilewhitecheckered,
 /area/turkenden3excluzone/indoors/nmilitaryoutpost/barracks1)
+"wVG" = (
+/obj/effect/ai_node{
+	pixel_x = 1
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/e)
 "wVT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -18490,6 +18666,10 @@
 "xpt" = (
 /turf/open/floor/prison,
 /area/turkenden3excluzone/indoors/serverbuilding/breakroom)
+"xpv" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/nw)
 "xpI" = (
 /obj/structure/platform{
 	dir = 6
@@ -18783,6 +18963,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/turkenden3excluzone/indoors/westresidencies)
+"xII" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/cave/inner_cave,
+/area/turkenden3excluzone/indoors/caves/sw)
 "xJd" = (
 /obj/structure/window/framed/chigusa{
 	color = "#8c6946"
@@ -19250,6 +19434,10 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/tile/dark,
 /area/turkenden3excluzone/indoors/serverbuilding/lobbysouth)
+"ylk" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth/desertdamrockwall/indestructible,
+/area/turkenden3excluzone/indoors/caves/nw)
 
 (1,1,1) = {"
 cwF
@@ -30427,7 +30615,7 @@ bKL
 bKL
 bKL
 bKL
-bKL
+oFG
 bKL
 bKL
 bKL
@@ -32168,7 +32356,7 @@ bKL
 jvB
 jvB
 bKL
-bKL
+oFG
 bKL
 bKL
 bKL
@@ -32799,15 +32987,15 @@ gFT
 gFT
 gFT
 jvB
-jvB
-jvB
-mLO
-bKL
-bKL
-bKL
-bKL
-mLO
-jvB
+mDu
+mDu
+rXs
+pZI
+pZI
+pZI
+pZI
+rXs
+mDu
 jvB
 jvB
 aEj
@@ -33016,37 +33204,37 @@ gFT
 gFT
 gFT
 jvB
-jvB
-jvB
-jvB
-bKL
-bKL
-bKL
-bKL
-jvB
-jvB
-jvB
-jvB
-aEj
-aEj
-jvB
-jvB
+mDu
 jvB
 jvB
 bKL
 bKL
 bKL
 bKL
+jvB
+mDu
 jvB
 jvB
 aEj
+aEj
+jvB
+jvB
+jvB
+jvB
+bKL
+bKL
+bKL
+bKL
+jvB
+jvB
+aEj
 jvB
 bKL
 bKL
 bKL
 bKL
 bKL
-bKL
+oFG
 bKL
 bKL
 bKL
@@ -33233,7 +33421,7 @@ gFT
 gFT
 gFT
 jvB
-jvB
+mDu
 jvB
 jvB
 bKL
@@ -33241,7 +33429,7 @@ bKL
 oFG
 bKL
 jvB
-jvB
+mDu
 jvB
 jvB
 jvB
@@ -33253,13 +33441,13 @@ jvB
 bKL
 bKL
 bKL
-bKL
+oFG
 jvB
 jvB
 aEj
 jvB
 bKL
-bKL
+oFG
 bKL
 bKL
 bKL
@@ -33450,15 +33638,15 @@ gFT
 drk
 drk
 jvB
-jvB
+mDu
 jvB
 jvB
 bKL
 bKL
-bKL
+pjY
 bKL
 jvB
-jvB
+mDu
 jvB
 jvB
 jvB
@@ -33484,13 +33672,13 @@ bKL
 bKL
 bKL
 bKL
-bKL
+oFG
 bKL
 vLL
 drz
 drz
 drz
-drz
+noi
 drz
 vLL
 vLL
@@ -33667,7 +33855,7 @@ nrf
 drk
 dry
 bKL
-jvB
+mDu
 bKL
 bKL
 bKL
@@ -33675,7 +33863,7 @@ bKL
 bKL
 bKL
 bKL
-jvB
+mDu
 jvB
 jvB
 jvB
@@ -33696,7 +33884,7 @@ bKL
 bKL
 bKL
 bKL
-bKL
+oFG
 bKL
 bKL
 bKL
@@ -33884,6 +34072,7 @@ drk
 drk
 drk
 bKL
+pZI
 bKL
 bKL
 bKL
@@ -33891,8 +34080,7 @@ bKL
 bKL
 bKL
 bKL
-bKL
-jvB
+mDu
 jvB
 jvB
 jvB
@@ -34101,7 +34289,7 @@ drk
 tpT
 drk
 bKL
-bKL
+pZI
 oFG
 bKL
 jvB
@@ -34109,7 +34297,7 @@ bKL
 bKL
 bKL
 bKL
-bKL
+pZI
 jvB
 jvB
 jvB
@@ -34137,7 +34325,7 @@ bKL
 bKL
 bKL
 bKL
-drz
+noi
 drz
 drz
 vLL
@@ -34318,7 +34506,7 @@ drk
 drk
 drk
 bKL
-bKL
+pZI
 mLO
 jvB
 jvB
@@ -34326,7 +34514,7 @@ jvB
 bKL
 oFG
 bKL
-bKL
+pZI
 mLO
 jvB
 oFG
@@ -34535,15 +34723,15 @@ drk
 drk
 drk
 bKL
-bKL
-jvB
-jvB
-jvB
-jvB
-bKL
-bKL
-bKL
-bKL
+pZI
+mDu
+mDu
+mDu
+mDu
+pZI
+pZI
+pZI
+pZI
 bKL
 bKL
 bKL
@@ -34561,7 +34749,7 @@ svp
 vMZ
 ofY
 dTb
-dTb
+gBX
 svp
 ofY
 dTb
@@ -34772,6 +34960,7 @@ jvB
 jvB
 aEj
 plj
+gBX
 dTb
 dTb
 dTb
@@ -34785,8 +34974,7 @@ dTb
 dTb
 dTb
 dTb
-dTb
-dTb
+gBX
 dTb
 plj
 vLL
@@ -35209,14 +35397,14 @@ plj
 dTb
 dTb
 dTb
-dTb
+gBX
 dTb
 dTb
 gzT
 dTb
 uST
 dTb
-dTb
+gBX
 dTb
 dTb
 dTb
@@ -35386,15 +35574,15 @@ gFT
 gFT
 gFT
 gFT
-gFT
-amv
-gFT
-gFT
-gFT
-fSp
-drk
-gFT
-gFT
+nmu
+ylk
+nmu
+nmu
+nmu
+pyG
+giL
+nmu
+nmu
 amv
 amv
 gFT
@@ -35603,7 +35791,7 @@ gFT
 gFT
 gFT
 amv
-amv
+ylk
 gFT
 gFT
 drk
@@ -35611,7 +35799,7 @@ drk
 drk
 drk
 drk
-gFT
+nmu
 gFT
 gFT
 amv
@@ -35820,7 +36008,7 @@ gFT
 amv
 amv
 amv
-gFT
+nmu
 gFT
 drk
 drk
@@ -35828,7 +36016,7 @@ drk
 dry
 drk
 drk
-gFT
+nmu
 gFT
 gFT
 gFT
@@ -35859,11 +36047,11 @@ aEj
 plj
 plj
 plj
+gBX
 dTb
 dTb
 dTb
-dTb
-dTb
+gBX
 dEP
 caS
 dTb
@@ -35871,7 +36059,7 @@ dTb
 dTb
 dTb
 dTb
-dTb
+gBX
 plj
 plj
 bMw
@@ -36037,15 +36225,15 @@ amv
 amv
 gFT
 gFT
+nmu
+drk
+drk
+drk
+drk
+xpv
+drk
 gFT
-drk
-drk
-drk
-drk
-drk
-drk
-gFT
-gFT
+nmu
 gFT
 gFT
 gFT
@@ -36066,7 +36254,7 @@ oFG
 bKL
 bKL
 bKL
-bKL
+oFG
 bKL
 jvB
 jvB
@@ -36254,7 +36442,7 @@ amv
 gFT
 gFT
 gFT
-drk
+giL
 drk
 drk
 drk
@@ -36262,7 +36450,7 @@ nrf
 drk
 drk
 drk
-gFT
+nmu
 gFT
 gFT
 gFT
@@ -36300,7 +36488,7 @@ plj
 dTb
 dTb
 dTb
-dTb
+gBX
 plj
 plj
 jvB
@@ -36471,6 +36659,7 @@ amv
 gFT
 gFT
 gFT
+giL
 drk
 drk
 drk
@@ -36478,8 +36667,7 @@ drk
 drk
 drk
 drk
-drk
-drk
+giL
 gFT
 gFT
 drk
@@ -36688,7 +36876,7 @@ amv
 amv
 gFT
 gFT
-gFT
+nmu
 drk
 drk
 drk
@@ -36696,7 +36884,7 @@ drk
 drk
 drk
 drk
-drk
+giL
 drk
 drk
 drk
@@ -36716,7 +36904,7 @@ jvB
 jvB
 jvB
 jvB
-jvB
+bKL
 bKL
 oFG
 bKL
@@ -36905,7 +37093,7 @@ gFT
 amv
 gFT
 gFT
-gFT
+nmu
 drk
 drk
 drk
@@ -36913,7 +37101,7 @@ drk
 drk
 drk
 drk
-drk
+giL
 drk
 drk
 drk
@@ -36929,14 +37117,14 @@ jvB
 jvB
 jvB
 jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-bKL
+mDu
+mDu
+pZI
+pZI
+pZI
+pZI
+pZI
+pZI
 bKL
 oFG
 bKL
@@ -37122,21 +37310,21 @@ gFT
 amv
 amv
 gFT
-gFT
-gFT
-drk
-drk
-gFT
-drk
-gFT
-drk
-dry
-drk
-gFT
-drk
-drk
+nmu
+nmu
+giL
+giL
+nmu
+giL
+nmu
+giL
+tCj
 drk
 gFT
+drk
+drk
+drk
+gFT
 gFT
 jvB
 jvB
@@ -37146,14 +37334,14 @@ jvB
 jvB
 jvB
 jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
+mDu
+bKL
+bKL
+bKL
+bKL
+bKL
+bKL
+pZI
 bKL
 bKL
 bKL
@@ -37363,15 +37551,15 @@ jvB
 jvB
 jvB
 jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
+mDu
+bKL
+bKL
+bKL
+pjY
+bKL
+bKL
+pZI
+bKL
 bKL
 bKL
 bKL
@@ -37580,18 +37768,18 @@ jvB
 jvB
 aEj
 aEj
-aEj
-aEj
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
-jvB
+uDH
 bKL
 bKL
 bKL
+bKL
+bKL
+bKL
+pZI
+bKL
+bKL
+bKL
+oFG
 bKL
 bKL
 bKL
@@ -37797,14 +37985,14 @@ aEj
 aEj
 aEj
 jvB
-jvB
+uDH
 aEj
-aEj
-aEj
-jvB
-jvB
-jvB
-jvB
+bKL
+bKL
+bKL
+bKL
+bKL
+pZI
 jvB
 jvB
 bKL
@@ -38014,14 +38202,14 @@ jvB
 jvB
 jvB
 jvB
-jvB
-jvB
-jvB
+mDu
 aEj
 aEj
-jvB
-jvB
-jvB
+bKL
+bKL
+bKL
+bKL
+mDu
 jvB
 jvB
 jvB
@@ -38231,14 +38419,14 @@ jvB
 nsM
 nsM
 nsM
-nsM
-jvB
-jvB
-jvB
-aEj
-aEj
-jvB
-jvB
+nAX
+mDu
+uDH
+uDH
+uDH
+uDH
+mDu
+mDu
 jvB
 jvB
 jvB
@@ -38265,15 +38453,15 @@ vLL
 vLL
 bMw
 bMw
-vLL
-vLL
-vLL
-vLL
-vLL
-vLL
-vLL
-vLL
-vLL
+sMl
+sMl
+sMl
+sMl
+sMl
+sMl
+sMl
+sMl
+sMl
 vLL
 vLL
 vLL
@@ -38482,7 +38670,7 @@ vLL
 bMw
 bMw
 vLL
-vLL
+sMl
 vLL
 vLL
 vLL
@@ -38490,7 +38678,7 @@ drz
 drz
 vLL
 drz
-drz
+xII
 vLL
 vLL
 vLL
@@ -38676,7 +38864,7 @@ jvB
 jvB
 jvB
 bKL
-bKL
+oFG
 bKL
 jvB
 jvB
@@ -38699,7 +38887,7 @@ bMw
 bMw
 vLL
 vLL
-vLL
+sMl
 vLL
 tzY
 drz
@@ -38707,7 +38895,7 @@ drz
 drz
 drz
 drz
-drz
+xII
 drz
 vLL
 vLL
@@ -38916,15 +39104,15 @@ vLL
 vLL
 vLL
 vLL
-vLL
+sMl
 vLL
 drz
 noi
 drz
 drz
+jVZ
 drz
-drz
-drz
+xII
 drz
 drz
 oVx
@@ -38936,7 +39124,7 @@ vLL
 vLL
 drz
 drz
-drz
+noi
 drz
 drz
 drz
@@ -39129,11 +39317,11 @@ eWO
 eWO
 eWO
 noi
+drz
 vLL
 vLL
 vLL
-vLL
-vLL
+sMl
 drz
 drz
 drz
@@ -39141,7 +39329,7 @@ drz
 drz
 drz
 drz
-drz
+xII
 rqc
 drz
 vLL
@@ -39346,10 +39534,11 @@ mGU
 eWO
 eWO
 eWO
-wXe
+cAd
 cAd
 cAd
 jIE
+rpA
 cAd
 cAd
 cAd
@@ -39357,8 +39546,7 @@ cAd
 cAd
 cAd
 cAd
-cAd
-cAd
+rpA
 cAd
 cAd
 cAd
@@ -39567,7 +39755,7 @@ jIE
 cAd
 cAd
 cAd
-cAd
+rpA
 cAd
 cAd
 jIE
@@ -39575,7 +39763,7 @@ cAd
 cAd
 cAd
 cAd
-cAd
+rpA
 cAd
 cAd
 cAd
@@ -39750,7 +39938,7 @@ eWO
 eWO
 eWO
 eWO
-eWO
+rDO
 eWO
 eWO
 oOk
@@ -39784,15 +39972,15 @@ cAd
 cAd
 jIE
 cAd
-wXe
-wXe
-cAd
-cAd
-wXe
-wXe
-cAd
-cAd
-wXe
+btN
+btN
+rpA
+rpA
+btN
+btN
+rpA
+rpA
+btN
 cAd
 cAd
 cAd
@@ -40183,7 +40371,7 @@ eWO
 eWO
 eWO
 eWO
-eWO
+rDO
 eWO
 eWO
 eWO
@@ -40240,7 +40428,7 @@ wXe
 wXe
 cAd
 cAd
-cAd
+jIE
 cAd
 cAd
 cAd
@@ -40621,7 +40809,7 @@ eWO
 eWO
 eWO
 eWO
-eWO
+rDO
 eWO
 rtU
 mGU
@@ -41028,16 +41216,16 @@ jcM
 jcM
 jcM
 jcM
-jcM
-jcM
-jcM
-pHo
-pHo
-pHo
-pHo
-jcM
-jcM
-jcM
+uDJ
+uDJ
+uDJ
+gFG
+gFG
+gFG
+gFG
+uDJ
+uDJ
+uDJ
 jcM
 pHo
 aoU
@@ -41245,7 +41433,7 @@ jcM
 jcM
 jcM
 jcM
-jcM
+uDJ
 jcM
 pHo
 pHo
@@ -41254,7 +41442,7 @@ aoU
 pHo
 pHo
 jcM
-jcM
+uDJ
 pHo
 pHo
 aoU
@@ -41271,7 +41459,7 @@ vmU
 mGU
 mGU
 rtU
-eWO
+rDO
 eWO
 eWO
 eWO
@@ -41462,7 +41650,7 @@ jcM
 jcM
 jcM
 jcM
-jcM
+uDJ
 pHo
 pHo
 aoU
@@ -41471,7 +41659,7 @@ aoU
 aoU
 pHo
 pHo
-jcM
+uDJ
 pHo
 aoU
 aoU
@@ -41679,16 +41867,16 @@ jcM
 jcM
 jcM
 jcM
+gFG
 pHo
-pHo
 aoU
 aoU
 aoU
-aoU
+rYM
 dUK
 aoU
 pHo
-pHo
+gFG
 pHo
 aoU
 aoU
@@ -41896,7 +42084,7 @@ jcM
 jcM
 jcM
 jcM
-pHo
+gFG
 aoU
 aoU
 aoU
@@ -41905,7 +42093,7 @@ aoU
 the
 aoU
 aoU
-aoU
+raW
 aoU
 aoU
 dUK
@@ -41925,9 +42113,9 @@ vmU
 eWO
 eWO
 eWO
+rDO
 eWO
 eWO
-dIG
 rtU
 mGU
 faA
@@ -42113,7 +42301,7 @@ jcM
 jcM
 jcM
 jcM
-pHo
+gFG
 pHo
 aoU
 dUK
@@ -42122,7 +42310,7 @@ aoU
 aoU
 aoU
 dUK
-aoU
+raW
 aoU
 aoU
 aoU
@@ -42140,7 +42328,7 @@ mGU
 mGU
 vmU
 rtU
-aPG
+eWO
 eWO
 eWO
 eWO
@@ -42330,7 +42518,7 @@ jcM
 jcM
 jcM
 jcM
-jcM
+uDJ
 pHo
 pHo
 aoU
@@ -42339,7 +42527,7 @@ aoU
 aoU
 aoU
 aoU
-aoU
+raW
 aoU
 mOG
 aoU
@@ -42362,12 +42550,12 @@ eWO
 eWO
 eWO
 dRu
-eWO
+rDO
 eWO
 cip
 eWO
 jin
-eWO
+rDO
 eWO
 rtU
 rtU
@@ -42395,17 +42583,17 @@ wXe
 wXe
 cAd
 cAd
+cAd
 wXe
 wXe
 wXe
-wXe
-wXe
-wXe
-oEa
-oEa
-wXe
-wXe
-wXe
+btN
+fvj
+fvj
+fvj
+fvj
+fvj
+fvj
 wXe
 wXe
 oEa
@@ -42547,8 +42735,8 @@ jcM
 jcM
 jcM
 jcM
+uDJ
 jcM
-jcM
 pHo
 pHo
 aoU
@@ -42556,7 +42744,7 @@ aoU
 aoU
 pHo
 pHo
-pHo
+gFG
 aoU
 aoU
 aoU
@@ -42575,7 +42763,7 @@ rtU
 vmU
 rtU
 aPG
-eWO
+rDO
 eWO
 eWO
 eWO
@@ -42613,16 +42801,16 @@ wXe
 dNL
 cAd
 cAd
+cAd
 wXe
 wXe
-wXe
-wXe
-wXe
-wXe
-oEa
-oEa
-oEa
-oEa
+rpA
+cAd
+cAd
+cAd
+cAd
+cAd
+fvj
 oEa
 oEa
 oEa
@@ -42740,7 +42928,7 @@ vTU
 vTU
 vTU
 wHb
-wHb
+ewT
 wHb
 wHb
 wHb
@@ -42764,16 +42952,16 @@ jcM
 jcM
 jcM
 jcM
-jcM
-jcM
-jcM
-pHo
-pHo
-pHo
-pHo
-pHo
-pHo
-dUK
+uDJ
+uDJ
+uDJ
+gFG
+gFG
+gFG
+gFG
+gFG
+gFG
+hrT
 aoU
 aoU
 pHo
@@ -42794,7 +42982,7 @@ rtU
 eWO
 eWO
 eWO
-eWO
+rDO
 eWO
 eWO
 eWO
@@ -42830,16 +43018,16 @@ wXe
 wXe
 cAd
 cAd
-wXe
-wXe
-wXe
-wXe
-wXe
-wXe
-wXe
-wXe
-wXe
-oEa
+cAd
+cAd
+cAd
+rpA
+cAd
+cAd
+cAd
+oHF
+cAd
+fvj
 wXe
 wXe
 wXe
@@ -43026,12 +43214,12 @@ mGU
 mGU
 mGU
 mGU
-mGU
-rtU
-rtU
-rtU
-rtU
-rtU
+eiw
+oOk
+oOk
+oOk
+oOk
+oOk
 eWO
 eWO
 eWO
@@ -43048,15 +43236,15 @@ wXe
 cAd
 jIE
 cAd
-wXe
-wXe
-wXe
-wXe
-wXe
-wXe
-wXe
-oEa
-oEa
+cAd
+cAd
+ptV
+cAd
+cAd
+cAd
+cAd
+cAd
+fvj
 wXe
 wXe
 wXe
@@ -43243,12 +43431,12 @@ mGU
 mGU
 mGU
 mGU
+oOk
 rtU
-rtU
 eWO
 eWO
 eWO
-eWO
+jkP
 eWO
 eWO
 eWO
@@ -43265,15 +43453,15 @@ wXe
 wXe
 cAd
 cAd
+jIE
 cAd
-wXe
-wXe
-wXe
-wXe
-wXe
-oEa
-oEa
-wXe
+rpA
+cAd
+cAd
+cAd
+cAd
+cAd
+fvj
 wXe
 wXe
 wXe
@@ -43394,7 +43582,7 @@ koV
 wHb
 koV
 wHb
-aoU
+dUK
 aoU
 skq
 jcM
@@ -43442,12 +43630,12 @@ rtU
 mjg
 eWO
 dRu
+rDO
 eWO
 eWO
 eWO
 eWO
-eWO
-eWO
+rDO
 eWO
 eWO
 rtU
@@ -43460,12 +43648,12 @@ mGU
 mGU
 mGU
 mGU
-rtU
+oOk
 eWO
 eWO
-rDO
+jjc
 eWO
-eWO
+jkP
 eWO
 eWO
 eWO
@@ -43483,14 +43671,14 @@ wXe
 cAd
 cAd
 cAd
-wXe
-wXe
-wXe
-wXe
-wXe
-oEa
-wXe
-wXe
+cAd
+rpA
+cAd
+cAd
+cAd
+cAd
+cAd
+fvj
 wXe
 wXe
 cAd
@@ -43677,12 +43865,12 @@ mGU
 mGU
 mGU
 mGU
-rtU
+oOk
 eWO
 eWO
 eWO
 eWO
-eWO
+jkP
 eWO
 eWO
 rDO
@@ -43700,14 +43888,14 @@ wXe
 cAd
 cAd
 dNL
-wXe
-wXe
-wXe
-wXe
-wXe
-oEa
-wXe
-wXe
+cAd
+rpA
+rpA
+ptV
+rpA
+rpA
+rpA
+fvj
 wXe
 wXe
 cAd
@@ -43878,7 +44066,7 @@ eWO
 rDO
 eWO
 eWO
-eWO
+rDO
 eWO
 eWO
 eWO
@@ -43894,12 +44082,12 @@ mGU
 mGU
 mGU
 mGU
-rtU
+oOk
 eWO
 eWO
 dRu
 eWO
-eWO
+jkP
 eWO
 eWO
 eWO
@@ -43918,13 +44106,13 @@ wXe
 cAd
 jIE
 cAd
-wXe
-wXe
-wXe
-wXe
+cAd
+cAd
+cAd
+cAd
 oEa
-wXe
-wXe
+oEa
+oEa
 wXe
 cAd
 cAd
@@ -44044,20 +44232,20 @@ aoU
 aoU
 aoU
 aoU
-aoU
+dUK
 aoU
 aoU
 skq
 jcM
 jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-skq
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+uDJ
+wGc
 jcM
 jcM
 jcM
@@ -44097,8 +44285,8 @@ eWO
 eWO
 eWO
 eWO
-pbb
-pbb
+eWO
+aPG
 pbb
 rtU
 rtU
@@ -44111,12 +44299,12 @@ mGU
 mGU
 mGU
 mGU
+oOk
 rtU
-rtU
 eWO
 eWO
 eWO
-eWO
+jkP
 eWO
 eWO
 eWO
@@ -44135,8 +44323,8 @@ wXe
 cAd
 cAd
 cAd
-wXe
-wXe
+jIE
+cAd
 wXe
 wXe
 oEa
@@ -44258,7 +44446,7 @@ skq
 jcM
 jcM
 aoU
-aoU
+dUK
 aoU
 aoU
 aoU
@@ -44267,14 +44455,14 @@ aoU
 skq
 jcM
 jcM
-jcM
+uDJ
 jcM
 jcM
 mvE
 jcM
 jcM
 jcM
-skq
+wGc
 skq
 jcM
 jcM
@@ -44328,12 +44516,12 @@ rtU
 mGU
 mGU
 mGU
-mGU
-rtU
-rtU
-rtU
-eWO
-eWO
+eiw
+oOk
+oOk
+oOk
+jkP
+jkP
 eWO
 eWO
 eWO
@@ -44353,7 +44541,7 @@ wXe
 cAd
 cAd
 cAd
-wXe
+cAd
 wXe
 wXe
 oEa
@@ -44484,14 +44672,14 @@ aoU
 skq
 jcM
 jcM
-jcM
+uDJ
 jcM
 aoU
 aoU
 jcM
 jcM
 jcM
-jcM
+uDJ
 skq
 jcM
 jcM
@@ -44701,14 +44889,14 @@ aoU
 skq
 jcM
 jcM
+uDJ
+aoU
+aoU
+aoU
+rYM
+aoU
 jcM
-aoU
-aoU
-aoU
-aoU
-aoU
-jcM
-jcM
+uDJ
 skq
 jcM
 jcM
@@ -44732,7 +44920,7 @@ jcM
 jcM
 rtU
 eWO
-eWO
+rDO
 eWO
 eWO
 vmU
@@ -44910,7 +45098,7 @@ jcM
 jcM
 aoU
 aoU
-aoU
+dUK
 aoU
 aoU
 aoU
@@ -44918,14 +45106,14 @@ aoU
 skq
 jcM
 jcM
-jcM
+uDJ
 aoU
 aoU
 aoU
 aoU
 dUK
 jcM
-jcM
+uDJ
 skq
 jcM
 jcM
@@ -45130,19 +45318,19 @@ aoU
 aoU
 aoU
 aoU
-aoU
+dUK
 aoU
 skq
 jcM
 jcM
-jcM
+uDJ
 aoU
 aoU
 aoU
 mOG
 aoU
 aoU
-jcM
+uDJ
 jcM
 jcM
 jcM
@@ -45352,14 +45540,14 @@ aoU
 skq
 jcM
 jcM
-jcM
+uDJ
 jcM
 aoU
 dUK
 aoU
 aoU
 aoU
-jcM
+uDJ
 jcM
 jcM
 jcM
@@ -45562,21 +45750,21 @@ jcM
 jcM
 jcM
 aoU
-aoU
+dUK
 aoU
 aoU
 aoU
 skq
 jcM
 jcM
-jcM
+uDJ
 jcM
 jcM
 aoU
 aoU
 jcM
 jcM
-jcM
+uDJ
 jcM
 jcM
 aoU
@@ -45786,7 +45974,14 @@ aoU
 skq
 jcM
 jcM
-jcM
+uDJ
+uDJ
+uDJ
+raW
+raW
+raW
+uDJ
+uDJ
 jcM
 jcM
 aoU
@@ -45796,29 +45991,22 @@ jcM
 jcM
 jcM
 jcM
+jcM
 aoU
-aoU
-aoU
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
 mOG
+aoU
+aoU
+aoU
 jcM
 jcM
 jcM
 jcM
-jcM
-jcM
-jcM
-jcM
+skq
 pHo
-rtU
 eWO
 eWO
 eWO
+rDO
 eWO
 eWO
 rtU
@@ -45844,7 +46032,7 @@ mGU
 mGU
 mGU
 mGU
-mGU
+eWO
 eWO
 dRu
 eWO
@@ -45873,7 +46061,7 @@ wXe
 wXe
 wXe
 cAd
-cAd
+jIE
 wXe
 wXe
 wXe
@@ -45999,7 +46187,7 @@ mOG
 aoU
 rXr
 aoU
-aoU
+dUK
 skq
 jcM
 jcM
@@ -46018,29 +46206,29 @@ aoU
 jcM
 jcM
 jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
+uDJ
+uDJ
+uDJ
+raW
+raW
+raW
+raW
+raW
+raW
+uDJ
+uDJ
 jcM
 skq
-rtU
-rtU
-rtU
+gFG
+jkP
+jkP
+jkP
+jkP
+jkP
+jkP
+jkP
 eWO
-eWO
-eWO
-eWO
-eWO
-eWO
+rDO
 eWO
 rtU
 eWO
@@ -46058,14 +46246,14 @@ rtU
 rtU
 mGU
 mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-eWO
-eWO
-eWO
+eiw
+eiw
+jkP
+jkP
+jkP
+jkP
+jkP
+jkP
 eWO
 eWO
 eWO
@@ -46235,27 +46423,27 @@ aoU
 jcM
 jcM
 jcM
+uDJ
 jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+uDJ
 jcM
 skq
-skq
-mGU
-mGU
-rtU
-rtU
+gFG
+eWO
+eWO
+eWO
+eWO
 eWO
 rDO
-eWO
+jkP
 eWO
 eWO
 eWO
@@ -46275,14 +46463,14 @@ mGU
 mGU
 mGU
 mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+eiw
 eWO
 eWO
+eWO
+eWO
+eWO
+eWO
+jkP
 eWO
 eWO
 mGU
@@ -46431,7 +46619,7 @@ jcM
 jcM
 jcM
 aoU
-aoU
+dUK
 aoU
 aoU
 skq
@@ -46452,27 +46640,27 @@ mOG
 jcM
 jcM
 jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
+uDJ
+aoU
+aoU
+dUK
+aoU
+aoU
+rYM
+aoU
+dUK
+aoU
+uDJ
 jcM
 skq
-jcM
-mGU
-mGU
-mGU
-rtU
-rtU
-rtU
-rtU
+gFG
+eWO
+eWO
+eWO
+eWO
+oeH
+eWO
+jkP
 eWO
 eWO
 eWO
@@ -46492,14 +46680,14 @@ faA
 faA
 mGU
 mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+eiw
 eWO
+eWO
+eWO
+eWO
+eWO
+eWO
+jkP
 eWO
 eWO
 eWO
@@ -46669,34 +46857,34 @@ jcM
 jcM
 jcM
 jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
+uDJ
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+skq
+wGc
 skq
 skq
-skq
-skq
-jcM
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+gFG
+eWO
+rDO
+eWO
+eWO
+eWO
+eWO
+jkP
+eWO
+rDO
+eWO
+eWO
+eWO
+eWO
 rtU
-rtU
-eWO
-eWO
-eWO
-eWO
-eWO
-rtU
 mGU
 faA
 faA
@@ -46709,14 +46897,14 @@ mGU
 faA
 faA
 faA
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+eiw
 eWO
+eWO
+eWO
+oeH
+eWO
+eWO
+jkP
 rDO
 eWO
 eWO
@@ -46739,7 +46927,7 @@ edj
 nOR
 nOR
 edj
-edj
+hhF
 edj
 edj
 hhF
@@ -46866,52 +47054,52 @@ jcM
 jcM
 aoU
 aoU
+dUK
+aoU
+skq
+skq
+jcM
+jcM
+jcM
+jcM
+jcM
+jcM
+jcM
+jcM
 aoU
 aoU
-skq
-skq
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-aoU
-aoU
 aoU
 aoU
 jcM
 jcM
 jcM
 jcM
+uDJ
 jcM
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+skq
+uDJ
 jcM
 skq
-skq
-skq
-skq
-skq
-skq
-skq
-skq
-jcM
-jcM
-skq
-skq
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-rtU
+gFG
 rtU
 eWO
 eWO
 eWO
+eWO
+eWO
+jkP
+eWO
+rtU
+eWO
+rDO
+eWO
 rtU
 rtU
 mGU
@@ -46926,14 +47114,14 @@ mGU
 mGU
 mGU
 faA
-faA
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+gxq
+eWO
+eWO
+eWO
+eWO
+eWO
+eWO
+eiw
 eWO
 eWO
 eWO
@@ -46946,7 +47134,7 @@ nOR
 nOR
 nOR
 edj
-edj
+hhF
 edj
 edj
 hhF
@@ -47103,54 +47291,54 @@ jcM
 jcM
 jcM
 jcM
-jcM
+uDJ
 skq
 skq
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
-jcM
+aoU
+aoU
+aoU
+aoU
+aoU
+aoU
+skq
+uDJ
 jcM
 skq
-kBw
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+wGc
+tMC
+rtU
+eWO
+eWO
+rDO
+eWO
+jkP
+rtU
 rtU
 eWO
 eWO
 eWO
+vmU
+vmU
+faA
+faA
+mGU
+mGU
+mGU
+mGU
+mGU
+mGU
+mGU
+mGU
+mGU
+mGU
+gxq
 eWO
-vmU
-vmU
-faA
-faA
+eWO
+eWO
+eWO
+eWO
 mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
-faA
-faA
-mGU
-mGU
-mGU
-mGU
-mGU
-mGU
+eiw
 eWO
 eWO
 eWO
@@ -47298,11 +47486,11 @@ hEW
 hEW
 hEW
 kUE
+mIf
 kUE
 kUE
 kUE
-kUE
-kUE
+mIf
 vhF
 hEW
 hEW
@@ -47320,27 +47508,27 @@ hEW
 hEW
 hEW
 hEW
+knM
+hEW
 vhF
+vhF
+kfl
+kUE
+kUE
+kUE
+vhF
+vhF
+eTU
 hEW
 hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-cDm
+njZ
 kBw
-kBw
-mGU
-mGU
-mGU
-mGU
-mGU
+tMC
+rtU
+eWO
+eWO
+eWO
+jkP
 rtU
 eWO
 eWO
@@ -47348,26 +47536,26 @@ dRu
 rDO
 rtU
 rtU
+eiw
+eiw
+eiw
+eiw
+eiw
+jkP
+jkP
+eiw
+eiw
+eiw
+eiw
 mGU
-mGU
-mGU
-mGU
-mGU
+gxq
+eWO
+eWO
 eWO
 eWO
 mGU
 mGU
-mGU
-mGU
-mGU
-mGU
-faA
-faA
-mGU
-mGU
-mGU
-mGU
-mGU
+eiw
 mGU
 dRu
 eWO
@@ -47391,7 +47579,7 @@ edj
 edj
 hhF
 edj
-edj
+hhF
 mMb
 nOR
 nOR
@@ -47537,27 +47725,27 @@ hEW
 hEW
 hEW
 vhF
+eTU
+eTU
+eTU
+knM
+knM
+knM
+knM
+knM
+knM
+eTU
+eTU
 hEW
 hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-hEW
-cDm
-cDm
-kBw
-kBw
-mGU
-mGU
-mGU
-mGU
+uiI
+njZ
+njZ
+dAL
+oOk
+oOk
+oOk
+oOk
 rtU
 rtU
 eWO
@@ -47565,7 +47753,7 @@ eWO
 eWO
 eWO
 rtU
-mGU
+eiw
 mGU
 mGU
 mGU
@@ -47575,16 +47763,16 @@ eWO
 eWO
 eWO
 mGU
+eiw
 mGU
-mGU
-mGU
-mGU
-faA
-faA
-mGU
-mGU
-mGU
-mGU
+gxq
+gxq
+gxq
+gxq
+eiw
+eiw
+eiw
+eiw
 mGU
 mGU
 mGU
@@ -47769,7 +47957,7 @@ hEW
 hEW
 cDm
 cDm
-cDm
+kBw
 kBw
 kBw
 cDm
@@ -47782,7 +47970,7 @@ ifU
 ifU
 ifU
 ifU
-cDm
+uiI
 cDm
 ifU
 ifU
@@ -47792,7 +47980,7 @@ ifU
 ifU
 ifU
 lAw
-cDm
+uiI
 cDm
 cDm
 cDm
@@ -47823,7 +48011,7 @@ nOR
 nOR
 edj
 edj
-edj
+hhF
 edj
 edj
 edj
@@ -47995,12 +48183,11 @@ cDm
 cDm
 tMC
 ifU
-ifU
-ifU
-ifU
 fIV
 ifU
 ifU
+fIV
+bAM
 ifU
 ifU
 ifU
@@ -48009,7 +48196,8 @@ ifU
 ifU
 ifU
 ifU
-cDm
+ifU
+uiI
 cDm
 cDm
 cDm
@@ -48040,7 +48228,7 @@ nOR
 mMb
 edj
 edj
-edj
+hhF
 edj
 edj
 nOR
@@ -48049,7 +48237,7 @@ nOR
 mOw
 nOR
 edj
-edj
+hhF
 edj
 edj
 edj
@@ -48168,7 +48356,7 @@ hEW
 hEW
 hEW
 kUE
-kUE
+mIf
 kUE
 kUE
 vhF
@@ -48216,17 +48404,17 @@ ifU
 ifU
 ifU
 muT
+bAM
 ifU
 ifU
+fIV
 ifU
-ifU
-ifU
-ifU
+los
 hQA
 ifU
 ifU
 muT
-cDm
+uiI
 cDm
 cDm
 kBw
@@ -48251,15 +48439,15 @@ mOw
 nOR
 nOR
 nOR
-nOR
-nOR
-edj
-edj
-edj
-hhF
-edj
-edj
-nOR
+jFt
+jFt
+pQY
+pQY
+pQY
+eaO
+pQY
+pQY
+jFt
 nOR
 nOR
 nOR
@@ -48413,7 +48601,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 hEW
@@ -48433,7 +48621,7 @@ ifU
 cDm
 cDm
 ifU
-ifU
+bAM
 ifU
 ifU
 ifU
@@ -48443,7 +48631,7 @@ ifU
 ifU
 ifU
 cDm
-cDm
+uiI
 cDm
 kBw
 kBw
@@ -48468,6 +48656,7 @@ nOR
 nOR
 nOR
 edj
+pQY
 edj
 edj
 edj
@@ -48475,8 +48664,7 @@ edj
 edj
 edj
 edj
-edj
-nOR
+jFt
 nOR
 nOR
 mOw
@@ -48604,7 +48792,7 @@ hEW
 kUE
 kUE
 kUE
-kUE
+mIf
 vhF
 vhF
 vhF
@@ -48650,7 +48838,7 @@ cDm
 cDm
 cDm
 cDm
-ifU
+bAM
 ifU
 ifU
 ifU
@@ -48660,7 +48848,7 @@ ifU
 ifU
 cDm
 cDm
-cDm
+uiI
 cDm
 kBw
 cDm
@@ -48685,15 +48873,15 @@ nOR
 nOR
 edj
 edj
+eaO
+edj
 hhF
 edj
 edj
 edj
+hhF
 edj
-nOR
-nOR
-nOR
-nOR
+pQY
 nOR
 nOR
 mOw
@@ -48704,7 +48892,7 @@ edj
 edj
 edj
 edj
-edj
+hhF
 nOR
 nOR
 mOw
@@ -48867,7 +49055,7 @@ cDm
 cDm
 cDm
 cDm
-ifU
+bAM
 ifU
 ifU
 ifU
@@ -48877,7 +49065,7 @@ ifU
 cDm
 cDm
 cDm
-kBw
+njZ
 kBw
 cDm
 cDm
@@ -48902,15 +49090,15 @@ edj
 edj
 edj
 edj
+pQY
 edj
 edj
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
+edj
+edj
+edj
+edj
+edj
+pQY
 nOR
 mOw
 mOw
@@ -49084,30 +49272,30 @@ cDm
 cDm
 cDm
 cDm
+uiI
+bAM
+pvh
+wVG
+bAM
+bAM
+uiI
+uiI
+uiI
+njZ
+njZ
+cDm
+cDm
+cDm
+cDm
 cDm
 ifU
-muT
+ifU
 fIV
 ifU
 ifU
 cDm
 cDm
 cDm
-kBw
-kBw
-cDm
-cDm
-cDm
-cDm
-cDm
-ifU
-ifU
-fIV
-ifU
-ifU
-cDm
-cDm
-cDm
 cDm
 kBw
 kBw
@@ -49119,15 +49307,15 @@ edj
 edj
 edj
 edj
+pQY
+hhF
 edj
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
+edj
+edj
+pxa
+edj
+edj
+pQY
 mOw
 mOw
 nOR
@@ -49252,7 +49440,7 @@ hEW
 hEW
 hEW
 hEW
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -49288,7 +49476,7 @@ kUE
 kUE
 ifU
 ifU
-ifU
+fIV
 ifU
 ifU
 fIV
@@ -49336,15 +49524,15 @@ hhF
 edj
 edj
 edj
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-mOw
+pQY
+edj
+edj
+edj
+edj
+edj
+edj
+hhF
+gtZ
 mOw
 nOR
 nOR
@@ -49472,7 +49660,7 @@ hEW
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -49551,17 +49739,17 @@ edj
 edj
 dUr
 edj
+hhF
+nOR
+jFt
 edj
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-nOR
-mOw
-mOw
+edj
+edj
+edj
+edj
+edj
+edj
+gtZ
 nOR
 nOR
 nOR
@@ -49692,7 +49880,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -49770,25 +49958,25 @@ edj
 edj
 mMb
 nOR
+jFt
 nOR
-nOR
-nOR
-nOR
-nOR
-nOR
+edj
+edj
+edj
+edj
+edj
 mOw
-mOw
+gtZ
 nOR
 nOR
 nOR
 nOR
-nOR
 edj
 edj
 edj
 edj
 edj
-edj
+hhF
 nOR
 mOw
 nHa
@@ -49987,15 +50175,15 @@ edj
 nOR
 nOR
 nOR
+jFt
 nOR
-nOR
-nOR
-nOR
-nOR
+edj
+edj
+edj
+edj
 mOw
 mOw
-nOR
-nOR
+jFt
 nOR
 nOR
 nOR
@@ -50120,7 +50308,7 @@ hEW
 hEW
 hEW
 kUE
-kUE
+mIf
 kUE
 hEW
 hEW
@@ -50135,7 +50323,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -50204,15 +50392,15 @@ nOR
 nOR
 nOR
 nOR
-nOR
-nOR
-nOR
-mOw
-mOw
-mOw
-nOR
-nOR
-nOR
+jFt
+jFt
+jFt
+gtZ
+gtZ
+gtZ
+gtZ
+jFt
+jFt
 nOR
 nOR
 nOR
@@ -50425,8 +50613,8 @@ nOR
 nOR
 mOw
 mOw
-nOR
-nOR
+mOw
+mOw
 nOR
 nOR
 nOR
@@ -50555,7 +50743,7 @@ hEW
 hEW
 hEW
 kUE
-kUE
+mIf
 kUE
 hEW
 hEW
@@ -50566,12 +50754,12 @@ kUE
 kUE
 kUE
 kUE
+mIf
 kUE
 kUE
 kUE
 kUE
-kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -50992,7 +51180,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 hEW
 kUE
 kUE
@@ -51211,7 +51399,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -51424,6 +51612,7 @@ hEW
 hEW
 hEW
 hEW
+mIf
 kUE
 kUE
 kUE
@@ -51433,8 +51622,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
-kUE
+mIf
 kUE
 kUE
 vhF
@@ -51845,7 +52033,7 @@ wHb
 mke
 cid
 cid
-cid
+mHp
 cid
 cid
 ieq
@@ -52077,7 +52265,7 @@ hEW
 hEW
 hEW
 pOn
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -52089,7 +52277,7 @@ vhF
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -52280,7 +52468,7 @@ mke
 cid
 tYf
 cid
-cid
+mHp
 aqc
 mke
 mke
@@ -52297,7 +52485,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 hEW
 hEW
@@ -52527,7 +52715,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 hEW
@@ -52929,7 +53117,7 @@ wHb
 wHb
 mke
 cid
-cid
+mHp
 cid
 cid
 ieq
@@ -52963,7 +53151,7 @@ kUE
 kUE
 kUE
 kUE
-kUE
+mIf
 kUE
 kUE
 kUE
@@ -53165,7 +53353,7 @@ hEW
 hEW
 kUE
 kUE
-kUE
+mIf
 kUE
 hEW
 hEW
@@ -53178,21 +53366,21 @@ hEW
 vhF
 kUE
 kUE
+mIf
 kUE
 kUE
 kUE
 kUE
 kUE
 kUE
-kUE
+sxN
+vQJ
 sxN
 sxN
 sxN
 sxN
 sxN
-sxN
-sxN
-sxN
+vQJ
 sxN
 sxN
 sxN
@@ -53399,8 +53587,8 @@ kUE
 kUE
 kUE
 kUE
+mIf
 kUE
-kUE
 sxN
 sxN
 sxN
@@ -53412,7 +53600,7 @@ sxN
 sxN
 sxN
 sxN
-sxN
+vQJ
 sxN
 sxN
 kBw
@@ -53577,7 +53765,7 @@ vlm
 vlm
 coQ
 lcS
-lcS
+nFr
 lcS
 lcS
 lcS
@@ -53590,7 +53778,7 @@ kYB
 kYB
 kYB
 kYB
-lcS
+nFr
 qwI
 lcS
 vhF
@@ -53623,7 +53811,7 @@ sxN
 sxN
 sxN
 sxN
-sxN
+vQJ
 sxN
 sxN
 sxN
@@ -54014,7 +54202,7 @@ lcS
 lcS
 lcS
 wds
-lcS
+nFr
 lcS
 lcS
 kYB
@@ -54048,11 +54236,11 @@ vhF
 vhF
 sxN
 sxN
+vQJ
 sxN
 sxN
 sxN
-sxN
-sxN
+vQJ
 sxN
 rnU
 vSe
@@ -54235,7 +54423,7 @@ lcS
 lcS
 lcS
 kYB
-kYB
+eVf
 kYB
 kYB
 kYB
@@ -54282,7 +54470,7 @@ vSe
 dOZ
 sxN
 sxN
-sxN
+vQJ
 sxN
 sxN
 sxN
@@ -54448,9 +54636,9 @@ qwI
 lcS
 lcS
 lcS
+nFr
 lcS
 lcS
-lcS
 kYB
 kYB
 kYB
@@ -54459,7 +54647,7 @@ kYB
 kYB
 kYB
 kYB
-lcS
+nFr
 lcS
 qwI
 lcS
@@ -54687,7 +54875,7 @@ lcS
 lcS
 lcS
 lcS
-lcS
+nFr
 lcS
 lcS
 qwI
@@ -54879,7 +55067,7 @@ coQ
 coQ
 coQ
 lcS
-lcS
+nFr
 lcS
 mke
 mke
@@ -54901,7 +55089,7 @@ lcS
 qwI
 lcS
 lcS
-lcS
+nFr
 lcS
 lcS
 lcS
@@ -54921,7 +55109,7 @@ sxN
 sxN
 sxN
 sxN
-sxN
+vQJ
 rnU
 vSe
 vSe
@@ -55113,7 +55301,7 @@ kYB
 xPw
 kYB
 lcS
-lcS
+nFr
 lcS
 lcS
 lcS
@@ -55149,7 +55337,7 @@ mqi
 pur
 rnU
 sxN
-sxN
+vQJ
 sxN
 sxN
 sxN
@@ -55317,7 +55505,7 @@ lcS
 mke
 csT
 cid
-cid
+mHp
 jLn
 bGw
 lcS
@@ -55372,7 +55560,7 @@ sxN
 sxN
 sxN
 sxN
-sxN
+vQJ
 ifU
 ifU
 ifU
@@ -55586,7 +55774,7 @@ sxN
 sxN
 sxN
 sxN
-sxN
+vQJ
 sxN
 sxN
 sxN
@@ -56244,14 +56432,14 @@ tIu
 tIu
 tIu
 tIu
+rlS
 tIu
 tIu
 tIu
 tIu
 tIu
 tIu
-tIu
-tIu
+rlS
 tIu
 tIu
 tIu
@@ -56682,7 +56870,7 @@ tIu
 tIu
 tIu
 tIu
-tIu
+rlS
 tIu
 tIu
 tIu

--- a/_maps/map_files/Vietzhuo_8/Vietzhuo_8_Borders.dmm
+++ b/_maps/map_files/Vietzhuo_8/Vietzhuo_8_Borders.dmm
@@ -217,6 +217,10 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/poolroom)
+"aiT" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ntc)
 "ajb" = (
 /obj/effect/ai_node,
 /turf/open/floor/iron/dark/small,
@@ -1354,6 +1358,11 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/warehouseEC)
+"bnl" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "bnx" = (
 /obj/effect/ai_node,
 /turf/open/floor/urban/tile/tilebeigecheckered,
@@ -1572,6 +1581,10 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ne/village)
+"bzb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth,
+/area/vietzhuo8/oob)
 "bzf" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -1714,6 +1727,10 @@
 /obj/item/bedsheet/captain,
 /turf/open/floor/urban_wood,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
+"bHr" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "bHE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -1989,6 +2006,13 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentafsec/security_checkpoint_northwest)
+"bTd" = (
+/obj/effect/ai_node,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ne/village)
 "bTe" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood/fancy/damaged,
@@ -2336,6 +2360,10 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
+"cjV" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner,
+/area/vietzhuo8/outdoors/river/north)
 "ckr" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -2389,6 +2417,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/officesmain)
+"cmL" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ne/village)
 "cne" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -2440,6 +2472,12 @@
 /obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
 /turf/open/floor/tile/white,
 /area/vietzhuo8/indoors/v8west/city/precinct/breakroom)
+"coa" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/southern)
 "cob" = (
 /obj/structure/sink/kitchen,
 /turf/open/floor/urban/tile/tilebeigecheckered,
@@ -2712,6 +2750,13 @@
 	dir = 9
 	},
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
+"cEx" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 14
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/north)
 "cGp" = (
 /obj/structure/table/reinforced,
 /obj/item/defibrillator/civi,
@@ -2919,6 +2964,10 @@
 "cSQ" = (
 /turf/open/ground/grass/weedable,
 /area/vietzhuo8/outdoors/v8ntcregionnorth)
+"cTa" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "cTi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3339,6 +3388,10 @@
 /obj/machinery/light,
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/precheck)
+"dqF" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "drd" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -3623,6 +3676,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentaf/corporate_dorms)
+"dCb" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ntc)
 "dCm" = (
 /obj/structure/sink{
 	dir = 4;
@@ -4389,10 +4446,6 @@
 /obj/effect/landmark/spawn_marker/civilian/atmos,
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8west/city/powerstation)
-"elN" = (
-/obj/effect/landmark/sensor_tower,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8ne/village)
 "elU" = (
 /obj/machinery/vending/cola,
 /obj/machinery/light,
@@ -4538,6 +4591,12 @@
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/cafediner)
+"esb" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 5
+	},
+/area/vietzhuo8/indoors/caves/river)
 "ese" = (
 /turf/open/floor/wood,
 /area/vietzhuo8/outdoors/bridge/north)
@@ -5727,6 +5786,12 @@
 "fsy" = (
 /turf/open/ground/grass/weedable,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
+"fsH" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/north)
 "fsO" = (
 /obj/structure/cable,
 /turf/open/floor/tile/bar,
@@ -5825,9 +5890,9 @@
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
 "fvS" = (
-/obj/effect/landmark/patrol_point/tgmc_21,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/landing_zone_2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/southarea)
 "fwe" = (
 /obj/structure/table/mainship,
 /obj/structure/window,
@@ -5839,6 +5904,10 @@
 	},
 /turf/open/floor/mainship/blue,
 /area/vietzhuo8/indoors/v8ntc/officesmain)
+"fwl" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "fwq" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -6090,6 +6159,10 @@
 "fHz" = (
 /turf/open/floor/wood,
 /area/vietzhuo8/outdoors/bridge/centralnorth)
+"fHC" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "fIa" = (
 /obj/structure/prop/mainship/chimney{
 	dir = 4;
@@ -6125,6 +6198,11 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/vietzhuo8/indoors/v8west/city/precinct/breakroom)
+"fIP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "fJu" = (
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
@@ -7590,6 +7668,10 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/vietzhuo8/indoors/v8west/city/embassy/visascenter/lobby)
+"hgX" = (
+/obj/effect/landmark/patrol_point/tgmc_21,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/landing_zone_2)
 "hhq" = (
 /obj/machinery/streetlight/street,
 /turf/open/urban/street/sidewalk{
@@ -7604,6 +7686,10 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/breakroom)
+"hhJ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "hif" = (
 /obj/machinery/light/mainship,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -7905,6 +7991,10 @@
 	},
 /turf/open/floor/wood/broken,
 /area/vietzhuo8/indoors/v8ne/village/guard/jail_cells)
+"hwi" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/southarea)
 "hwp" = (
 /obj/structure/table/wood,
 /obj/item/weapon/cleaver{
@@ -7972,6 +8062,10 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/office2)
+"hza" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/indoors/caves/river)
 "hzv" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	name = "\improper Power Station"
@@ -8010,6 +8104,12 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/offices)
+"hAv" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 10
+	},
+/area/vietzhuo8/outdoors/river/north)
 "hAH" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -8109,6 +8209,12 @@
 "hIe" = (
 /turf/open/urban/street/sidewalkfull,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
+"hIt" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 1
+	},
+/area/vietzhuo8/outdoors/river/north)
 "hIv" = (
 /turf/open/floor/wood/fancy/damaged,
 /area/vietzhuo8/indoors/v8ne/village/clinic)
@@ -8145,6 +8251,10 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/red/full,
 /area/vietzhuo8/indoors/v8west/city/precinct/swatarmory)
+"hJz" = (
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/deep,
+/area/vietzhuo8/indoors/caves/river)
 "hJA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8211,6 +8321,13 @@
 	},
 /turf/open/floor/urban/carpet/carpetred,
 /area/vietzhuo8/indoors/v8west/city/border/security/central)
+"hKw" = (
+/obj/effect/urban/decal/road/lines3{
+	pixel_y = -2
+	},
+/obj/effect/landmark/patrol_point/tgmc_11,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/landing_zone_1)
 "hKJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -8497,11 +8614,9 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/dresses)
 "hVV" = (
-/obj/effect/landmark/sensor_tower,
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/vietzhuo8/indoors/v8west/stripmall)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/north)
 "hWl" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -8858,6 +8973,11 @@
 "ipY" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/warmemorial)
+"iqr" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "irf" = (
 /obj/structure/cable,
 /obj/machinery/newscaster{
@@ -8875,6 +8995,7 @@
 /obj/structure/window/framed/urban/reinforced{
 	dir = 8
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "irI" = (
@@ -10105,6 +10226,10 @@
 	dir = 1
 	},
 /area/vietzhuo8/indoors/v8west/stripmall)
+"jAD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "jAJ" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
@@ -10483,6 +10608,12 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8ntcroadwest)
+"jXg" = (
+/obj/effect/landmark/sensor_tower,
+/turf/open/urban/street/sidewalk{
+	dir = 1
+	},
+/area/vietzhuo8/indoors/v8west/stripmall)
 "jXO" = (
 /obj/structure/prop/urban/misc/trash/blue,
 /turf/open/floor/tile/bar,
@@ -11199,6 +11330,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/alt_nine,
 /area/vietzhuo8/indoors/v8ne/village/civilian_coastal_hut)
+"kDw" = (
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "kDJ" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1
@@ -11229,6 +11363,11 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/vietzhuo8/indoors/v8west/city/precinct/dispatchoffices)
+"kEC" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "kEY" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt_alt,
@@ -11252,6 +11391,10 @@
 "kGu" = (
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/lobby)
+"kHf" = (
+/obj/effect/ai_node,
+/turf/open/floor/urban/carpet/carpetred,
+/area/vietzhuo8/indoors/v8west/city/border/security/central)
 "kHt" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -11352,6 +11495,11 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8west/city/southarea)
+"kMp" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/northeast)
 "kMJ" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship{
 	dir = 4
@@ -12610,12 +12758,9 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/dresses)
 "lQg" = (
-/obj/effect/urban/decal/road/lines3{
-	pixel_y = -2
-	},
-/obj/effect/landmark/patrol_point/tgmc_11,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/landing_zone_1)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/northwest)
 "lQm" = (
 /turf/closed/wall/wood,
 /area/vietzhuo8/indoors/v8ne/village/guard/post_south)
@@ -12891,6 +13036,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
+"mcP" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "mcX" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -12987,7 +13137,13 @@
 	dir = 8
 	},
 /area/vietzhuo8/indoors/v8west/city/precinct/holdingcell)
+"mhS" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "miG" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/urban/colony,
 /area/vietzhuo8/outdoors/v8west/hanakohilton/courtyard)
 "mjj" = (
@@ -13046,6 +13202,12 @@
 "mlJ" = (
 /turf/open/floor/plating/ground/dirt_alt,
 /area/vietzhuo8/outdoors/v8west/city/miningpit/North)
+"mlX" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/north)
 "mmL" = (
 /turf/open/floor/plating,
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
@@ -13160,6 +13322,10 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
 /area/vietzhuo8/outdoors/v8west/city/northarea)
+"mrZ" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/urban/colony,
+/area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "msa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -13272,6 +13438,7 @@
 /obj/machinery/door/airlock/mainship/medical/glass/free_access{
 	name = "\improper Leisure Dome"
 	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "mxB" = (
@@ -13457,6 +13624,10 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/vietzhuo8/indoors/v8central/cargo_requisitions)
+"mFe" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "mFx" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/bar,
@@ -13756,6 +13927,12 @@
 "mUm" = (
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8sentaf/substation)
+"mUy" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 5
+	},
+/area/vietzhuo8/outdoors/river/north)
 "mUN" = (
 /turf/closed/wall/r_wall,
 /area/vietzhuo8/indoors/v8west/city/powerstation)
@@ -14025,6 +14202,10 @@
 	},
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/halls)
+"njA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ntc)
 "njZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -14816,6 +14997,12 @@
 	},
 /turf/open/floor/urban_wood,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
+"nWs" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 1
+	},
+/area/vietzhuo8/outdoors/river/north)
 "nWB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -15295,6 +15482,10 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
+"ovW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "owr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15697,11 +15888,23 @@
 "oMn" = (
 /turf/open/floor/tile/dark,
 /area/vietzhuo8/indoors/v8west/city/precinct/holdingcell)
+"oMH" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 5
+	},
+/area/vietzhuo8/outdoors/river/southern)
 "oMW" = (
 /obj/structure/bed/fancy,
 /obj/item/bedsheet/captain,
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/guard/barracks)
+"oNc" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/vietzhuo8/indoors/caves/river)
 "oNn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -16528,6 +16731,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/officeslobby)
+"pyx" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "pyS" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/plating,
@@ -17307,6 +17515,10 @@
 	dir = 10
 	},
 /area/vietzhuo8/outdoors/river/central)
+"qju" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "qjC" = (
 /obj/effect/ai_node{
 	pixel_x = 3
@@ -17561,6 +17773,10 @@
 	},
 /turf/open/floor/wood/alt_three,
 /area/vietzhuo8/indoors/v8ne/village/civilian_coastal_diner)
+"qve" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/kutjevo,
+/area/vietzhuo8/outdoors/v8ne/village)
 "qvg" = (
 /turf/open/urban/street/sidewalk{
 	dir = 10
@@ -17948,6 +18164,14 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/officeslobby)
+"qIf" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ne/village)
+"qIK" = (
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/northeast)
 "qJn" = (
 /obj/structure/bed/chair/comfy,
 /obj/machinery/light/mainship{
@@ -18573,6 +18797,10 @@
 	},
 /turf/open/liquid/water/river/deep,
 /area/vietzhuo8/outdoors/river/southern)
+"rlp" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/city/northstreets)
 "rlF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -18719,6 +18947,11 @@
 	},
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/landing_zone_1/hangars)
+"rrA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "rrB" = (
 /obj/effect/urban/decal/road/lines1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -19237,6 +19470,10 @@
 	},
 /turf/open/liquid/water/river/deep,
 /area/vietzhuo8/outdoors/river/north)
+"rMh" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/southarea)
 "rMj" = (
 /obj/structure/cable,
 /turf/open/floor/wood/fancy/damaged,
@@ -20213,6 +20450,10 @@
 "sHh" = (
 /turf/open/ground/coast/corner,
 /area/vietzhuo8/indoors/caves/river)
+"sHj" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "sHs" = (
 /obj/structure/curtain/shower{
 	color = "#a57d4b";
@@ -20965,6 +21206,10 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
+"tmQ" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "tmV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -21461,6 +21706,12 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/poolroom)
+"tJf" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/north)
 "tJm" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -21572,6 +21823,10 @@
 	dir = 1
 	},
 /area/vietzhuo8/outdoors/river/southern)
+"tQD" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/hanakohilton/courtyard)
 "tQF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable,
@@ -21761,6 +22016,12 @@
 	},
 /turf/open/floor/urban/wood/greywood,
 /area/vietzhuo8/indoors/v8sentaf/corporate_dorms)
+"ubh" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/southern)
 "ubi" = (
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalk{
@@ -21784,6 +22045,13 @@
 /obj/item/defibrillator/civi,
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/operatingroom)
+"ucq" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 14
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/southern)
 "ucO" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/urban/carpet/carpetreddeco,
@@ -22262,6 +22530,10 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8central/cargo_requisitions)
+"uzE" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "uzI" = (
 /obj/machinery/light{
 	dir = 4
@@ -22397,6 +22669,7 @@
 /area/vietzhuo8/outdoors/river/southern)
 "uEp" = (
 /obj/structure/fence/dark/quality,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "uEF" = (
@@ -22951,6 +23224,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue,
 /area/vietzhuo8/indoors/v8ntc/breakroom)
+"veN" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/north)
 "veZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -22985,6 +23264,10 @@
 	},
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/triage)
+"vgG" = (
+/obj/effect/landmark/sensor_tower,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ne/village)
 "vgV" = (
 /obj/structure/cable,
 /turf/open/floor/urban/carpet/carpetred,
@@ -23797,6 +24080,10 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/landing_zone_2)
+"vOc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/gm/dense,
+/area/vietzhuo8/oob)
 "vOl" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	name = "Hanako Hilton Room 2";
@@ -23971,6 +24258,10 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/clothing)
+"vWD" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/city/centralstreets)
 "vWJ" = (
 /obj/structure/prop/urban/misc/trash/blue,
 /turf/open/floor/urban/tile/tilewhite,
@@ -24176,6 +24467,18 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/security_checkpoint_northwest)
+"weS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
+"weT" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "wff" = (
 /obj/structure/bed/roller,
 /turf/open/floor/wood/fancy/damaged,
@@ -24279,6 +24582,11 @@
 	dir = 8
 	},
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
+"wmF" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ntc)
 "wmH" = (
 /turf/open/floor/urban/carpet/carpetred,
 /area/vietzhuo8/indoors/v8west/city/border/security/north)
@@ -24424,6 +24732,12 @@
 	dir = 5
 	},
 /area/vietzhuo8/outdoors/river/central)
+"wrN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/north)
 "wrV" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/road_edge/four,
@@ -24553,6 +24867,10 @@
 /obj/item/reagent_containers/food/snacks/cubancarp,
 /turf/open/floor/wood/alt_eleven,
 /area/vietzhuo8/indoors/v8ne/village/civilian_coastal_hut)
+"wwN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ne/village)
 "wwX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -24581,6 +24899,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8ne/village/guard/assembly)
+"wyq" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 6
+	},
+/area/vietzhuo8/outdoors/river/north)
 "wyz" = (
 /turf/open/floor/prison/sterilewhite{
 	dir = 10
@@ -24624,6 +24948,12 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/cafediner)
+"wzP" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/north)
 "wzX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -25198,6 +25528,10 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
+"xjc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "xjl" = (
 /obj/structure/barricade/concrete{
 	dir = 1
@@ -25280,6 +25614,9 @@
 /area/vietzhuo8/indoors/caves/river)
 "xlG" = (
 /turf/open/urban/street/sidewalk,
+/area/vietzhuo8/outdoors/v8west/city/centralarea)
+"xlV" = (
+/turf/open/floor/plating/ground/dirt_alt,
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
 "xmq" = (
 /turf/closed/wall/urban/colony,
@@ -25825,6 +26162,10 @@
 	dir = 4
 	},
 /area/vietzhuo8/outdoors/v8west/city/southarea)
+"xGN" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/southern)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/concrete,
@@ -25898,6 +26239,10 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/civilian_farm_hut)
+"xMo" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/north)
 "xMp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -26044,6 +26389,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/conference)
+"xUy" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "xUZ" = (
 /obj/structure/flora/pottedplant{
 	pixel_y = 4
@@ -26838,14 +27188,14 @@ luL
 luL
 luL
 luL
-luL
-luL
-luL
-luL
-luL
-luL
-luL
-luL
+vOc
+vOc
+vOc
+vOc
+vOc
+vOc
+vOc
+vOc
 nIW
 sSu
 nIW
@@ -26988,15 +27338,15 @@ czz
 czz
 eBC
 jdK
-jdK
-jdK
-jdK
-jdK
-luL
-luL
-luL
-luL
-luL
+bzb
+bzb
+bzb
+bzb
+vOc
+vOc
+vOc
+vOc
+vOc
 luL
 luL
 luL
@@ -27055,14 +27405,14 @@ luL
 luL
 luL
 luL
-luL
+vOc
 yhl
 eKe
+jka
 eKe
-eKe
-eKe
+mFe
 hoU
-hoU
+hhJ
 gcu
 pni
 gcu
@@ -27199,13 +27549,13 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 czz
 eBC
 eBC
-eKe
+cTa
 eKe
 tre
 pwp
@@ -27213,7 +27563,7 @@ eKe
 pwp
 luL
 luL
-luL
+vOc
 luL
 luL
 luL
@@ -27272,14 +27622,14 @@ eKe
 eKe
 eKe
 eKe
-pwp
+bHr
 eKe
 tre
 eKe
 eKe
 eKe
 hoU
-sEi
+sHj
 gcu
 pni
 gcu
@@ -27413,7 +27763,7 @@ hiB
 hiB
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -27422,15 +27772,15 @@ hiB
 czz
 czz
 eBC
-eKe
+cTa
 eKe
 qjC
 eKe
-eKe
+mFe
 pwp
 lAY
 eKe
-eKe
+cTa
 eKe
 eKe
 jka
@@ -27489,14 +27839,14 @@ eKe
 eKe
 eKe
 eKe
-eKe
+cTa
 eKe
 eKe
 fEB
 eKe
 pwp
 sEi
-sEi
+sHj
 gcu
 pni
 gcu
@@ -27628,18 +27978,18 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 czz
 czz
 czz
-eBC
+eag
 eKe
 viN
 eKe
@@ -27647,7 +27997,7 @@ eKe
 eKe
 qjC
 eKe
-ylG
+xUy
 ile
 pwp
 eKe
@@ -27706,14 +28056,14 @@ pwp
 pwp
 lAY
 pwp
-pwp
+bHr
 pwp
 pwp
 pwp
 pwp
 pwp
 sEi
-sEi
+sHj
 gcu
 pni
 gcu
@@ -27839,24 +28189,24 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 lGa
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 czz
 czz
-eBC
+eag
 pwp
 eKe
 eKe
@@ -27864,7 +28214,7 @@ eKe
 eKe
 pwp
 eKe
-eKe
+cTa
 viN
 eKe
 eKe
@@ -27923,14 +28273,14 @@ oVu
 oVu
 oVu
 oVu
-oVu
-oVu
-oVu
-oVu
-oVu
-oVu
-gcu
-gcu
+rlp
+rlp
+rlp
+rlp
+rlp
+rlp
+vWD
+vWD
 gcu
 pni
 gcu
@@ -28063,17 +28413,17 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 czz
 hiB
 hiB
 fMJ
 hiB
-hiB
+lQg
 czz
 czz
-eBC
+eag
 pwp
 eKe
 eKe
@@ -28081,7 +28431,7 @@ yhl
 eKe
 pwp
 fEB
-eKe
+cTa
 eKe
 eKe
 pwp
@@ -28271,7 +28621,7 @@ czz
 lGa
 ryS
 fMJ
-hiB
+lQg
 hiB
 ryS
 lGa
@@ -28290,7 +28640,7 @@ hiB
 hiB
 czz
 czz
-eBC
+eag
 pwp
 pwp
 eKe
@@ -28298,7 +28648,7 @@ pwp
 eKe
 viN
 eKe
-eKe
+cTa
 pwp
 eKe
 qjC
@@ -28494,20 +28844,20 @@ lGa
 lGa
 hiB
 hiB
+lQg
 hiB
-hiB
+czz
 czz
 czz
 czz
 czz
-czz
 hiB
 hiB
 hiB
 hiB
 hiB
 czz
-eBC
+eag
 eBC
 pwp
 eKe
@@ -28515,7 +28865,7 @@ qjC
 eKe
 eKe
 eKe
-eKe
+cTa
 pwp
 eKe
 bQg
@@ -28707,32 +29057,32 @@ hiB
 hiB
 hiB
 hiB
-hiB
-hiB
-czz
-czz
-czz
-czz
-czz
-czz
-czz
-czz
-czz
-hiB
-hiB
-hiB
-hiB
+lQg
 hiB
 czz
 czz
-eBC
-pwp
-viN
-eKe
-pwp
-eKe
-eKe
-eKe
+czz
+czz
+czz
+czz
+czz
+czz
+czz
+hiB
+lQg
+hiB
+hiB
+lQg
+czz
+vjo
+eag
+bHr
+fIP
+cTa
+bHr
+cTa
+cTa
+cTa
 eKe
 eKe
 bQg
@@ -28920,7 +29270,7 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -29135,10 +29485,10 @@ eBC
 czz
 czz
 czz
+lQg
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -29154,9 +29504,9 @@ czz
 czz
 hiB
 hiB
+lQg
 hiB
-hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -29591,7 +29941,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 czz
 eBC
@@ -29805,7 +30155,7 @@ fMJ
 hiB
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -30004,7 +30354,7 @@ czz
 czz
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -30018,7 +30368,7 @@ eBC
 czz
 czz
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -30225,19 +30575,19 @@ hiB
 hiB
 hiB
 hiB
+lQg
+hiB
+czz
+czz
+czz
+czz
+czz
+czz
+czz
+czz
 hiB
 hiB
-czz
-czz
-czz
-czz
-czz
-czz
-czz
-czz
-hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -30460,7 +30810,7 @@ hiB
 hiB
 hiB
 fMJ
-hiB
+lQg
 czz
 eBC
 eKe
@@ -30654,7 +31004,7 @@ eBC
 czz
 czz
 czz
-hiB
+lQg
 hiB
 fMJ
 hiB
@@ -30670,11 +31020,11 @@ czz
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -30874,18 +31224,18 @@ czz
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
 fMJ
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -31089,6 +31439,7 @@ czz
 czz
 czz
 hiB
+lQg
 hiB
 hiB
 hiB
@@ -31097,18 +31448,17 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
-hiB
-hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 czz
@@ -31318,7 +31668,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -31522,7 +31872,7 @@ eBC
 czz
 czz
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -31699,7 +32049,7 @@ rab
 rab
 rab
 oPr
-fvS
+hgX
 oPr
 oPr
 oPr
@@ -31742,22 +32092,22 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 eBC
 eBC
 hiB
 hiB
+lQg
+hiB
+hiB
+lQg
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
-hiB
-hiB
-hiB
-hiB
-hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -31962,7 +32312,7 @@ hiB
 hiB
 eBC
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -32175,7 +32525,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 eBC
 eBC
 czz
@@ -32186,7 +32536,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 czz
@@ -32400,7 +32750,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -32614,7 +32964,7 @@ eBC
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -32629,7 +32979,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 fMJ
 hiB
 czz
@@ -32825,7 +33175,7 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 eBC
 czz
 czz
@@ -32843,7 +33193,7 @@ czz
 czz
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -33040,16 +33390,16 @@ pRU
 eBC
 czz
 czz
-hiB
+lQg
 hiB
 hiB
 eBC
 czz
 kjO
+lQg
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 czz
 czz
@@ -33058,7 +33408,7 @@ czz
 czz
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -33272,6 +33622,7 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
@@ -33280,8 +33631,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -33410,10 +33760,10 @@ hMr
 hMr
 hMr
 gzv
-hMr
+uzE
 hMr
 ohM
-ohM
+dqF
 esC
 wfo
 knY
@@ -33476,17 +33826,17 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 eBC
 eBC
 czz
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -33630,7 +33980,7 @@ hMr
 hMr
 hMr
 ohM
-ohM
+dqF
 esC
 fWh
 knY
@@ -33700,7 +34050,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -33712,7 +34062,7 @@ hiB
 hiB
 fMJ
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -33922,7 +34272,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -34126,12 +34476,12 @@ eBC
 czz
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -34143,12 +34493,12 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 czz
 czz
@@ -34352,6 +34702,7 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
@@ -34362,8 +34713,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -34558,6 +34908,7 @@ pRU
 (38,1,1) = {"
 eBC
 czz
+lQg
 hiB
 hiB
 hiB
@@ -34573,8 +34924,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -34584,7 +34934,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 czz
 czz
@@ -34780,10 +35130,10 @@ hiB
 hiB
 fMJ
 hiB
+lQg
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -34793,7 +35143,7 @@ hiB
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -35016,7 +35366,7 @@ eBC
 eBC
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -35236,7 +35586,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 czz
@@ -35428,7 +35778,7 @@ eBC
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -35448,7 +35798,7 @@ eBC
 eBC
 czz
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -35458,7 +35808,7 @@ hiB
 hiB
 czz
 lsR
-eKe
+lsR
 eKe
 jpY
 pwp
@@ -35648,7 +35998,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 eBC
 eBC
@@ -35672,10 +36022,10 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 vAP
 lsR
-eKe
+lsR
 pwp
 pwp
 eKe
@@ -35860,7 +36210,7 @@ pRU
 (44,1,1) = {"
 eBC
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -35869,14 +36219,14 @@ hiB
 hiB
 czz
 czz
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 eBC
 eBC
@@ -35884,15 +36234,15 @@ eBC
 eBC
 czz
 hiB
-hiB
+lQg
 hiB
 fMJ
-hiB
+lQg
 hiB
 hiB
 lsR
 lsR
-viN
+weS
 pwp
 eKe
 aWt
@@ -36080,6 +36430,7 @@ czz
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
@@ -36088,8 +36439,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -36107,9 +36457,9 @@ hiB
 hiB
 hiB
 hiB
-eKe
 lsR
-eKe
+lsR
+lsR
 eKe
 eKe
 eKe
@@ -36301,14 +36651,14 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 eBC
@@ -36323,10 +36673,10 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 lsR
 lsR
-eKe
+lsR
 eKe
 eKe
 stX
@@ -36520,7 +36870,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -36542,8 +36892,8 @@ czz
 hiB
 hiB
 lsR
-eKe
-eKe
+lsR
+lsR
 jpY
 pUK
 stX
@@ -36729,7 +37079,7 @@ pRU
 eBC
 czz
 czz
-hiB
+lQg
 hiB
 czz
 czz
@@ -36740,6 +37090,7 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
@@ -36747,8 +37098,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -36760,7 +37110,7 @@ hiB
 hiB
 lsR
 lsR
-eKe
+lsR
 eKe
 pUK
 stX
@@ -36954,14 +37304,14 @@ czz
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -36970,14 +37320,14 @@ fMJ
 hiB
 hiB
 aHe
-hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 lsR
 lsR
-eKe
+lsR
 eKe
 pUK
 pUK
@@ -37165,11 +37515,11 @@ czz
 czz
 czz
 hiB
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 czz
@@ -37181,20 +37531,20 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 fMJ
+lQg
 hiB
-hiB
-eKe
 lsR
-eKe
+lsR
+lsR
 eKe
 pUK
 pUK
@@ -37242,16 +37592,16 @@ eae
 eae
 ubW
 jcN
-gah
-gah
+mrZ
+mrZ
 irF
 irF
 irF
-gah
-gah
+mrZ
+mrZ
 mxq
-gah
-gah
+mrZ
+mrZ
 usY
 usY
 usY
@@ -37392,7 +37742,7 @@ czz
 eBC
 eBC
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -37410,8 +37760,8 @@ hiB
 hiB
 hiB
 lsR
-eKe
-eKe
+lsR
+lsR
 eKe
 roU
 pUK
@@ -37599,7 +37949,7 @@ czz
 czz
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -37612,7 +37962,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 eBC
 eBC
@@ -37621,14 +37971,14 @@ eBC
 czz
 czz
 hiB
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 lsR
 lsR
-eKe
+lsR
 eKe
 pUK
 pUK
@@ -37818,7 +38168,7 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 eBC
 eBC
@@ -37840,7 +38190,7 @@ eBC
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 lsR
@@ -37898,7 +38248,7 @@ wnL
 osr
 osr
 hAb
-hAb
+tQD
 hAb
 hAb
 osr
@@ -38044,11 +38394,11 @@ eBC
 eBC
 eBC
 czz
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 czz
@@ -38059,7 +38409,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 eBC
 eKe
@@ -38252,6 +38602,19 @@ czz
 czz
 hiB
 hiB
+lQg
+hiB
+hiB
+czz
+czz
+eBC
+czz
+czz
+czz
+hiB
+hiB
+lQg
+hiB
 hiB
 hiB
 hiB
@@ -38260,20 +38623,7 @@ czz
 eBC
 czz
 czz
-czz
-hiB
-hiB
-hiB
-hiB
-hiB
-hiB
-hiB
-czz
-czz
-eBC
-czz
-czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -38378,7 +38728,7 @@ bSo
 bSo
 sDb
 bSo
-hVV
+jXg
 bSo
 noq
 bSo
@@ -38472,7 +38822,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 eBC
 czz
@@ -38483,7 +38833,7 @@ hiB
 hiB
 hiB
 fMJ
-hiB
+lQg
 hiB
 czz
 eBC
@@ -38492,7 +38842,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -38694,7 +39044,7 @@ hiB
 czz
 czz
 fMJ
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -38903,18 +39253,18 @@ czz
 czz
 czz
 hiB
-hiB
+lQg
 hiB
 fMJ
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -38923,11 +39273,11 @@ czz
 eBC
 czz
 hiB
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 czz
 czz
 eBC
@@ -38978,16 +39328,16 @@ eae
 eae
 mCN
 jcN
-gah
-gah
+mrZ
+mrZ
 mxq
-gah
-gah
+mrZ
+mrZ
 irF
 irF
 irF
-gah
-gah
+mrZ
+mrZ
 usY
 usY
 usY
@@ -39123,17 +39473,17 @@ hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
-hiB
-hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -39142,7 +39492,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 czz
@@ -39343,7 +39693,7 @@ eBC
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -39355,13 +39705,13 @@ czz
 eBC
 eBC
 czz
+lQg
 hiB
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 czz
 czz
 eBC
@@ -39554,7 +39904,7 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -39564,7 +39914,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -39791,7 +40141,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 swG
 hiB
 hiB
@@ -39984,19 +40334,19 @@ pRU
 eBC
 czz
 czz
+lQg
 hiB
 hiB
+lQg
 hiB
 hiB
-hiB
-hiB
-hiB
+lQg
 czz
 czz
 eBC
 eBC
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -40005,7 +40355,7 @@ eBC
 eBC
 czz
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -40216,7 +40566,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 eBC
 czz
@@ -40227,7 +40577,7 @@ hiB
 hiB
 hiB
 fMJ
-hiB
+lQg
 hiB
 hiB
 czz
@@ -40420,12 +40770,12 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 czz
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -40441,12 +40791,12 @@ czz
 czz
 hiB
 hiB
+lQg
 hiB
 hiB
 hiB
 hiB
-hiB
-hiB
+lQg
 czz
 eBC
 viN
@@ -40645,7 +40995,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -40865,7 +41215,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -40877,7 +41227,7 @@ czz
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -41068,7 +41418,7 @@ pRU
 (68,1,1) = {"
 eBC
 vjo
-hiB
+lQg
 ryS
 hiB
 hiB
@@ -41078,7 +41428,7 @@ eBC
 czz
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -41096,7 +41446,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 czz
 czz
@@ -41288,12 +41638,12 @@ vjo
 hiB
 hiB
 hiB
-hiB
+lQg
 ryS
 vjo
 eBC
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -41304,7 +41654,7 @@ hiB
 eBC
 czz
 hiB
-hiB
+lQg
 hiB
 czz
 eBC
@@ -41515,7 +41865,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 eBC
 eBC
@@ -41527,7 +41877,7 @@ hiB
 czz
 eBC
 czz
-hiB
+lQg
 hiB
 hiB
 hiB
@@ -41728,7 +42078,7 @@ eag
 czz
 czz
 fMJ
-hiB
+lQg
 czz
 hiB
 hiB
@@ -41740,7 +42090,7 @@ hiB
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 hiB
 eBC
@@ -41748,7 +42098,7 @@ czz
 hiB
 hiB
 hiB
-hiB
+lQg
 czz
 czz
 eBC
@@ -41939,7 +42289,7 @@ vjo
 hiB
 hiB
 hiB
-hiB
+lQg
 hiB
 eag
 czz
@@ -41950,10 +42300,10 @@ czz
 czz
 hiB
 hiB
+lQg
 hiB
 hiB
-hiB
-hiB
+lQg
 hiB
 hiB
 aHe
@@ -42161,10 +42511,11 @@ thT
 cny
 qyt
 thT
-thT
+hVV
 thT
 ybg
 qyt
+hVV
 thT
 thT
 thT
@@ -42174,8 +42525,7 @@ thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 qyt
 ybg
@@ -42385,7 +42735,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 thT
 aEg
 thT
@@ -42397,7 +42747,7 @@ thT
 thT
 ybg
 ybg
-thT
+hVV
 thT
 thT
 qyt
@@ -42594,7 +42944,7 @@ qyt
 ybg
 cny
 qyt
-thT
+hVV
 thT
 thT
 ybg
@@ -42606,7 +42956,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -42813,7 +43163,7 @@ xrW
 qyt
 thT
 thT
-thT
+hVV
 thT
 qyt
 ybg
@@ -42821,7 +43171,7 @@ ybg
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -42829,7 +43179,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -43247,7 +43597,7 @@ qyt
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -43260,14 +43610,14 @@ thT
 qyt
 ybg
 qyt
+hVV
 thT
 thT
 thT
 thT
 thT
 thT
-thT
-thT
+hVV
 qyt
 qyt
 ybg
@@ -43466,14 +43816,14 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 thT
 qyt
 thT
 thT
 thT
 thT
-thT
+hVV
 qyt
 ybg
 qyt
@@ -43484,7 +43834,7 @@ aEg
 thT
 thT
 thT
-thT
+qyt
 qyt
 qyt
 ybg
@@ -43687,7 +44037,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -43698,7 +44048,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -43747,7 +44097,7 @@ eKe
 pwp
 pwp
 pwp
-pwp
+tEq
 pwp
 pwp
 viN
@@ -43893,7 +44243,7 @@ qyt
 qyt
 qyt
 thT
-thT
+qyt
 qyt
 qyt
 ybg
@@ -43901,7 +44251,7 @@ ybg
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -44123,14 +44473,14 @@ thT
 thT
 aEg
 thT
-thT
+hVV
 thT
 qyt
 ybg
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 qyt
@@ -44189,13 +44539,13 @@ eKe
 pwp
 eKe
 eKe
-aWt
 eKe
 eKe
 eKe
 eKe
 eKe
-ylG
+eKe
+eKe
 hoU
 hoU
 hoU
@@ -44326,7 +44676,7 @@ qyt
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 qyt
@@ -44337,7 +44687,7 @@ ybg
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -44411,7 +44761,7 @@ eKe
 eKe
 eKe
 eKe
-eKe
+kDw
 pwp
 hoU
 hoU
@@ -44546,7 +44896,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -44627,9 +44977,9 @@ eKe
 eKe
 eKe
 eKe
-eKe
-eKe
-eKe
+kDw
+kDw
+kDw
 hoU
 hoU
 hoU
@@ -44759,13 +45109,13 @@ ybg
 qyt
 qyt
 qyt
-thT
+hVV
 thT
 rCa
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -44843,11 +45193,11 @@ eKe
 eKe
 eKe
 jpY
-eKe
-eKe
-eKe
-eKe
-sEi
+kDw
+kDw
+tmQ
+kDw
+xlV
 bLd
 hoU
 hoU
@@ -44984,7 +45334,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 ybg
@@ -45000,7 +45350,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -45060,12 +45410,12 @@ jpY
 eKe
 eKe
 eKe
-viN
 eKe
-eKe
-eKe
-hoU
-hoU
+kDw
+kDw
+kDw
+xlV
+xlV
 sEi
 lBc
 hoU
@@ -45205,7 +45555,7 @@ thT
 thT
 qyt
 qyt
-thT
+hVV
 thT
 thT
 thT
@@ -45214,7 +45564,7 @@ qyt
 qyt
 ybg
 ybg
-thT
+hVV
 thT
 thT
 thT
@@ -45278,10 +45628,10 @@ eKe
 eKe
 eKe
 eKe
-eKe
-eKe
-aWt
-hoU
+kDw
+kDw
+kDw
+xlV
 hoU
 hoU
 hoU
@@ -45413,6 +45763,7 @@ qyt
 thT
 thT
 thT
+hVV
 thT
 thT
 thT
@@ -45425,8 +45776,7 @@ thT
 thT
 thT
 thT
-thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -45435,19 +45785,19 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 qyt
 qyt
-ybg
-eKe
-eKe
-eKe
-eKe
-eKe
-eKe
-eKe
+cny
+cTa
+cTa
+cTa
+cTa
+cTa
+cTa
+cTa
 lAY
 fQi
 pwp
@@ -45497,7 +45847,7 @@ eKe
 pwp
 pwp
 jpY
-eKe
+kDw
 hoU
 hoU
 ljS
@@ -45628,12 +45978,12 @@ qyt
 qyt
 qyt
 thT
+hVV
 thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -45657,14 +46007,14 @@ qyt
 qyt
 qyt
 qyt
-ybg
+cny
 eKe
 eKe
 fEB
 eKe
 pwp
 pwp
-ylG
+xUy
 eKe
 eKe
 uNH
@@ -45711,7 +46061,7 @@ fQi
 eKe
 eKe
 eKe
-ylG
+eKe
 pwp
 pwp
 pwp
@@ -45858,30 +46208,30 @@ thT
 xFl
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
 qyt
-qyt
-qyt
-ybg
-qyt
-thT
-thT
-thT
-thT
 qyt
 qyt
 ybg
+qyt
+hVV
+thT
+thT
+thT
+qyt
+qyt
 ybg
+cny
 eKe
 tre
-eKe
+mFe
 eKe
 pwp
 eKe
-eKe
+cTa
 eKe
 eKe
 eKe
@@ -45940,7 +46290,7 @@ hoU
 sEi
 sEi
 sEi
-erh
+hoU
 hoU
 mUN
 kQT
@@ -46091,14 +46441,14 @@ thT
 qyt
 qyt
 ybg
-eKe
+cTa
 eKe
 eKe
 eKe
 jpY
 pwp
 eKe
-jpY
+kEC
 tre
 eKe
 eKe
@@ -46157,7 +46507,7 @@ hoU
 hoU
 nqK
 sEi
-sEi
+bLd
 hoU
 mUN
 olw
@@ -46281,17 +46631,17 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 qyt
 ybg
 qyt
 qyt
+hVV
 thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 aEg
@@ -46304,18 +46654,18 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 ybg
-ylG
+xUy
 eKe
 eKe
 tre
 eKe
 eKe
 eKe
-eKe
+cTa
 eKe
 pwp
 pwp
@@ -46513,7 +46863,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -46525,14 +46875,14 @@ thT
 thT
 qyt
 ybg
+cTa
+jpY
 eKe
 eKe
 eKe
 eKe
 eKe
-eKe
-eKe
-eKe
+cTa
 pwp
 pwp
 xMJ
@@ -46693,16 +47043,16 @@ cXs
 cXs
 cXs
 cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
-cXs
+hwi
+hwi
+hwi
+hwi
+hwi
+hwi
+hwi
+hwi
+hwi
+hwi
 ajj
 jdK
 pRU
@@ -46713,16 +47063,16 @@ qyt
 qyt
 qyt
 qyt
+hVV
+thT
+thT
+thT
+hVV
 thT
 thT
 thT
 thT
-thT
-thT
-thT
-thT
-thT
-thT
+hVV
 thT
 sHh
 ftz
@@ -46736,20 +47086,20 @@ ftz
 aGg
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
 thT
 ybg
+cTa
 eKe
 eKe
-eKe
 pwp
 pwp
 pwp
 pwp
-xMJ
+cjV
 pjx
 pjx
 yhR
@@ -46810,10 +47160,10 @@ xmK
 tMF
 qBB
 qBB
-qBB
+kHf
 vxX
 sEi
-sEi
+bLd
 sEi
 sEi
 sEi
@@ -46910,6 +47260,7 @@ cXs
 cXs
 cXs
 cXs
+hwi
 cXs
 cXs
 cXs
@@ -46918,8 +47269,7 @@ cXs
 cXs
 cXs
 cXs
-cXs
-cXs
+hwi
 ajj
 jdK
 pRU
@@ -46937,7 +47287,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 sHh
 ftz
@@ -46957,16 +47307,16 @@ aGg
 thT
 thT
 thT
-thT
+hVV
 ybg
-eKe
-eKe
-xMJ
-pjx
-pjx
-pjx
-pjx
-yhR
+cTa
+cTa
+cjV
+wrN
+wrN
+wrN
+wrN
+wyq
 tpA
 xxw
 tpA
@@ -47127,6 +47477,7 @@ cXs
 cXs
 cXs
 cXs
+hwi
 cXs
 cXs
 cXs
@@ -47135,8 +47486,7 @@ cXs
 cXs
 cXs
 cXs
-cXs
-cXs
+hwi
 ajj
 jdK
 pRU
@@ -47148,7 +47498,7 @@ aGg
 qyt
 qyt
 thT
-thT
+hVV
 sHh
 ftz
 ftz
@@ -47159,7 +47509,7 @@ sHh
 jDG
 xlm
 xlm
-xlm
+hza
 xlm
 xlm
 xlm
@@ -47177,7 +47527,7 @@ ftz
 ftz
 ftz
 pjx
-pjx
+veN
 yhR
 xxw
 xxw
@@ -47344,16 +47694,16 @@ ajj
 cXs
 cXs
 cXs
+hwi
 cXs
 cXs
 cXs
 cXs
-cXs
-ajj
-cXs
+rMh
 cXs
 cXs
 cXs
+hwi
 cXs
 jdK
 pRU
@@ -47370,7 +47720,7 @@ jDG
 xlm
 xlm
 xlm
-uoC
+esb
 ftz
 jDG
 xlm
@@ -47379,20 +47729,20 @@ ezS
 ezS
 ezS
 xlm
-xlm
+hza
 ezS
 ezS
 ezS
 ezS
 ezS
 ezS
-ezS
+hJz
 xlm
 xlm
 xlm
 xlm
 xlm
-xlm
+hza
 xxw
 xxw
 xxw
@@ -47561,6 +47911,7 @@ ajj
 ajj
 ajj
 ajj
+hwi
 cXs
 cXs
 cXs
@@ -47569,8 +47920,7 @@ cXs
 cXs
 cXs
 cXs
-cXs
-cXs
+hwi
 ajj
 jdK
 pRU
@@ -47581,10 +47931,10 @@ xlm
 xlm
 xlm
 xlm
+hza
 xlm
 xlm
-xlm
-xlm
+hza
 ezS
 ezS
 ezS
@@ -47648,15 +47998,15 @@ xxw
 tpA
 eSp
 fqx
-lQC
-iiy
-iiy
-iiy
-jVy
-fqx
-fqx
-sPx
-xxw
+mlX
+jAD
+jAD
+jAD
+hIt
+wzP
+wzP
+hAv
+xMo
 xxw
 xxw
 kzH
@@ -47778,8 +48128,8 @@ aJr
 lBp
 ajj
 ajj
+fvS
 ajj
-ajj
 cXs
 cXs
 cXs
@@ -47787,7 +48137,7 @@ cXs
 cXs
 cXs
 cXs
-ajj
+fvS
 ajj
 jdK
 pRU
@@ -47809,6 +48159,7 @@ ezS
 ezS
 ezS
 ezS
+hJz
 ezS
 ezS
 ezS
@@ -47822,8 +48173,7 @@ ezS
 ezS
 ezS
 ezS
-ezS
-ezS
+hJz
 ezS
 ezS
 ezS
@@ -47865,7 +48215,7 @@ eSp
 fqx
 lQC
 aly
-aly
+bnl
 iiy
 lvb
 lvb
@@ -47873,7 +48223,7 @@ aly
 aly
 aly
 jVy
-sPx
+hAv
 xxw
 xxw
 xxw
@@ -47995,7 +48345,7 @@ ygq
 sqp
 lBp
 ajj
-ajj
+fvS
 ajj
 ajj
 ajj
@@ -48004,7 +48354,7 @@ cXs
 cXs
 cXs
 cXs
-ajj
+fvS
 ajj
 jdK
 pRU
@@ -48020,6 +48370,7 @@ ezS
 ezS
 ezS
 ezS
+hJz
 ezS
 ezS
 ezS
@@ -48028,15 +48379,14 @@ ezS
 ezS
 ezS
 ezS
+hJz
 ezS
 ezS
 ezS
 ezS
 ezS
 ezS
-ezS
-ezS
-ezS
+hJz
 ezS
 ezS
 ezS
@@ -48082,7 +48432,7 @@ bNu
 aly
 aly
 aly
-aly
+bnl
 veA
 mPt
 lvb
@@ -48090,7 +48440,7 @@ veA
 veA
 aly
 aly
-jVy
+hIt
 fqx
 sPx
 xxw
@@ -48212,7 +48562,7 @@ ygq
 gdp
 sqp
 aJr
-aJr
+coa
 aJr
 aJr
 lBp
@@ -48221,7 +48571,7 @@ ajj
 cXs
 cXs
 cXs
-ajj
+fvS
 ajj
 jdK
 pRU
@@ -48233,7 +48583,7 @@ ezS
 ezS
 ezS
 ezS
-ezS
+hJz
 ezS
 ezS
 ezS
@@ -48260,7 +48610,7 @@ xlm
 xlm
 xlm
 xlm
-xlm
+hza
 xxw
 xxw
 tpA
@@ -48299,15 +48649,15 @@ bbf
 vjf
 aly
 aly
+weT
 veA
 veA
-veA
-iiy
+qju
 lvb
-veA
+iqr
 veA
 aly
-aly
+bnl
 aly
 jVy
 sPx
@@ -48429,16 +48779,16 @@ gdp
 ygq
 ygq
 ygq
-gdp
-ygq
-ygq
-sqp
-lBp
-ajj
-ajj
-ajj
-ajj
-ajj
+ucq
+xGN
+xGN
+oMH
+ubh
+fvS
+fvS
+fvS
+fvS
+fvS
 reW
 aJr
 pRU
@@ -48480,7 +48830,7 @@ ebd
 ebd
 fqx
 fqx
-fqx
+tJf
 sPx
 xxw
 tpA
@@ -48516,15 +48866,15 @@ xxw
 uGV
 pjx
 vjf
+bnl
 aly
-aly
 veA
 lvb
 lvb
 lvb
 veA
 veA
-veA
+weT
 iiy
 lvb
 jVy
@@ -48669,17 +49019,17 @@ ezS
 ezS
 ezS
 ezS
-ezS
-ezS
-xlm
-ezS
-ezS
+hJz
 ezS
 xlm
+ezS
+ezS
+ezS
 xlm
 xlm
+hza
 xlm
-xlm
+hza
 yhK
 ebd
 ebd
@@ -48687,10 +49037,10 @@ ebd
 ebd
 ebd
 oDQ
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -48733,7 +49083,7 @@ xxw
 xxw
 xxw
 uGV
-vjf
+fsH
 veA
 veA
 veA
@@ -48741,7 +49091,7 @@ lvb
 lvb
 iiy
 lvb
-iiy
+jAD
 lvb
 lvb
 iiy
@@ -48889,7 +49239,7 @@ xlm
 xlm
 xlm
 xlm
-xlm
+hza
 xlm
 xlm
 yhK
@@ -48900,6 +49250,7 @@ ebd
 oDQ
 thT
 thT
+hVV
 thT
 thT
 thT
@@ -48908,8 +49259,7 @@ thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 ybg
@@ -48950,17 +49300,17 @@ kzH
 xxw
 tpA
 xxw
-bNu
+nWs
 aly
 aly
 aly
 lvb
-lvb
+ovW
 iiy
 jQG
+fHC
 lvb
-lvb
-lvb
+ovW
 veA
 aly
 fBm
@@ -49102,7 +49452,7 @@ xlm
 xlm
 xlm
 xlm
-xlm
+hza
 xlm
 xlm
 yhK
@@ -49120,7 +49470,7 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -49167,7 +49517,7 @@ kzH
 kzH
 xxw
 tpA
-bbf
+mUy
 pjx
 vjf
 iiy
@@ -49175,7 +49525,7 @@ lvb
 lvb
 lvb
 lvb
-lvb
+fHC
 ldH
 lvb
 veA
@@ -49316,16 +49666,16 @@ ybg
 xlm
 xlm
 xlm
-ebd
+oNc
 ebd
 ebd
 ebd
 ebd
 ebd
 oDQ
+hVV
 thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -49384,15 +49734,15 @@ kzH
 kzH
 xxw
 xxw
-xxw
-tpA
-bbf
-vjf
-iiy
-veA
-veA
-veA
-lvb
+xMo
+cEx
+mUy
+fsH
+jAD
+weT
+weT
+weT
+fHC
 lvb
 iiy
 veA
@@ -49546,7 +49896,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -49755,13 +50105,13 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 qyt
 aEg
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -49830,7 +50180,7 @@ aly
 veA
 lvb
 veA
-veA
+mcP
 veA
 veA
 aly
@@ -49970,7 +50320,7 @@ qyt
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -50201,11 +50551,11 @@ thT
 thT
 thT
 thT
+hVV
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 qyt
@@ -50407,7 +50757,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -50415,7 +50765,7 @@ ybg
 ybg
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -50638,11 +50988,11 @@ thT
 thT
 thT
 thT
+hVV
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -50840,11 +51190,11 @@ qyt
 qyt
 qyt
 qyt
-thT
+hVV
 thT
 xFl
 thT
-thT
+hVV
 thT
 qyt
 ybg
@@ -50852,6 +51202,7 @@ ybg
 qyt
 qyt
 qyt
+hVV
 thT
 thT
 thT
@@ -50861,8 +51212,7 @@ thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -51073,10 +51423,10 @@ thT
 thT
 thT
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 aEg
@@ -51495,17 +51845,17 @@ qyt
 qyt
 qyt
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 qyt
 qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 thT
 thT
@@ -51514,7 +51864,7 @@ thT
 xFl
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -51937,7 +52287,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 ybg
@@ -51945,7 +52295,7 @@ ybg
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -52149,10 +52499,10 @@ qyt
 qyt
 thT
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -52167,7 +52517,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -52373,7 +52723,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 qyt
 ybg
 ybg
@@ -52588,7 +52938,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -52598,7 +52948,7 @@ ybg
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -52803,7 +53153,7 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -53010,6 +53360,18 @@ qyt
 qyt
 thT
 thT
+hVV
+thT
+thT
+hVV
+thT
+qyt
+ybg
+ybg
+qyt
+thT
+thT
+thT
 thT
 thT
 thT
@@ -53019,22 +53381,10 @@ qyt
 ybg
 ybg
 qyt
-thT
-thT
-thT
-thT
-thT
-thT
-thT
-thT
-qyt
-ybg
-ybg
-qyt
 qyt
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -53253,7 +53603,7 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -53442,7 +53792,7 @@ qyt
 qyt
 qyt
 qyt
-thT
+hVV
 thT
 thT
 thT
@@ -53456,10 +53806,10 @@ ybg
 ybg
 qyt
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -53661,11 +54011,11 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 aEg
 thT
 thT
-thT
+hVV
 thT
 thT
 qyt
@@ -53875,37 +54225,37 @@ qyt
 qyt
 qyt
 thT
-thT
-thT
-thT
-thT
-qyt
-qyt
-thT
-thT
-thT
+hVV
 thT
 thT
 thT
 qyt
+qyt
 thT
+thT
+thT
+thT
+thT
+hVV
+qyt
+hVV
 thT
 thT
 thT
 qyt
 ybg
-ybg
-qyt
-qyt
-qyt
-qyt
 ybg
 qyt
 qyt
 qyt
+qyt
+ybg
+qyt
+qyt
+qyt
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -54108,7 +54458,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -54310,15 +54660,15 @@ qyt
 qyt
 thT
 thT
+hVV
 thT
-thT
 qyt
 qyt
 qyt
 qyt
 qyt
 qyt
-thT
+hVV
 thT
 thT
 thT
@@ -54340,7 +54690,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 ybg
@@ -54539,7 +54889,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -54554,7 +54904,7 @@ qyt
 ybg
 qyt
 qyt
-thT
+hVV
 thT
 thT
 thT
@@ -54742,14 +55092,14 @@ qyt
 qyt
 qyt
 qyt
+hVV
 thT
 thT
 thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -54761,10 +55111,10 @@ thT
 thT
 thT
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 qyt
@@ -54969,13 +55319,13 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
 aEg
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -54989,10 +55339,10 @@ ybg
 qyt
 qyt
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 qyt
 qyt
 ybg
@@ -55179,17 +55529,17 @@ qyt
 thT
 thT
 thT
+hVV
+thT
+thT
+hVV
 thT
 thT
 thT
 thT
 thT
 thT
-thT
-thT
-thT
-thT
-thT
+hVV
 thT
 thT
 thT
@@ -55393,7 +55743,7 @@ qyt
 qyt
 qyt
 qyt
-thT
+hVV
 aEg
 thT
 thT
@@ -55402,17 +55752,7 @@ qyt
 qyt
 qyt
 thT
-thT
-thT
-thT
-thT
-thT
-thT
-thT
-qyt
-ybg
-qyt
-qyt
+hVV
 thT
 thT
 thT
@@ -55421,8 +55761,18 @@ thT
 thT
 qyt
 ybg
-ybg
+qyt
+qyt
 thT
+hVV
+thT
+thT
+hVV
+thT
+qyt
+ybg
+ybg
+hVV
 thT
 rCa
 thT
@@ -55622,28 +55972,28 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 thT
 thT
 qyt
-qyt
-ybg
-ybg
-qyt
-qyt
-thT
-thT
-thT
-thT
-thT
 qyt
 ybg
 ybg
+qyt
+qyt
 thT
 thT
 thT
 thT
 thT
+qyt
+ybg
+ybg
+thT
+thT
+thT
+thT
+hVV
 qyt
 qyt
 qyt
@@ -55841,7 +56191,7 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 thT
 thT
 qyt
@@ -55852,7 +56202,7 @@ thT
 aEg
 thT
 thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -56046,7 +56396,7 @@ qyt
 qyt
 thT
 thT
-thT
+hVV
 qyt
 qyt
 ybg
@@ -56074,9 +56424,9 @@ thT
 thT
 qyt
 thT
+hVV
 thT
-thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -56283,13 +56633,13 @@ thT
 thT
 thT
 thT
+hVV
 thT
 thT
 thT
 thT
 thT
-thT
-thT
+hVV
 thT
 thT
 aEg
@@ -56478,7 +56828,7 @@ qyt
 qyt
 qyt
 qyt
-thT
+hVV
 thT
 thT
 thT
@@ -56503,7 +56853,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -56698,7 +57048,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -56708,13 +57058,13 @@ thT
 thT
 thT
 thT
+hVV
 thT
 thT
 thT
+hVV
 thT
-thT
-thT
-thT
+hVV
 thT
 thT
 qyt
@@ -56725,7 +57075,7 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -56922,7 +57272,7 @@ xrW
 xrW
 thT
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -56939,7 +57289,7 @@ ybg
 ybg
 qyt
 thT
-thT
+hVV
 thT
 thT
 thT
@@ -57347,10 +57697,10 @@ qyt
 qyt
 qyt
 gEC
+hVV
 thT
 thT
-thT
-thT
+hVV
 sCw
 thT
 gEC
@@ -57359,17 +57709,17 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 thT
 aEg
 thT
 qyt
 thT
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 ybg
 ybg
@@ -57571,7 +57921,7 @@ thT
 thT
 thT
 gEC
-thT
+hVV
 thT
 qyt
 qyt
@@ -57785,24 +58135,24 @@ thT
 thT
 thT
 thT
-thT
+hVV
 thT
 gEC
 qyt
 qyt
 ybg
 qyt
+hVV
 thT
 thT
-thT
-thT
+hVV
 thT
 qyt
 qyt
 qyt
 thT
 thT
-thT
+hVV
 aEg
 thT
 thT
@@ -58021,7 +58371,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 thT
 qyt
 qyt
@@ -58228,7 +58578,7 @@ qyt
 thT
 thT
 thT
-thT
+hVV
 qyt
 qyt
 qyt
@@ -58443,16 +58793,16 @@ qyt
 qyt
 thT
 thT
+hVV
 thT
 thT
-thT
 qyt
 qyt
 qyt
 qyt
 qyt
 qyt
-thT
+hVV
 thT
 thT
 qyt
@@ -58662,7 +59012,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 rzk
@@ -58683,7 +59033,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -58875,7 +59225,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -58888,7 +59238,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 okU
@@ -59096,7 +59446,7 @@ sAv
 sAv
 nrp
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -59112,17 +59462,17 @@ okU
 rzk
 rzk
 sAv
+qIK
+sAv
+sAv
+qIK
 sAv
 sAv
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -59306,7 +59656,7 @@ okU
 okU
 rzk
 rzk
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -59320,9 +59670,9 @@ rzk
 rzk
 rzk
 sAv
+qIK
 sAv
-sAv
-sAv
+qIK
 rzk
 rzk
 okU
@@ -59529,7 +59879,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -59738,11 +60088,11 @@ rzk
 rzk
 rzk
 rzk
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -59762,16 +60112,16 @@ rzk
 okU
 okU
 sAv
+qIK
+sAv
+qIK
+sAv
+sAv
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -59965,7 +60315,7 @@ rzk
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -60168,13 +60518,13 @@ rzk
 rzk
 rzk
 rzk
+qIK
+sAv
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -60185,11 +60535,11 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -60197,7 +60547,7 @@ rzk
 okU
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -60397,10 +60747,10 @@ rzk
 rzk
 rzk
 rzk
+qIK
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -60425,7 +60775,7 @@ sAv
 sAv
 sAv
 jJT
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -60606,7 +60956,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 rzk
@@ -60626,19 +60976,19 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 rzk
 okU
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -60820,7 +61170,7 @@ rzk
 rzk
 sAv
 nmb
-sAv
+qIK
 jJT
 sAv
 sAv
@@ -60836,7 +61186,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 sAv
@@ -61041,7 +61391,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -61050,22 +61400,7 @@ rzk
 rzk
 rzk
 sAv
-sAv
-sAv
-sAv
-sAv
-rzk
-okU
-rzk
-sAv
-sAv
-sAv
-sAv
-sAv
-rzk
-rzk
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -61075,6 +61410,21 @@ rzk
 sAv
 sAv
 sAv
+sAv
+sAv
+rzk
+rzk
+sAv
+sAv
+sAv
+sAv
+sAv
+rzk
+okU
+rzk
+sAv
+sAv
+qIK
 sAv
 sAv
 sAv
@@ -61256,7 +61606,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -61282,7 +61632,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -61477,7 +61827,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 okU
 rzk
@@ -61486,12 +61836,13 @@ rzk
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 okU
 rzk
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -61501,8 +61852,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 rzk
 okU
@@ -61692,7 +62042,7 @@ iVy
 iVy
 gfh
 iTI
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -61700,27 +62050,11 @@ rzk
 okU
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
 rzk
-rzk
-okU
-rzk
-rzk
-jJT
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
 rzk
 okU
 rzk
@@ -61729,6 +62063,22 @@ jJT
 sAv
 sAv
 sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+rzk
+okU
+rzk
+rzk
+jJT
+sAv
+sAv
+qIK
 sAv
 rzk
 okU
@@ -61931,7 +62281,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -62127,7 +62477,7 @@ sAv
 okU
 gfh
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -62346,7 +62696,7 @@ iTI
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 okU
 rzk
@@ -62367,11 +62717,11 @@ rzk
 rzk
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 rzk
 okU
 rzk
@@ -62560,7 +62910,7 @@ sAv
 sAv
 sAv
 iTI
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -62594,7 +62944,7 @@ okU
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -62855,7 +63205,7 @@ fFv
 kac
 fFv
 fFv
-elN
+vgG
 fFv
 fFv
 fFv
@@ -62996,7 +63346,7 @@ sAv
 iTI
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -63209,7 +63559,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 iTI
 sAv
 sAv
@@ -63224,7 +63574,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -63247,7 +63597,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -63431,31 +63781,31 @@ iTI
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
-rzk
-okU
-rzk
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
 rzk
 okU
+rzk
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+qIK
+rzk
+okU
 okU
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 okU
@@ -63662,7 +64012,7 @@ sAv
 nrp
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -63678,7 +64028,7 @@ okU
 okU
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -63841,13 +64191,13 @@ rGz
 csL
 csL
 csL
-rGz
-rGz
-rGz
-nMN
-rGz
-csL
-jdK
+dCb
+dCb
+dCb
+wmF
+dCb
+njA
+bzb
 pRU
 "}
 (173,1,1) = {"
@@ -63872,7 +64222,7 @@ rzk
 okU
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -64058,13 +64408,13 @@ csL
 csL
 eOV
 csL
-rGz
-rGz
-csL
+dCb
 rGz
 csL
+rGz
 csL
-jdK
+csL
+bzb
 pRU
 "}
 (174,1,1) = {"
@@ -64081,7 +64431,7 @@ gfh
 gfh
 rzk
 sAv
-sAv
+qIK
 sAv
 jJT
 rzk
@@ -64275,13 +64625,13 @@ nMN
 csL
 rGz
 csL
+njA
 csL
-csL
 rGz
 rGz
 rGz
 rGz
-jdK
+bzb
 pRU
 "}
 (175,1,1) = {"
@@ -64316,7 +64666,7 @@ sAv
 rzk
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -64492,13 +64842,13 @@ csL
 csL
 csL
 csL
-csL
+njA
 nMN
 csL
 rGz
-rGz
+aiT
 csL
-jdK
+bzb
 pRU
 "}
 (176,1,1) = {"
@@ -64527,7 +64877,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -64544,11 +64894,11 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -64709,13 +65059,13 @@ rGz
 rGz
 csL
 csL
-rGz
+dCb
 csL
 csL
 csL
 csL
 csL
-jdK
+bzb
 pRU
 "}
 (177,1,1) = {"
@@ -64756,7 +65106,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -64926,13 +65276,13 @@ csL
 rGz
 rGz
 csL
-csL
+njA
 csL
 csL
 rGz
 csL
 csL
-csL
+njA
 pRU
 "}
 (178,1,1) = {"
@@ -64952,7 +65302,7 @@ rzk
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 okU
 rzk
@@ -65143,13 +65493,13 @@ rGz
 csL
 csL
 csL
-csL
+njA
 nMN
 csL
 rGz
 rGz
 rGz
-csL
+njA
 pRU
 "}
 (179,1,1) = {"
@@ -65175,7 +65525,7 @@ okU
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -65187,7 +65537,7 @@ rzk
 jJT
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -65360,13 +65710,13 @@ csL
 csL
 csL
 rGz
-csL
-csL
-csL
-rGz
-rGz
-csL
-csL
+njA
+njA
+njA
+dCb
+dCb
+njA
+njA
 pRU
 "}
 (180,1,1) = {"
@@ -65409,7 +65759,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -65630,7 +65980,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 jJT
@@ -65829,7 +66179,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -66036,7 +66386,7 @@ rzk
 okU
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -66247,7 +66597,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -66689,19 +67039,19 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
+qIK
 sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -66902,7 +67252,7 @@ sAv
 jJT
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -66923,7 +67273,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 jJT
 rzk
@@ -67138,7 +67488,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -67330,6 +67680,7 @@ rzk
 rzk
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -67342,8 +67693,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -67360,7 +67710,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -67569,18 +67919,18 @@ okU
 rzk
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -67801,7 +68151,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -67985,12 +68335,12 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 jJT
@@ -68014,7 +68364,7 @@ rzk
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -68217,7 +68567,7 @@ okU
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 ssH
 sAv
@@ -68228,13 +68578,13 @@ rzk
 okU
 okU
 rzk
+qIK
 sAv
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -68454,7 +68804,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -68654,7 +69004,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -68806,7 +69156,7 @@ xYK
 xYK
 xYK
 xYK
-lQg
+hKw
 xYK
 xYK
 xYK
@@ -68860,7 +69210,7 @@ okU
 okU
 rzk
 sAv
-sAv
+qIK
 sAv
 jJT
 rzk
@@ -68886,7 +69236,7 @@ rzk
 rzk
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -68894,7 +69244,7 @@ sAv
 sAv
 fSy
 vmd
-fFv
+vmd
 lia
 lia
 lia
@@ -69091,7 +69441,7 @@ rzk
 sAv
 nrp
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -69111,7 +69461,7 @@ sAv
 sAv
 fSy
 fSy
-hvS
+bTd
 fFv
 lia
 lia
@@ -69295,7 +69645,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -69328,7 +69678,7 @@ sAv
 sAv
 fSy
 vmd
-lia
+fSy
 lia
 lia
 lia
@@ -69505,47 +69855,47 @@ sAv
 sAv
 sAv
 sAv
+qIK
+sAv
+sAv
+qIK
+sAv
+sAv
+sAv
+sAv
+iTI
+iTI
+iTI
+iTI
+iTI
+gfh
+kMp
+iTI
+iTI
 sAv
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+rzk
+okU
+okU
+rzk
+rzk
+rzk
+okU
+okU
+rzk
 rzk
 jJT
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-rzk
-okU
-okU
-rzk
-rzk
-rzk
-okU
-okU
-rzk
-rzk
-jJT
-sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 fSy
 vmd
-lia
+fSy
 lia
 lia
 eXh
@@ -69719,6 +70069,7 @@ okU
 rzk
 ksP
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -69729,16 +70080,15 @@ sAv
 sAv
 sAv
 sAv
+iTI
 sAv
 sAv
 sAv
+qIK
+jho
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+iTI
 sAv
 sAv
 sAv
@@ -69755,14 +70105,14 @@ okU
 okU
 rzk
 rzk
-sAv
+qIK
 sAv
 sAv
 sAv
 sAv
 fSy
 fSy
-lia
+fSy
 lia
 hvS
 lia
@@ -69944,6 +70294,10 @@ sAv
 sAv
 sAv
 sAv
+qIK
+sAv
+sAv
+iTI
 sAv
 sAv
 sAv
@@ -69951,12 +70305,8 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+iTI
+qIK
 sAv
 sAv
 rzk
@@ -69965,7 +70315,7 @@ okU
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -69979,7 +70329,7 @@ sAv
 sAv
 vmd
 fSy
-lia
+fSy
 lia
 lia
 lia
@@ -70156,6 +70506,7 @@ rzk
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -70163,16 +70514,15 @@ sAv
 sAv
 sAv
 sAv
+iTI
+sAv
+qIK
 sAv
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+iTI
 sAv
 sAv
 jJT
@@ -70191,12 +70541,12 @@ rzk
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
 vmd
-lia
+fSy
 lia
 fFv
 lia
@@ -70376,20 +70726,20 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 rzk
 sAv
+iTI
 sAv
 sAv
 sAv
 sAv
+qGH
 sAv
-sAv
-sAv
-sAv
-sAv
+qIK
+iTI
 sAv
 sAv
 rzk
@@ -70403,9 +70753,9 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -70587,7 +70937,7 @@ rzk
 rzk
 rzk
 rzk
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -70598,15 +70948,15 @@ rzk
 rzk
 rzk
 jJT
+iTI
+jho
 sAv
 sAv
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
+iTI
 sAv
 sAv
 rzk
@@ -70615,6 +70965,7 @@ rzk
 rzk
 jJT
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -70624,8 +70975,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 rzk
 rzk
 rzk
@@ -70815,6 +71165,7 @@ rzk
 rzk
 rzk
 rzk
+iTI
 sAv
 sAv
 sAv
@@ -70822,20 +71173,19 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+iTI
 sAv
 rzk
 okU
 okU
 rzk
 rzk
+qIK
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -71022,7 +71372,7 @@ rzk
 rzk
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -71032,15 +71382,15 @@ rzk
 rzk
 rzk
 rzk
+iTI
 sAv
 sAv
+qIK
 sAv
 sAv
+jho
 sAv
-sAv
-sAv
-sAv
-sAv
+iTI
 rzk
 rzk
 okU
@@ -71056,7 +71406,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -71249,7 +71599,7 @@ rzk
 rzk
 rzk
 rzk
-rzk
+gfh
 sAv
 sAv
 sAv
@@ -71257,7 +71607,7 @@ sAv
 sAv
 sAv
 sAv
-rzk
+gfh
 okU
 okU
 rzk
@@ -71267,6 +71617,7 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -71275,8 +71626,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -71457,7 +71807,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 rzk
@@ -71466,7 +71816,7 @@ rzk
 rzk
 rzk
 rzk
-rzk
+gfh
 rzk
 rzk
 sAv
@@ -71474,7 +71824,7 @@ sAv
 jJT
 rzk
 rzk
-rzk
+gfh
 okU
 rzk
 rzk
@@ -71482,16 +71832,16 @@ rzk
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -71672,22 +72022,9 @@ rzk
 rzk
 rzk
 rzk
+qIK
 sAv
 sAv
-sAv
-rzk
-rzk
-rzk
-okU
-okU
-rzk
-rzk
-rzk
-rzk
-rzk
-rzk
-rzk
-rzk
 rzk
 rzk
 rzk
@@ -71696,7 +72033,20 @@ okU
 rzk
 rzk
 rzk
-sAv
+gfh
+gfh
+gfh
+gfh
+gfh
+gfh
+gfh
+gfh
+iVy
+okU
+rzk
+rzk
+rzk
+qIK
 sAv
 sAv
 sAv
@@ -71713,7 +72063,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 okU
@@ -71917,7 +72267,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 sAv
@@ -72129,11 +72479,11 @@ rzk
 rzk
 rzk
 sAv
+qIK
 sAv
 sAv
 sAv
 sAv
-sAv
 rzk
 rzk
 rzk
@@ -72145,7 +72495,7 @@ rzk
 rzk
 rzk
 sAv
-sAv
+qIK
 sAv
 ksP
 okU
@@ -72325,7 +72675,7 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -72349,7 +72699,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -72540,7 +72890,7 @@ rzk
 rzk
 rzk
 rzk
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -72662,15 +73012,15 @@ mtS
 lia
 fFv
 gRx
-gRx
-vYf
-pDY
-iUQ
-iUQ
-iUQ
-aMX
-iUQ
-iUQ
+qve
+xjc
+mhS
+fwl
+fwl
+fwl
+rrA
+fwl
+fwl
 vYf
 iUQ
 iUQ
@@ -72779,7 +73129,7 @@ rzk
 okU
 rzk
 iTI
-sAv
+qIK
 sAv
 nrp
 sAv
@@ -72802,7 +73152,7 @@ okU
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 okU
@@ -72879,7 +73229,7 @@ lia
 lia
 fFv
 gRx
-gRx
+qve
 iUQ
 iUQ
 iUQ
@@ -72887,7 +73237,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-iUQ
+fwl
 fEp
 iUQ
 pDY
@@ -72979,7 +73329,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 jJT
 rzk
 rzk
@@ -73001,7 +73351,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -73088,15 +73438,15 @@ fFv
 fFv
 fFv
 oNI
-fFv
-fFv
-fFv
-lia
-lia
-lia
-fFv
-gRx
-gRx
+wwN
+wwN
+wwN
+qIf
+qIf
+qIf
+wwN
+qve
+qve
 vYf
 iUQ
 yeU
@@ -73104,7 +73454,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-iUQ
+fwl
 iUQ
 iUQ
 iUQ
@@ -73188,7 +73538,7 @@ rzk
 rzk
 rzk
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73208,7 +73558,7 @@ rzk
 sAv
 sAv
 jho
-sAv
+qIK
 sAv
 rzk
 okU
@@ -73216,12 +73566,12 @@ gfh
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -73234,7 +73584,7 @@ sAv
 sAv
 jJT
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73305,23 +73655,23 @@ fFv
 fFv
 fFv
 fFv
-fFv
+wwN
 fFv
 lia
 lia
 lia
 fFv
 fFv
-gRx
-gRx
+qve
+qve
 vYf
 iUQ
 iUQ
 iUQ
-pDY
+pyx
 iUQ
 iUQ
-iUQ
+fwl
 iUQ
 iUQ
 iUQ
@@ -73408,10 +73758,10 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
-sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73436,7 +73786,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73448,14 +73798,14 @@ okU
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
 sAv
 sAv
 jJT
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73522,15 +73872,15 @@ lia
 lia
 fFv
 fFv
-lia
+qIf
 hvS
 fFv
 lia
 lia
 fFv
 fFv
-gRx
-gRx
+qve
+qve
 vYf
 iUQ
 iUQ
@@ -73538,7 +73888,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-iUQ
+fwl
 yeU
 iUQ
 pDY
@@ -73631,14 +73981,14 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
-sAv
-sAv
+qIK
 rzk
 rzk
 gfh
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73648,6 +73998,17 @@ sAv
 rzk
 iVy
 sAv
+qIK
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+qIK
+sAv
+sAv
+qIK
 sAv
 sAv
 sAv
@@ -73660,22 +74021,11 @@ sAv
 sAv
 sAv
 sAv
+qGH
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+qIK
 sAv
 okU
 okU
@@ -73739,15 +74089,15 @@ lia
 hvS
 lia
 lia
+qIf
 lia
 lia
 lia
-lia
-lia
+cmL
 kac
 fFv
-gRx
-gRx
+qve
+qve
 lkG
 iUQ
 iUQ
@@ -73755,7 +74105,7 @@ vYf
 iUQ
 iUQ
 iUQ
-iUQ
+fwl
 iUQ
 iUQ
 iUQ
@@ -73838,7 +74188,7 @@ rzk
 rzk
 rzk
 rzk
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -73852,7 +74202,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 iTI
 sAv
 sAv
@@ -73869,7 +74219,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 rzk
 rzk
@@ -73879,6 +74229,7 @@ sAv
 sAv
 sAv
 sAv
+qIK
 sAv
 sAv
 sAv
@@ -73889,8 +74240,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
+qIK
 nrp
 sAv
 jJT
@@ -73956,15 +74306,15 @@ hnD
 lia
 lia
 lia
-lia
+qIf
 lia
 jhp
 lia
 lia
 lia
 fFv
-gRx
-gRx
+qve
+qve
 vYf
 iUQ
 vYf
@@ -73972,7 +74322,7 @@ vYf
 njs
 iUQ
 iUQ
-iUQ
+fwl
 pDY
 vYf
 iUQ
@@ -74058,12 +74408,12 @@ rzk
 rzk
 sAv
 sAv
-sAv
+qIK
 rzk
 rzk
 rzk
 rzk
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -74092,6 +74442,16 @@ rzk
 rzk
 rzk
 rzk
+qIK
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+qIK
 sAv
 sAv
 sAv
@@ -74101,17 +74461,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
+qIK
 okU
 luL
 lia
@@ -74173,15 +74523,15 @@ lia
 lia
 lia
 lia
-lia
+qIf
 lia
 lia
 lia
 lia
 lia
 fFv
-gRx
-gRx
+qve
+qve
 vYf
 rfT
 vYf
@@ -74189,7 +74539,7 @@ vYf
 vYf
 vYf
 vYf
-vYf
+xjc
 vYf
 vYf
 vYf
@@ -74284,7 +74634,7 @@ rzk
 rzk
 sAv
 jJT
-sAv
+qIK
 sAv
 sAv
 iTI
@@ -74295,13 +74645,13 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 iVy
 okU
 jJT
 sAv
-sAv
+qIK
 sAv
 sAv
 rzk
@@ -74314,7 +74664,7 @@ rzk
 rzk
 okU
 sAv
-sAv
+qIK
 sAv
 sAv
 jJT
@@ -74323,7 +74673,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -74390,15 +74740,15 @@ lia
 lia
 lia
 lia
-lia
+qIf
 lia
 lia
 lia
 lqa
 lia
 fFv
-gRx
-gRx
+qve
+qve
 iUQ
 iUQ
 iUQ
@@ -74406,7 +74756,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-iUQ
+fwl
 iUQ
 iUQ
 iUQ
@@ -74503,11 +74853,11 @@ rzk
 rzk
 rzk
 sAv
-sAv
+qIK
 iTI
 sAv
 sAv
-sAv
+qIK
 sAv
 jho
 sAv
@@ -74542,7 +74892,7 @@ sAv
 sAv
 sAv
 sAv
-sAv
+qIK
 sAv
 sAv
 sAv
@@ -74607,23 +74957,23 @@ luL
 luL
 luL
 luL
+qIf
 lia
 lia
 lia
 lia
 lia
 lia
-lia
-gRx
-gRx
-luL
-luL
-luL
-luL
-luL
-luL
-luL
-luL
+qve
+qve
+vOc
+vOc
+vOc
+vOc
+vOc
+vOc
+vOc
+vOc
 iUQ
 fzU
 iUQ
@@ -74824,14 +75174,14 @@ luL
 luL
 luL
 luL
-luL
-luL
-luL
-lia
-lia
-lia
-lia
-luL
+vOc
+vOc
+vOc
+qIf
+qIf
+qIf
+qIf
+vOc
 luL
 luL
 luL

--- a/_maps/map_files/Vietzhuo_8/Vietzhuo_8_Borders.dmm
+++ b/_maps/map_files/Vietzhuo_8/Vietzhuo_8_Borders.dmm
@@ -70,10 +70,9 @@
 /turf/open/urban/street/sidewalkfull,
 /area/vietzhuo8/indoors/v8west/city/hospital/lobby)
 "adO" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/embassy/office3)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/northwest)
 "aeo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -217,10 +216,6 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/poolroom)
-"aiT" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ntc)
 "ajb" = (
 /obj/effect/ai_node,
 /turf/open/floor/iron/dark/small,
@@ -228,6 +223,11 @@
 "ajj" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8west/city/southarea)
+"ajY" = (
+/obj/structure/bed/stool,
+/obj/effect/landmark/spawn_marker/civilian/viet/random,
+/turf/open/floor/wood/alt_three,
+/area/vietzhuo8/indoors/v8ne/village/civilian_coastal_diner)
 "akr" = (
 /obj/effect/ai_node,
 /turf/open/floor/plating,
@@ -447,7 +447,6 @@
 	color = "#a6aeab"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/office1)
 "awp" = (
@@ -690,6 +689,10 @@
 	dir = 6
 	},
 /area/vietzhuo8/indoors/v8central/cargo_storage)
+"aJW" = (
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "aJY" = (
 /obj/structure/table/reinforced/prison{
 	color = "#6b675e"
@@ -1221,9 +1224,9 @@
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "bgL" = (
-/obj/effect/landmark/spawn_marker/civilian/nationaldefense,
-/turf/open/floor/urban/carpet/carpetred,
-/area/vietzhuo8/indoors/v8west/city/border/security/north)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "bhq" = (
 /obj/machinery/light/mainship,
 /turf/open/floor/urban_wood,
@@ -1312,9 +1315,9 @@
 /turf/open/floor/wood/broken,
 /area/vietzhuo8/indoors/v8ne/village/civilian_eatery)
 "blh" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/watchman,
-/turf/open/floor/wood/broken,
-/area/vietzhuo8/indoors/v8ne/village/guard/center)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ne/village)
 "bli" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -1358,11 +1361,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/warehouseEC)
-"bnl" = (
-/obj/structure/flora/grass/tallgrass/autosmooth,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "bnx" = (
 /obj/effect/ai_node,
 /turf/open/floor/urban/tile/tilebeigecheckered,
@@ -1581,10 +1579,6 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ne/village)
-"bzb" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/mineral/smooth,
-/area/vietzhuo8/oob)
 "bzf" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -1727,10 +1721,6 @@
 /obj/item/bedsheet/captain,
 /turf/open/floor/urban_wood,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
-"bHr" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "bHE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave,
@@ -2006,13 +1996,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentafsec/security_checkpoint_northwest)
-"bTd" = (
-/obj/effect/ai_node,
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ne/village)
 "bTe" = (
 /obj/effect/ai_node,
 /turf/open/floor/wood/fancy/damaged,
@@ -2360,10 +2343,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
-"cjV" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast/corner,
-/area/vietzhuo8/outdoors/river/north)
 "ckr" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -2417,10 +2396,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/officesmain)
-"cmL" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ne/village)
+"cmx" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/city/northstreets)
 "cne" = (
 /obj/structure/flora/tree/jungle/small,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -2472,12 +2451,6 @@
 /obj/effect/spawner/random/misc/structure/flavorvending/coffeeweighted,
 /turf/open/floor/tile/white,
 /area/vietzhuo8/indoors/v8west/city/precinct/breakroom)
-"coa" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 4
-	},
-/area/vietzhuo8/outdoors/river/southern)
 "cob" = (
 /obj/structure/sink/kitchen,
 /turf/open/floor/urban/tile/tilebeigecheckered,
@@ -2526,6 +2499,11 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/offices)
+"cri" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ntc)
 "crw" = (
 /obj/effect/urban/decal/road/road_stop/one{
 	pixel_y = -10
@@ -2750,13 +2728,10 @@
 	dir = 9
 	},
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
-"cEx" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 14
-	},
+"cFf" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/liquid/water/river,
-/area/vietzhuo8/outdoors/river/north)
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "cGp" = (
 /obj/structure/table/reinforced,
 /obj/item/defibrillator/civi,
@@ -2866,6 +2841,11 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ntcroadnw)
+"cNG" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "cNO" = (
 /obj/structure/closet/crate/trashcart,
 /obj/structure/cable,
@@ -2964,10 +2944,6 @@
 "cSQ" = (
 /turf/open/ground/grass/weedable,
 /area/vietzhuo8/outdoors/v8ntcregionnorth)
-"cTa" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "cTi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3256,6 +3232,11 @@
 	},
 /turf/closed/gm/dense,
 /area/vietzhuo8/oob)
+"dhq" = (
+/obj/effect/landmark/weed_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/northeast)
 "dhI" = (
 /obj/structure/table/mainship,
 /turf/open/floor/wood,
@@ -3388,10 +3369,6 @@
 /obj/machinery/light,
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/precheck)
-"dqF" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "drd" = (
 /obj/machinery/light/mainship{
 	dir = 8
@@ -3460,10 +3437,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/indoors/v8west/city/hospital/triage)
 "dtY" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/embassy/office2)
+/obj/effect/ai_node,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/indoors/caves/river)
 "dub" = (
 /obj/structure/bed/chair/sofa/left{
 	dir = 8
@@ -3534,11 +3510,9 @@
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
 "dwA" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/vietzhuo8/outdoors/v8west/city/centralstreets)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/northeast)
 "dwB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -3676,10 +3650,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentaf/corporate_dorms)
-"dCb" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ntc)
 "dCm" = (
 /obj/structure/sink{
 	dir = 4;
@@ -3937,6 +3907,10 @@
 	},
 /turf/open/floor/urban_wood,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room2)
+"dOd" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/southarea)
 "dOG" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -4024,9 +3998,9 @@
 /turf/open/floor/tile/blue,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/lounge)
 "dSG" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/watchman,
-/turf/open/floor/wood/fancy/damaged,
-/area/vietzhuo8/indoors/v8ne/village/guard/post_south)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/mineral/smooth,
+/area/vietzhuo8/oob)
 "dSL" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -4591,12 +4565,6 @@
 /obj/structure/bed/chair/wood/wings,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/cafediner)
-"esb" = (
-/obj/effect/ai_node,
-/turf/open/ground/coast{
-	dir = 5
-	},
-/area/vietzhuo8/indoors/caves/river)
 "ese" = (
 /turf/open/floor/wood,
 /area/vietzhuo8/outdoors/bridge/north)
@@ -4659,6 +4627,10 @@
 	dir = 1
 	},
 /area/vietzhuo8/outdoors/river/central)
+"eud" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/north)
 "eum" = (
 /obj/machinery/door/airlock/mainship/security/glass/free_access{
 	name = "\improper Customs Airlock"
@@ -4681,6 +4653,12 @@
 	},
 /turf/open/floor/plating/ground/concrete,
 /area/vietzhuo8/outdoors/landing_zone_2)
+"evP" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/north)
 "ewn" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -4746,9 +4724,9 @@
 	},
 /area/vietzhuo8/indoors/v8ntc/officesmain)
 "ezi" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/floor/wood/alt_three,
-/area/vietzhuo8/indoors/v8ne/village/civilian_coastal_diner)
+/obj/effect/ai_node,
+/turf/open/liquid/water/river/deep,
+/area/vietzhuo8/indoors/caves/river)
 "ezv" = (
 /obj/structure/curtain/shower{
 	color = "#a57d4b";
@@ -4802,6 +4780,14 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
+"eAI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/structure/cable,
+/obj/effect/landmark/spawn_marker/civilian/doctor,
+/turf/open/floor/tile/bar,
+/area/vietzhuo8/indoors/v8west/city/hospital/halls)
 "eAK" = (
 /obj/structure/closet/crate,
 /turf/open/floor/wood,
@@ -4819,9 +4805,9 @@
 	},
 /area/vietzhuo8/indoors/v8west/city/embassy/visascenter)
 "eBB" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/hanakohilton/lobby)
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/hanakohilton/courtyard)
 "eBC" = (
 /turf/closed/mineral/smooth/indestructible,
 /area/vietzhuo8/indoors/caves/northwest)
@@ -5285,11 +5271,8 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/office4)
 "eVp" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk{
-	dir = 4
-	},
-/area/vietzhuo8/outdoors/v8west/city/southarea)
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "eVH" = (
 /obj/machinery/autodoc,
 /turf/open/floor/tile/bar,
@@ -5511,9 +5494,10 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/clothing)
 "ffm" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/embassy/office4)
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "fgf" = (
 /obj/machinery/light{
 	dir = 8
@@ -5786,12 +5770,6 @@
 "fsy" = (
 /turf/open/ground/grass/weedable,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
-"fsH" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast/corner{
-	dir = 8
-	},
-/area/vietzhuo8/outdoors/river/north)
 "fsO" = (
 /obj/structure/cable,
 /turf/open/floor/tile/bar,
@@ -5891,8 +5869,8 @@
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
 "fvS" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8west/city/southarea)
+/turf/closed/wall/urban/colony,
+/area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "fwe" = (
 /obj/structure/table/mainship,
 /obj/structure/window,
@@ -5904,10 +5882,6 @@
 	},
 /turf/open/floor/mainship/blue,
 /area/vietzhuo8/indoors/v8ntc/officesmain)
-"fwl" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8eastcentral)
 "fwq" = (
 /obj/machinery/light/mainship{
 	dir = 1
@@ -5945,6 +5919,12 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/border/security/south)
+"fzN" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 5
+	},
+/area/vietzhuo8/indoors/caves/river)
 "fzU" = (
 /obj/effect/landmark/xeno_tunnel_spawn,
 /turf/open/ground/grass/weedable,
@@ -5991,7 +5971,6 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/effect/landmark/spawn_marker/civilian/doctor,
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/doctorsoffice3)
 "fBN" = (
@@ -6159,10 +6138,6 @@
 "fHz" = (
 /turf/open/floor/wood,
 /area/vietzhuo8/outdoors/bridge/centralnorth)
-"fHC" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "fIa" = (
 /obj/structure/prop/mainship/chimney{
 	dir = 4;
@@ -6179,10 +6154,9 @@
 /turf/open/urban/street/sidewalkfull,
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
 "fIq" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/watchman,
-/obj/effect/ai_node,
-/turf/open/floor/wood/fancy/damaged,
-/area/vietzhuo8/indoors/v8ne/village/guard/post_northwest)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/southarea)
 "fIt" = (
 /obj/effect/ai_node,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -6198,11 +6172,6 @@
 	},
 /turf/open/floor/prison/kitchen,
 /area/vietzhuo8/indoors/v8west/city/precinct/breakroom)
-"fIP" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "fJu" = (
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
@@ -6517,9 +6486,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
 "gdf" = (
-/obj/effect/landmark/spawn_marker/civilian/doctor,
-/turf/open/floor/tile/bar,
-/area/vietzhuo8/indoors/v8west/city/hospital/doctorsoffice2)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ntc)
 "gdp" = (
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 14
@@ -6850,6 +6819,10 @@
 "guq" = (
 /turf/open/floor/wood/fancy/damaged,
 /area/vietzhuo8/indoors/v8ne/village/guard/post_south)
+"guA" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/southern)
 "gvc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -7176,6 +7149,13 @@
 "gKL" = (
 /turf/open/floor/wood/broken,
 /area/vietzhuo8/indoors/v8ne/village/guard/center)
+"gKX" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 14
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/north)
 "gLn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/mainship/blue{
@@ -7306,6 +7286,10 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8central/cargo_requisitions)
+"gSd" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ntc)
 "gSm" = (
 /turf/closed/wall/kutjevo,
 /area/vietzhuo8/indoors/v8ne/village/guard/jail_cells)
@@ -7521,6 +7505,10 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8eastcentral)
+"hce" = (
+/obj/effect/ai_node,
+/turf/open/floor/urban/carpet/carpetred,
+/area/vietzhuo8/indoors/v8west/city/border/security/central)
 "hck" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7668,10 +7656,6 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/vietzhuo8/indoors/v8west/city/embassy/visascenter/lobby)
-"hgX" = (
-/obj/effect/landmark/patrol_point/tgmc_21,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/landing_zone_2)
 "hhq" = (
 /obj/machinery/streetlight/street,
 /turf/open/urban/street/sidewalk{
@@ -7686,10 +7670,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/breakroom)
-"hhJ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "hif" = (
 /obj/machinery/light/mainship,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
@@ -7861,9 +7841,9 @@
 /turf/open/floor/urban/tile/tilewhite,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room)
 "hps" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/freezer,
-/area/vietzhuo8/indoors/v8west/city/cafediner)
+/obj/effect/landmark/spawn_marker/civilian/viet/random,
+/turf/open/floor/plating,
+/area/vietzhuo8/indoors/v8ne/village/warehouseEC)
 "hpw" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -7911,6 +7891,12 @@
 "hrG" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8west/city/miningpit/south)
+"hrL" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/north)
 "hrU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/ground/grass/weedable,
@@ -7991,10 +7977,6 @@
 	},
 /turf/open/floor/wood/broken,
 /area/vietzhuo8/indoors/v8ne/village/guard/jail_cells)
-"hwi" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/southarea)
 "hwp" = (
 /obj/structure/table/wood,
 /obj/item/weapon/cleaver{
@@ -8062,10 +8044,6 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/office2)
-"hza" = (
-/obj/effect/ai_node,
-/turf/open/liquid/water/river,
-/area/vietzhuo8/indoors/caves/river)
 "hzv" = (
 /obj/machinery/door/airlock/mainship/engineering/free_access{
 	name = "\improper Power Station"
@@ -8104,12 +8082,6 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/offices)
-"hAv" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 10
-	},
-/area/vietzhuo8/outdoors/river/north)
 "hAH" = (
 /obj/structure/platform_decoration{
 	dir = 8
@@ -8209,12 +8181,6 @@
 "hIe" = (
 /turf/open/urban/street/sidewalkfull,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
-"hIt" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast/corner{
-	dir = 1
-	},
-/area/vietzhuo8/outdoors/river/north)
 "hIv" = (
 /turf/open/floor/wood/fancy/damaged,
 /area/vietzhuo8/indoors/v8ne/village/clinic)
@@ -8251,10 +8217,6 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/red/full,
 /area/vietzhuo8/indoors/v8west/city/precinct/swatarmory)
-"hJz" = (
-/obj/effect/ai_node,
-/turf/open/liquid/water/river/deep,
-/area/vietzhuo8/indoors/caves/river)
 "hJA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -8274,10 +8236,9 @@
 /turf/open/floor/iron/dark/small,
 /area/vietzhuo8/indoors/v8west/city/gym)
 "hJP" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/hanakohilton/poolroom)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "hJS" = (
 /obj/structure/table/mainship,
 /obj/machinery/faxmachine,
@@ -8321,13 +8282,6 @@
 	},
 /turf/open/floor/urban/carpet/carpetred,
 /area/vietzhuo8/indoors/v8west/city/border/security/central)
-"hKw" = (
-/obj/effect/urban/decal/road/lines3{
-	pixel_y = -2
-	},
-/obj/effect/landmark/patrol_point/tgmc_11,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/landing_zone_1)
 "hKJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -8407,9 +8361,9 @@
 /turf/open/floor/urban/wood,
 /area/vietzhuo8/indoors/v8west/city/northhouses)
 "hNs" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/floor/wood,
-/area/vietzhuo8/indoors/v8ne/village/civilian_farm_hut)
+/obj/effect/landmark/sensor_tower,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ne/village)
 "hNW" = (
 /turf/closed/wall/urban/colony,
 /area/vietzhuo8/indoors/v8west/city/embassy/pressroom)
@@ -8478,11 +8432,11 @@
 /turf/open/floor/kutjevo/colors/orange,
 /area/vietzhuo8/indoors/v8west/city/border/security/commpostsouth)
 "hRv" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk{
-	dir = 4
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 10
 	},
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
+/area/vietzhuo8/outdoors/river/north)
 "hRz" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
@@ -8614,9 +8568,12 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/dresses)
 "hVV" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/vietzhuo8/indoors/caves/north)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/effect/landmark/spawn_marker/civilian/random,
+/turf/open/floor/urban/tile/tilebeigecheckered,
+/area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "hWl" = (
 /obj/structure/cable,
 /obj/effect/ai_node,
@@ -8939,6 +8896,10 @@
 	},
 /turf/open/floor/wood/broken,
 /area/vietzhuo8/indoors/v8ne/village/guard/jail_cells)
+"inm" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner,
+/area/vietzhuo8/outdoors/river/north)
 "ioj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -8973,11 +8934,6 @@
 "ipY" = (
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/warmemorial)
-"iqr" = (
-/obj/structure/flora/grass/tallgrass/autosmooth,
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "irf" = (
 /obj/structure/cable,
 /obj/machinery/newscaster{
@@ -9363,12 +9319,9 @@
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ne/village)
 "iHt" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/vietzhuo8/outdoors/v8west/city/northstreets)
+/obj/effect/ai_node,
+/turf/open/floor/plating/ground/mars/random/cave/darker,
+/area/vietzhuo8/indoors/caves/north)
 "iIj" = (
 /obj/structure/prop/mainship/hangar_stencil/two,
 /obj/machinery/landinglight/lz2{
@@ -9487,9 +9440,9 @@
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/halls)
 "iPS" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/embassy/officeslobby)
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "iQQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -9717,17 +9670,13 @@
 /turf/open/floor/urban_wood,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
 "jaM" = (
-/obj/effect/urban/decal/road/lines3{
-	pixel_y = -2
-	},
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/landing_zone_2)
-"jaR" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/viet/watchman,
-/turf/open/floor/plating/ground/desertdam/asphalt,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ne/village)
+"jaR" = (
+/obj/effect/landmark/spawn_marker/civilian/viet/random,
+/turf/open/floor/wood/alt_nine,
+/area/vietzhuo8/indoors/v8ne/village/civilian_coastal_diner)
 "jbk" = (
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
@@ -10157,9 +10106,11 @@
 /turf/open/floor/kutjevo/colors/orange,
 /area/vietzhuo8/indoors/v8west/city/border/security/central)
 "jxd" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/v8west/city/northstreets)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 1
+	},
+/area/vietzhuo8/outdoors/river/north)
 "jxe" = (
 /obj/structure/transmitter/colony_net/auto_id{
 	pixel_y = 32
@@ -10196,9 +10147,10 @@
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/precheck)
 "jyE" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ne/village)
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "jyK" = (
 /obj/structure/table/mainship,
 /obj/machinery/prop/computer{
@@ -10226,10 +10178,6 @@
 	dir = 1
 	},
 /area/vietzhuo8/indoors/v8west/stripmall)
-"jAD" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "jAJ" = (
 /obj/structure/table/mainship,
 /turf/open/floor/mainship/mono,
@@ -10253,6 +10201,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/vietzhuo8/indoors/v8west/city/gym)
+"jCj" = (
+/obj/effect/landmark/spawn_marker/civilian/viet/watchman,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8ne/village)
 "jCA" = (
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/office4)
@@ -10344,6 +10296,13 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/offices)
+"jIA" = (
+/obj/effect/urban/decal/road/lines3{
+	pixel_y = -2
+	},
+/obj/effect/landmark/patrol_point/tgmc_11,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/landing_zone_1)
 "jJy" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/ground/grass/weedable/patch/grassyellow,
@@ -10608,12 +10567,6 @@
 	},
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8ntcroadwest)
-"jXg" = (
-/obj/effect/landmark/sensor_tower,
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/vietzhuo8/indoors/v8west/stripmall)
 "jXO" = (
 /obj/structure/prop/urban/misc/trash/blue,
 /turf/open/floor/tile/bar,
@@ -10914,9 +10867,9 @@
 /turf/open/liquid/water/river,
 /area/vietzhuo8/outdoors/river/north)
 "klm" = (
-/obj/effect/landmark/spawn_marker/civilian/doctor,
-/turf/open/floor/tile/bar,
-/area/vietzhuo8/indoors/v8west/city/hospital/doctorsoffice)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/v8west/city/centralstreets)
 "kmo" = (
 /obj/machinery/door/airlock/multi_tile/mainship/medidoor{
 	name = "\improper Medical Clinic"
@@ -11330,9 +11283,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood/alt_nine,
 /area/vietzhuo8/indoors/v8ne/village/civilian_coastal_hut)
-"kDw" = (
-/turf/open/floor/plating/ground/dirt_alt,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "kDJ" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 1
@@ -11363,11 +11313,6 @@
 /obj/structure/cable,
 /turf/open/floor,
 /area/vietzhuo8/indoors/v8west/city/precinct/dispatchoffices)
-"kEC" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "kEY" = (
 /obj/machinery/miner/damaged,
 /turf/open/floor/plating/ground/dirt_alt,
@@ -11391,10 +11336,6 @@
 "kGu" = (
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/lobby)
-"kHf" = (
-/obj/effect/ai_node,
-/turf/open/floor/urban/carpet/carpetred,
-/area/vietzhuo8/indoors/v8west/city/border/security/central)
 "kHt" = (
 /obj/structure/bed/chair/wood/wings{
 	dir = 4
@@ -11495,11 +11436,6 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8west/city/southarea)
-"kMp" = (
-/obj/effect/landmark/weed_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/vietzhuo8/indoors/caves/northeast)
 "kMJ" = (
 /obj/machinery/computer/shuttle/shuttle_control/dropship{
 	dir = 4
@@ -11941,6 +11877,12 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/clothing)
+"lhx" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 6
+	},
+/area/vietzhuo8/outdoors/river/north)
 "lhI" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/mainship,
@@ -12463,6 +12405,12 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8ntcroadnw)
+"lDM" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/north)
 "lDO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -12607,9 +12555,11 @@
 	},
 /area/vietzhuo8/indoors/v8sentafsec/security_armory)
 "lIz" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/floor/wood/broken,
-/area/vietzhuo8/indoors/v8ne/village/civilian_hut)
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/north)
 "lIP" = (
 /turf/closed/wall/urban/colony,
 /area/vietzhuo8/indoors/v8west/city/precinct/swatarmory)
@@ -12758,9 +12708,9 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/dresses)
 "lQg" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/vietzhuo8/indoors/caves/northwest)
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "lQm" = (
 /turf/closed/wall/wood,
 /area/vietzhuo8/indoors/v8ne/village/guard/post_south)
@@ -13036,11 +12986,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
-"mcP" = (
-/obj/structure/flora/grass/tallgrass/autosmooth,
-/obj/effect/landmark/weed_node,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "mcX" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -13121,6 +13066,10 @@
 /obj/structure/bed/chair,
 /turf/open/floor/wood/fancy/damaged,
 /area/vietzhuo8/indoors/v8ne/village/civilian_hut)
+"mhj" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ne/village)
 "mhl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -13137,11 +13086,6 @@
 	dir = 8
 	},
 /area/vietzhuo8/indoors/v8west/city/precinct/holdingcell)
-"mhS" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8eastcentral)
 "miG" = (
 /obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
 /turf/closed/wall/urban/colony,
@@ -13202,12 +13146,6 @@
 "mlJ" = (
 /turf/open/floor/plating/ground/dirt_alt,
 /area/vietzhuo8/outdoors/v8west/city/miningpit/North)
-"mlX" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast/corner{
-	dir = 4
-	},
-/area/vietzhuo8/outdoors/river/north)
 "mmL" = (
 /turf/open/floor/plating,
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
@@ -13322,10 +13260,6 @@
 /obj/effect/ai_node,
 /turf/open/ground/grass/weedable,
 /area/vietzhuo8/outdoors/v8west/city/northarea)
-"mrZ" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/urban/colony,
-/area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
 "msa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -13624,10 +13558,6 @@
 	},
 /turf/open/floor/urban/tile/tilewhite,
 /area/vietzhuo8/indoors/v8central/cargo_requisitions)
-"mFe" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "mFx" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/tile/bar,
@@ -13830,9 +13760,11 @@
 	},
 /area/vietzhuo8/indoors/v8west/city/gym)
 "mPN" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/floor/wood/broken,
-/area/vietzhuo8/indoors/v8ne/village/civilian_farm_hut)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 5
+	},
+/area/vietzhuo8/outdoors/river/north)
 "mQk" = (
 /obj/effect/ai_node,
 /obj/structure/bed/chair/office/dark{
@@ -13927,12 +13859,6 @@
 "mUm" = (
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8sentaf/substation)
-"mUy" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 5
-	},
-/area/vietzhuo8/outdoors/river/north)
 "mUN" = (
 /turf/closed/wall/r_wall,
 /area/vietzhuo8/indoors/v8west/city/powerstation)
@@ -14202,10 +14128,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/halls)
-"njA" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8ntc)
 "njZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -14535,10 +14457,9 @@
 /turf/open/floor/freezer,
 /area/vietzhuo8/indoors/v8west/city/cafediner)
 "nCN" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalkfull,
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ntc)
 "nDg" = (
 /turf/closed/wall,
 /area/vietzhuo8/outdoors/v8west/city/hospital/parkinglot)
@@ -14889,9 +14810,11 @@
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/officeslobby)
 "nPP" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/v8ne/village/coastalgrounds)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 5
+	},
+/area/vietzhuo8/outdoors/river/southern)
 "nQO" = (
 /obj/structure/table,
 /turf/open/floor/wood,
@@ -14979,6 +14902,12 @@
 	color = "#a57d4b"
 	},
 /area/vietzhuo8/indoors/v8ne/village/monk_temple)
+"nVt" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 1
+	},
+/area/vietzhuo8/outdoors/river/north)
 "nVN" = (
 /obj/effect/ai_node,
 /turf/open/floor/tile/chapel{
@@ -14997,12 +14926,6 @@
 	},
 /turf/open/floor/urban_wood,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/room5)
-"nWs" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 1
-	},
-/area/vietzhuo8/outdoors/river/north)
 "nWB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -15083,6 +15006,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8sentafsec/security_checkpoint_west)
+"ody" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "odU" = (
 /obj/structure/barricade/wooden{
 	dir = 8
@@ -15270,9 +15198,9 @@
 /turf/open/urban/street/sidewalkfull,
 /area/vietzhuo8/outdoors/v8west/city/southarea)
 "omw" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ne/village/coastalgrounds)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "omx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -15482,10 +15410,6 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
-"ovW" = (
-/obj/effect/landmark/weed_node,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "owr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -15852,6 +15776,16 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/office3)
+"oKL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
+	color = "#a6aeab";
+	dir = 8
+	},
+/obj/effect/landmark/spawn_marker/civilian/random,
+/turf/open/urban/street/sidewalk{
+	dir = 1
+	},
+/area/vietzhuo8/indoors/v8west/stripmall)
 "oKQ" = (
 /obj/structure/platform_decoration{
 	dir = 1
@@ -15888,23 +15822,11 @@
 "oMn" = (
 /turf/open/floor/tile/dark,
 /area/vietzhuo8/indoors/v8west/city/precinct/holdingcell)
-"oMH" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 5
-	},
-/area/vietzhuo8/outdoors/river/southern)
 "oMW" = (
 /obj/structure/bed/fancy,
 /obj/item/bedsheet/captain,
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/guard/barracks)
-"oNc" = (
-/obj/effect/ai_node,
-/turf/open/ground/coast{
-	dir = 8
-	},
-/area/vietzhuo8/indoors/caves/river)
 "oNn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -15945,6 +15867,11 @@
 /obj/structure/cable,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/officeshalls)
+"oOf" = (
+/obj/structure/flora/tree/jungle/small,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "oOz" = (
 /obj/effect/landmark/spawn_marker/civilian/random,
 /turf/open/floor/urban/wood,
@@ -16247,6 +16174,10 @@
 "pbY" = (
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/triage)
+"pcv" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/southarea)
 "pcx" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/dexalin{
@@ -16731,11 +16662,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/officeslobby)
-"pyx" = (
-/obj/effect/ai_node,
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8eastcentral)
 "pyS" = (
 /obj/effect/spawner/random/misc/structure/supplycrate,
 /turf/open/floor/plating,
@@ -16862,6 +16788,11 @@
 "pHu" = (
 /turf/closed/wall/mainship/gray,
 /area/vietzhuo8/indoors/v8ntc/breakroom)
+"pHG" = (
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/weed_node,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "pHK" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -16994,6 +16925,10 @@
 "pMa" = (
 /turf/closed/wall,
 /area/vietzhuo8/indoors/v8west/city/hospital/pharmacylab)
+"pMv" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "pMT" = (
 /obj/structure/curtain/shower{
 	color = "#a57d4b";
@@ -17442,11 +17377,10 @@
 /turf/open/urban/street/sidewalkfull,
 /area/vietzhuo8/outdoors/v8west/city/northstreets)
 "qfx" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/prison{
-	dir = 8
-	},
-/area/vietzhuo8/indoors/v8west/city/embassy/visascenter)
+/obj/structure/flora/grass/tallgrass/autosmooth,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "qgo" = (
 /obj/effect/spawner/random/misc/structure/large/car{
 	dir = 1;
@@ -17496,6 +17430,13 @@
 	dir = 8
 	},
 /area/vietzhuo8/indoors/v8west/stripmall/produce)
+"qhB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	color = "#a6aeab"
+	},
+/obj/effect/landmark/spawn_marker/civilian/random,
+/turf/open/floor/urban/tile/tilebeigecheckered,
+/area/vietzhuo8/indoors/v8west/city/hanakohilton/lobby)
 "qiD" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -17515,10 +17456,6 @@
 	dir = 10
 	},
 /area/vietzhuo8/outdoors/river/central)
-"qju" = (
-/obj/effect/landmark/weed_node,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "qjC" = (
 /obj/effect/ai_node{
 	pixel_x = 3
@@ -17632,10 +17569,9 @@
 	},
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
 "qoK" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/iron/dark/small,
-/area/vietzhuo8/indoors/v8west/city/gym)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/river/deltanorth)
 "qoQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -17773,10 +17709,6 @@
 	},
 /turf/open/floor/wood/alt_three,
 /area/vietzhuo8/indoors/v8ne/village/civilian_coastal_diner)
-"qve" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/wall/kutjevo,
-/area/vietzhuo8/outdoors/v8ne/village)
 "qvg" = (
 /turf/open/urban/street/sidewalk{
 	dir = 10
@@ -17852,9 +17784,11 @@
 	},
 /area/vietzhuo8/indoors/v8west/stripmall/mensrest)
 "qxG" = (
-/obj/effect/landmark/spawn_marker/civilian/nationaldefense,
-/turf/open/urban/street/sidewalk,
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/north)
 "qxQ" = (
 /obj/structure/cable,
 /obj/machinery/light/mainship{
@@ -17951,6 +17885,12 @@
 	},
 /turf/open/floor/freezer,
 /area/vietzhuo8/indoors/v8west/city/cafediner)
+"qAc" = (
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/southern)
 "qAT" = (
 /obj/structure/cable,
 /obj/machinery/streetlight/traffic_alt{
@@ -18164,14 +18104,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/embassy/officeslobby)
-"qIf" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8ne/village)
-"qIK" = (
-/obj/effect/ai_node,
-/turf/open/floor/plating/ground/mars/random/cave/darker,
-/area/vietzhuo8/indoors/caves/northeast)
 "qJn" = (
 /obj/structure/bed/chair/comfy,
 /obj/machinery/light/mainship{
@@ -18316,9 +18248,11 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8west/city/centralstreets)
 "qRq" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk,
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast/corner{
+	dir = 8
+	},
+/area/vietzhuo8/outdoors/river/north)
 "qRI" = (
 /obj/structure/barricade/wooden{
 	dir = 4
@@ -18601,12 +18535,9 @@
 /turf/open/floor/wood/broken,
 /area/vietzhuo8/indoors/v8ne/village/civilian_tavern)
 "rdq" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/nationaldefense,
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable/patch/grassyellow,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "rdM" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/pod/old{
@@ -18694,12 +18625,9 @@
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/landing_zone_1)
 "rhx" = (
-/obj/structure/cable,
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk{
-	dir = 1
-	},
-/area/vietzhuo8/indoors/v8west/stripmall)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/gm/dense,
+/area/vietzhuo8/oob)
 "rhB" = (
 /obj/structure/bed/chair/comfy{
 	dir = 1
@@ -18797,10 +18725,6 @@
 	},
 /turf/open/liquid/water/river/deep,
 /area/vietzhuo8/outdoors/river/southern)
-"rlp" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/v8west/city/northstreets)
 "rlF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -18947,11 +18871,6 @@
 	},
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/landing_zone_1/hangars)
-"rrA" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8eastcentral)
 "rrB" = (
 /obj/effect/urban/decal/road/lines1,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -19470,10 +19389,6 @@
 	},
 /turf/open/liquid/water/river/deep,
 /area/vietzhuo8/outdoors/river/north)
-"rMh" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8west/city/southarea)
 "rMj" = (
 /obj/structure/cable,
 /turf/open/floor/wood/fancy/damaged,
@@ -19695,9 +19610,11 @@
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/clinic)
 "rWr" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/iron/dark/small,
-/area/vietzhuo8/indoors/v8west/city/gym)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/coast{
+	dir = 4
+	},
+/area/vietzhuo8/outdoors/river/southern)
 "rWv" = (
 /turf/closed/wall/mainship/gray,
 /area/vietzhuo8/indoors/v8sentaf/substation/maintenance)
@@ -20010,6 +19927,10 @@
 /obj/structure/window/framed/mainship/gray,
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/breakroom)
+"sma" = (
+/obj/machinery/miner/damaged,
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "smu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -20373,6 +20294,13 @@
 /obj/effect/landmark/start/job/xenomorph,
 /turf/open/floor/plating/ground/mars/random/cave/darker,
 /area/vietzhuo8/indoors/caves/north)
+"sCz" = (
+/obj/effect/ai_node,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8ne/village)
 "sCJ" = (
 /obj/machinery/light/mainship{
 	dir = 4
@@ -20450,10 +20378,6 @@
 "sHh" = (
 /turf/open/ground/coast/corner,
 /area/vietzhuo8/indoors/caves/river)
-"sHj" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "sHs" = (
 /obj/structure/curtain/shower{
 	color = "#a57d4b";
@@ -20517,6 +20441,7 @@
 	color = "#a6aeab";
 	dir = 4
 	},
+/obj/effect/landmark/spawn_marker/civilian/random,
 /turf/open/urban/street/sidewalk{
 	dir = 1
 	},
@@ -21206,10 +21131,6 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
-"tmQ" = (
-/obj/machinery/miner/damaged,
-/turf/open/floor/plating/ground/dirt_alt,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "tmV" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -21706,12 +21627,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/poolroom)
-"tJf" = (
-/obj/effect/ai_node,
-/turf/open/ground/coast{
-	dir = 8
-	},
-/area/vietzhuo8/outdoors/river/north)
 "tJm" = (
 /obj/effect/ai_node,
 /turf/open/floor/mainship/mono,
@@ -21736,9 +21651,9 @@
 /turf/open/floor/tile/dark,
 /area/vietzhuo8/indoors/v8west/city/border/security/cells)
 "tKI" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/urban/tile/tilebeigecheckered,
-/area/vietzhuo8/indoors/v8west/city/cafediner)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "tLq" = (
 /obj/machinery/door/airlock/mainship/generic,
 /turf/open/floor/urban/tile/tilewhite,
@@ -21759,6 +21674,11 @@
 "tMF" = (
 /turf/closed/wall/urban/colony,
 /area/vietzhuo8/indoors/v8west/city/border/security/central)
+"tMZ" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "tNC" = (
 /obj/structure/cable,
 /turf/open/floor/plating/ground/desertdam/asphalt,
@@ -21823,10 +21743,6 @@
 	dir = 1
 	},
 /area/vietzhuo8/outdoors/river/southern)
-"tQD" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/v8west/hanakohilton/courtyard)
 "tQF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/ground/grass/weedable,
@@ -22016,12 +21932,6 @@
 	},
 /turf/open/floor/urban/wood/greywood,
 /area/vietzhuo8/indoors/v8sentaf/corporate_dorms)
-"ubh" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast/corner{
-	dir = 8
-	},
-/area/vietzhuo8/outdoors/river/southern)
 "ubi" = (
 /obj/effect/ai_node,
 /turf/open/urban/street/sidewalk{
@@ -22031,6 +21941,12 @@
 "ubO" = (
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/landing_zone_1)
+"ubP" = (
+/obj/effect/landmark/sensor_tower,
+/turf/open/urban/street/sidewalk{
+	dir = 1
+	},
+/area/vietzhuo8/indoors/v8west/stripmall)
 "ubW" = (
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/poolroom)
@@ -22045,13 +21961,6 @@
 /obj/item/defibrillator/civi,
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/operatingroom)
-"ucq" = (
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 14
-	},
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/liquid/water/river,
-/area/vietzhuo8/outdoors/river/southern)
 "ucO" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/urban/carpet/carpetreddeco,
@@ -22530,10 +22439,6 @@
 /obj/structure/largecrate/random,
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8central/cargo_requisitions)
-"uzE" = (
-/obj/effect/landmark/xeno_silo_spawn,
-/turf/open/floor/plating/ground/dirt_alt,
-/area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "uzI" = (
 /obj/machinery/light{
 	dir = 4
@@ -22800,6 +22705,10 @@
 	},
 /turf/open/floor/plating,
 /area/vietzhuo8/indoors/v8sentaf/substation)
+"uKv" = (
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/miningpit/south)
 "uKD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -23224,12 +23133,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/tile/blue,
 /area/vietzhuo8/indoors/v8ntc/breakroom)
-"veN" = (
-/obj/effect/ai_node,
-/turf/open/ground/coast{
-	dir = 4
-	},
-/area/vietzhuo8/outdoors/river/north)
 "veZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab"
@@ -23249,6 +23152,13 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ntcregionnorth)
+"vge" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/barricade/wooden{
+	dir = 1
+	},
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "vgj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -23264,10 +23174,6 @@
 	},
 /turf/open/floor/tile/bar,
 /area/vietzhuo8/indoors/v8west/city/hospital/triage)
-"vgG" = (
-/obj/effect/landmark/sensor_tower,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8ne/village)
 "vgV" = (
 /obj/structure/cable,
 /turf/open/floor/urban/carpet/carpetred,
@@ -23474,6 +23380,13 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/checkpoint_north)
+"voX" = (
+/obj/structure/flora/ausbushes/reedbush{
+	pixel_y = 14
+	},
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/liquid/water/river,
+/area/vietzhuo8/outdoors/river/southern)
 "vpd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -23869,6 +23782,11 @@
 "vFD" = (
 /turf/closed/wall/wood,
 /area/vietzhuo8/indoors/v8ne/village/guard/center)
+"vFG" = (
+/obj/effect/ai_node,
+/obj/effect/landmark/xeno_silo_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "vGb" = (
 /obj/machinery/door/airlock/mainship/generic{
 	dir = 8
@@ -24080,10 +23998,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/landing_zone_2)
-"vOc" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/closed/gm/dense,
-/area/vietzhuo8/oob)
 "vOl" = (
 /obj/machinery/door/airlock/mainship/generic/corporate{
 	name = "Hanako Hilton Room 2";
@@ -24258,10 +24172,6 @@
 /obj/structure/cable,
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/stripmall/clothing)
-"vWD" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/floor/plating/ground/desertdam/asphalt,
-/area/vietzhuo8/outdoors/v8west/city/centralstreets)
 "vWJ" = (
 /obj/structure/prop/urban/misc/trash/blue,
 /turf/open/floor/urban/tile/tilewhite,
@@ -24321,11 +24231,9 @@
 /turf/closed/wall,
 /area/vietzhuo8/indoors/v8central/cargo_storage)
 "vZZ" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/floor/prison{
-	dir = 8
-	},
-/area/vietzhuo8/indoors/v8west/city/embassy/visascenter/lobby)
+/obj/effect/landmark/patrol_point/tgmc_21,
+/turf/open/floor/plating/ground/desertdam/asphalt,
+/area/vietzhuo8/outdoors/landing_zone_2)
 "wab" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -24467,18 +24375,6 @@
 	color = "#ff7d7d"
 	},
 /area/vietzhuo8/indoors/v8sentafsec/security_checkpoint_northwest)
-"weS" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/barricade/wooden{
-	dir = 1
-	},
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
-"weT" = (
-/obj/structure/flora/grass/tallgrass/autosmooth,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/river/deltanorth)
 "wff" = (
 /obj/structure/bed/roller,
 /turf/open/floor/wood/fancy/damaged,
@@ -24558,6 +24454,12 @@
 	},
 /turf/open/ground/grass/weedable/patch/grassyellow,
 /area/vietzhuo8/outdoors/v8ntcregionnorthwest)
+"wla" = (
+/obj/effect/ai_node,
+/turf/open/ground/coast{
+	dir = 8
+	},
+/area/vietzhuo8/indoors/caves/river)
 "wlg" = (
 /turf/open/floor/urban/carpet/carpetreddeco,
 /area/vietzhuo8/indoors/v8west/city/precinct/offices)
@@ -24582,11 +24484,6 @@
 	dir = 8
 	},
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
-"wmF" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8ntc)
 "wmH" = (
 /turf/open/floor/urban/carpet/carpetred,
 /area/vietzhuo8/indoors/v8west/city/border/security/north)
@@ -24732,12 +24629,6 @@
 	dir = 5
 	},
 /area/vietzhuo8/outdoors/river/central)
-"wrN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 4
-	},
-/area/vietzhuo8/outdoors/river/north)
 "wrV" = (
 /obj/effect/urban/decal/dirt,
 /obj/effect/urban/decal/road/road_edge/four,
@@ -24824,9 +24715,8 @@
 	},
 /area/vietzhuo8/indoors/v8west/stripmall)
 "wva" = (
-/obj/effect/landmark/spawn_marker/civilian/random,
-/turf/open/urban/street/sidewalk,
-/area/vietzhuo8/outdoors/v8west/city/centralstreets)
+/turf/open/floor/plating/ground/dirt_alt,
+/area/vietzhuo8/outdoors/v8west/city/centralarea)
 "wvb" = (
 /obj/structure/cable,
 /turf/open/floor/mainship/mono{
@@ -24867,10 +24757,6 @@
 /obj/item/reagent_containers/food/snacks/cubancarp,
 /turf/open/floor/wood/alt_eleven,
 /area/vietzhuo8/indoors/v8ne/village/civilian_coastal_hut)
-"wwN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8ne/village)
 "wwX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	color = "#a6aeab";
@@ -24899,12 +24785,6 @@
 /obj/effect/ai_node,
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/outdoors/v8ne/village/guard/assembly)
-"wyq" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 6
-	},
-/area/vietzhuo8/outdoors/river/north)
 "wyz" = (
 /turf/open/floor/prison/sterilewhite{
 	dir = 10
@@ -24948,12 +24828,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/cafediner)
-"wzP" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/coast{
-	dir = 8
-	},
-/area/vietzhuo8/outdoors/river/north)
 "wzX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/drained{
@@ -25528,10 +25402,6 @@
 	},
 /turf/open/floor/urban/tile/tilebeigecheckered,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/halls)
-"xjc" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8eastcentral)
 "xjl" = (
 /obj/structure/barricade/concrete{
 	dir = 1
@@ -25614,9 +25484,6 @@
 /area/vietzhuo8/indoors/caves/river)
 "xlG" = (
 /turf/open/urban/street/sidewalk,
-/area/vietzhuo8/outdoors/v8west/city/centralarea)
-"xlV" = (
-/turf/open/floor/plating/ground/dirt_alt,
 /area/vietzhuo8/outdoors/v8west/city/centralarea)
 "xmq" = (
 /turf/closed/wall/urban/colony,
@@ -25847,9 +25714,9 @@
 /turf/open/floor/plating/ground/desertdam/asphalt,
 /area/vietzhuo8/indoors/v8west/city/border/security/south)
 "xtD" = (
-/obj/effect/landmark/spawn_marker/civilian/viet/random,
-/turf/open/ground/grass/weedable/patch/grassyellow,
-/area/vietzhuo8/outdoors/v8ne/village/coastalgrounds)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/closed/wall/kutjevo,
+/area/vietzhuo8/outdoors/v8ne/village)
 "xtK" = (
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/clinic)
@@ -26162,10 +26029,6 @@
 	dir = 4
 	},
 /area/vietzhuo8/outdoors/v8west/city/southarea)
-"xGN" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/liquid/water/river,
-/area/vietzhuo8/outdoors/river/southern)
 "xGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/ground/concrete,
@@ -26189,6 +26052,11 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/outdoors/v8sentaf/corporatewalkwaysnorth)
+"xHU" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8eastcentral)
 "xIP" = (
 /obj/structure/barricade/sandbags{
 	dir = 8
@@ -26239,10 +26107,6 @@
 /obj/structure/closet/cabinet,
 /turf/open/floor/wood,
 /area/vietzhuo8/indoors/v8ne/village/civilian_farm_hut)
-"xMo" = (
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/liquid/water/river,
-/area/vietzhuo8/outdoors/river/north)
 "xMp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 1
@@ -26389,11 +26253,6 @@
 	},
 /turf/open/floor/mainship/mono,
 /area/vietzhuo8/indoors/v8ntc/conference)
-"xUy" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
-/turf/open/ground/grass/weedable,
-/area/vietzhuo8/outdoors/v8west/city/northarea)
 "xUZ" = (
 /obj/structure/flora/pottedplant{
 	pixel_y = 4
@@ -26793,11 +26652,9 @@
 /turf/open/floor/tile/blue,
 /area/vietzhuo8/indoors/v8west/city/hanakohilton/lounge)
 "yiO" = (
-/obj/effect/landmark/spawn_marker/civilian/nationaldefense,
-/turf/open/urban/street/sidewalk{
-	dir = 8
-	},
-/area/vietzhuo8/outdoors/v8west/city/southarea)
+/obj/effect/landmark/lv624/fog_blocker/xeno_spawn,
+/turf/open/ground/grass/weedable,
+/area/vietzhuo8/outdoors/v8west/city/northarea)
 "yiT" = (
 /turf/closed/wall/urban/colony,
 /area/vietzhuo8/indoors/v8west/city/border/security/south)
@@ -27188,14 +27045,14 @@ luL
 luL
 luL
 luL
-vOc
-vOc
-vOc
-vOc
-vOc
-vOc
-vOc
-vOc
+rhx
+rhx
+rhx
+rhx
+rhx
+rhx
+rhx
+rhx
 nIW
 sSu
 nIW
@@ -27338,15 +27195,15 @@ czz
 czz
 eBC
 jdK
-bzb
-bzb
-bzb
-bzb
-vOc
-vOc
-vOc
-vOc
-vOc
+dSG
+dSG
+dSG
+dSG
+rhx
+rhx
+rhx
+rhx
+rhx
 luL
 luL
 luL
@@ -27405,14 +27262,14 @@ luL
 luL
 luL
 luL
-vOc
+rhx
 yhl
 eKe
 jka
 eKe
-mFe
+iPS
 hoU
-hhJ
+pMv
 gcu
 pni
 gcu
@@ -27549,13 +27406,13 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
 eBC
 eBC
-cTa
+yiO
 eKe
 tre
 pwp
@@ -27563,7 +27420,7 @@ eKe
 pwp
 luL
 luL
-vOc
+rhx
 luL
 luL
 luL
@@ -27622,14 +27479,14 @@ eKe
 eKe
 eKe
 eKe
-bHr
+rdq
 eKe
 tre
 eKe
 eKe
 eKe
 hoU
-sHj
+omw
 gcu
 pni
 gcu
@@ -27763,7 +27620,7 @@ hiB
 hiB
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -27772,15 +27629,15 @@ hiB
 czz
 czz
 eBC
-cTa
+yiO
 eKe
 qjC
 eKe
-mFe
+iPS
 pwp
 lAY
 eKe
-cTa
+yiO
 eKe
 eKe
 jka
@@ -27839,14 +27696,14 @@ eKe
 eKe
 eKe
 eKe
-cTa
+yiO
 eKe
 eKe
 fEB
 eKe
 pwp
 sEi
-sHj
+omw
 gcu
 pni
 gcu
@@ -27978,13 +27835,13 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -27997,7 +27854,7 @@ eKe
 eKe
 qjC
 eKe
-xUy
+oOf
 ile
 pwp
 eKe
@@ -28056,14 +27913,14 @@ pwp
 pwp
 lAY
 pwp
-bHr
+rdq
 pwp
 pwp
 pwp
 pwp
 pwp
 sEi
-sHj
+omw
 gcu
 pni
 gcu
@@ -28189,17 +28046,17 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 lGa
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -28214,7 +28071,7 @@ eKe
 eKe
 pwp
 eKe
-cTa
+yiO
 viN
 eKe
 eKe
@@ -28273,14 +28130,14 @@ oVu
 oVu
 oVu
 oVu
-rlp
-rlp
-rlp
-rlp
-rlp
-rlp
-vWD
-vWD
+cmx
+cmx
+cmx
+cmx
+cmx
+cmx
+klm
+klm
 gcu
 pni
 gcu
@@ -28413,14 +28270,14 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 czz
 hiB
 hiB
 fMJ
 hiB
-lQg
+adO
 czz
 czz
 eag
@@ -28431,7 +28288,7 @@ yhl
 eKe
 pwp
 fEB
-cTa
+yiO
 eKe
 eKe
 pwp
@@ -28621,7 +28478,7 @@ czz
 lGa
 ryS
 fMJ
-lQg
+adO
 hiB
 ryS
 lGa
@@ -28648,7 +28505,7 @@ pwp
 eKe
 viN
 eKe
-cTa
+yiO
 pwp
 eKe
 qjC
@@ -28772,7 +28629,7 @@ iaa
 uys
 tkX
 nXe
-qfx
+nXe
 plY
 nXe
 nXe
@@ -28844,7 +28701,7 @@ lGa
 lGa
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -28865,7 +28722,7 @@ qjC
 eKe
 eKe
 eKe
-cTa
+yiO
 pwp
 eKe
 bQg
@@ -28995,7 +28852,7 @@ shK
 bVD
 tgd
 uys
-qfx
+nXe
 iaa
 fWh
 ajj
@@ -29057,7 +28914,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -29069,20 +28926,20 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 czz
 vjo
 eag
-bHr
-fIP
-cTa
-bHr
-cTa
-cTa
-cTa
+rdq
+jyE
+yiO
+rdq
+yiO
+yiO
+yiO
 eKe
 eKe
 bQg
@@ -29270,7 +29127,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -29485,10 +29342,10 @@ eBC
 czz
 czz
 czz
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -29504,9 +29361,9 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -29756,7 +29613,7 @@ pwp
 bQg
 enN
 mwh
-oOz
+wTy
 wZn
 dub
 bQg
@@ -29784,12 +29641,12 @@ kQN
 xqC
 bHM
 jNh
-klm
+jNh
 bLg
 cSK
 bVU
 sqM
-gdf
+sqM
 vXK
 sqM
 glL
@@ -29854,7 +29711,7 @@ wls
 aug
 aug
 iHi
-vZZ
+aug
 epJ
 wls
 rDz
@@ -29941,7 +29798,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 czz
 eBC
@@ -30155,7 +30012,7 @@ fMJ
 hiB
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -30175,7 +30032,7 @@ bQg
 bQg
 bQg
 wTy
-oOz
+wTy
 mIp
 bQg
 pwp
@@ -30354,7 +30211,7 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -30368,7 +30225,7 @@ eBC
 czz
 czz
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -30575,7 +30432,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -30587,7 +30444,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -30658,7 +30515,7 @@ ido
 lUN
 lfV
 hoW
-lfV
+eAI
 lfV
 lfV
 nlS
@@ -30810,7 +30667,7 @@ hiB
 hiB
 hiB
 fMJ
-lQg
+adO
 czz
 eBC
 eKe
@@ -31004,7 +30861,7 @@ eBC
 czz
 czz
 czz
-lQg
+adO
 hiB
 fMJ
 hiB
@@ -31020,11 +30877,11 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -31224,18 +31081,18 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 fMJ
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -31439,7 +31296,7 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -31448,17 +31305,17 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 czz
@@ -31610,7 +31467,7 @@ knY
 oze
 oPr
 oPr
-jpI
+oPr
 oPr
 oPr
 oPr
@@ -31668,7 +31525,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -31872,7 +31729,7 @@ eBC
 czz
 czz
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -32049,7 +31906,7 @@ rab
 rab
 rab
 oPr
-hgX
+vZZ
 oPr
 oPr
 oPr
@@ -32092,22 +31949,22 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 eBC
 eBC
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -32312,7 +32169,7 @@ hiB
 hiB
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -32446,7 +32303,7 @@ kuB
 dDB
 stJ
 juO
-qRq
+xlG
 gcu
 pni
 gcu
@@ -32525,7 +32382,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 eBC
 eBC
 czz
@@ -32536,7 +32393,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -32750,7 +32607,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -32964,7 +32821,7 @@ eBC
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -32979,7 +32836,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 fMJ
 hiB
 czz
@@ -33175,7 +33032,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 eBC
 czz
 czz
@@ -33193,7 +33050,7 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -33228,7 +33085,7 @@ pwp
 bQg
 ugN
 wTy
-oOz
+wTy
 ekU
 wTy
 bQg
@@ -33390,16 +33247,16 @@ pRU
 eBC
 czz
 czz
-lQg
+adO
 hiB
 hiB
 eBC
 czz
 kjO
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -33408,7 +33265,7 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -33428,7 +33285,7 @@ pwp
 uFv
 bLs
 eES
-oOz
+wTy
 wTy
 ekU
 kzK
@@ -33536,7 +33393,7 @@ gcu
 gcu
 gcu
 gcu
-dwA
+mKA
 hag
 uEp
 ohM
@@ -33622,7 +33479,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -33631,7 +33488,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -33645,7 +33502,7 @@ pwp
 uFv
 nlI
 eES
-wTy
+oOz
 wTy
 wTy
 bQg
@@ -33760,10 +33617,10 @@ hMr
 hMr
 hMr
 gzv
-uzE
+uKv
 hMr
 ohM
-dqF
+bgL
 esC
 wfo
 knY
@@ -33784,7 +33641,7 @@ gpm
 xSx
 wnI
 oPr
-jpI
+oPr
 xqa
 oPr
 oPr
@@ -33826,17 +33683,17 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 eBC
 eBC
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -33980,7 +33837,7 @@ hMr
 hMr
 hMr
 ohM
-dqF
+bgL
 esC
 fWh
 knY
@@ -34050,7 +33907,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34062,7 +33919,7 @@ hiB
 hiB
 fMJ
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34172,7 +34029,7 @@ juO
 khF
 juO
 juO
-nCN
+juO
 juO
 juO
 juO
@@ -34272,7 +34129,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34476,12 +34333,12 @@ eBC
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34493,12 +34350,12 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -34656,7 +34513,7 @@ oPr
 xqa
 oPr
 oPr
-jpI
+oPr
 gpm
 jjM
 swy
@@ -34702,7 +34559,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34713,7 +34570,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34795,7 +34652,7 @@ gcu
 oNF
 gcu
 gcu
-rdq
+aXw
 ldW
 gcu
 gcu
@@ -34908,7 +34765,7 @@ pRU
 (38,1,1) = {"
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34924,7 +34781,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -34934,7 +34791,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 czz
 czz
@@ -35130,10 +34987,10 @@ hiB
 hiB
 fMJ
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -35143,7 +35000,7 @@ hiB
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -35304,7 +35161,7 @@ gpm
 wnI
 oPr
 oPr
-jaM
+xqa
 oPr
 oPr
 oPr
@@ -35366,7 +35223,7 @@ eBC
 eBC
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -35586,7 +35443,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 czz
@@ -35778,7 +35635,7 @@ eBC
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -35798,7 +35655,7 @@ eBC
 eBC
 czz
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -35998,7 +35855,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 eBC
 eBC
@@ -36022,7 +35879,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 vAP
 lsR
 lsR
@@ -36058,7 +35915,7 @@ oVu
 oVu
 oVu
 rbA
-jxd
+oVu
 oVu
 oVu
 oVu
@@ -36210,7 +36067,7 @@ pRU
 (44,1,1) = {"
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -36219,14 +36076,14 @@ hiB
 hiB
 czz
 czz
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 eBC
 eBC
@@ -36234,15 +36091,15 @@ eBC
 eBC
 czz
 hiB
-lQg
+adO
 hiB
 fMJ
-lQg
+adO
 hiB
 hiB
 lsR
 lsR
-weS
+vge
 pwp
 eKe
 aWt
@@ -36298,7 +36155,7 @@ rId
 oRt
 rYj
 rYj
-iHt
+rYj
 rYj
 rYj
 rYj
@@ -36362,7 +36219,7 @@ pOs
 qeu
 qeu
 qeu
-yiO
+qeu
 qeu
 qTf
 qeu
@@ -36391,7 +36248,7 @@ oPr
 oPr
 xqa
 oPr
-jpI
+oPr
 oPr
 gpm
 gpm
@@ -36430,7 +36287,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -36439,7 +36296,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -36651,14 +36508,14 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 eBC
@@ -36673,7 +36530,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 lsR
 lsR
 lsR
@@ -36870,7 +36727,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -36937,7 +36794,7 @@ gvK
 viL
 kkP
 viL
-viL
+hVV
 viL
 viL
 gvK
@@ -36952,7 +36809,7 @@ viL
 viL
 viL
 qsZ
-qsZ
+qhB
 coH
 gHK
 mnK
@@ -37079,7 +36936,7 @@ pRU
 eBC
 czz
 czz
-lQg
+adO
 hiB
 czz
 czz
@@ -37090,7 +36947,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -37098,7 +36955,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -37304,14 +37161,14 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -37320,7 +37177,7 @@ fMJ
 hiB
 hiB
 aHe
-lQg
+adO
 hiB
 hiB
 hiB
@@ -37369,7 +37226,7 @@ gah
 ygF
 ujZ
 tME
-fFD
+tME
 tME
 tME
 tME
@@ -37380,7 +37237,7 @@ xPI
 tME
 tME
 tME
-tME
+fFD
 tME
 tME
 tME
@@ -37388,7 +37245,7 @@ tME
 jsA
 usY
 usY
-eBB
+usY
 xDD
 usY
 uSj
@@ -37515,11 +37372,11 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 czz
@@ -37531,16 +37388,16 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 fMJ
-lQg
+adO
 hiB
 lsR
 lsR
@@ -37592,16 +37449,16 @@ eae
 eae
 ubW
 jcN
-mrZ
-mrZ
+fvS
+fvS
 irF
 irF
 irF
-mrZ
-mrZ
+fvS
+fvS
 mxq
-mrZ
-mrZ
+fvS
+fvS
 usY
 usY
 usY
@@ -37742,7 +37599,7 @@ czz
 eBC
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -37933,7 +37790,7 @@ ejD
 lAj
 eDx
 oKJ
-adO
+lLn
 lLn
 txp
 fWh
@@ -37949,7 +37806,7 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -37962,7 +37819,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 eBC
 eBC
@@ -37971,11 +37828,11 @@ eBC
 czz
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 lsR
 lsR
 lsR
@@ -38168,7 +38025,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 eBC
 eBC
@@ -38190,7 +38047,7 @@ eBC
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 lsR
@@ -38248,7 +38105,7 @@ wnL
 osr
 osr
 hAb
-tQD
+eBB
 hAb
 hAb
 osr
@@ -38300,8 +38157,8 @@ mBh
 mBh
 mBh
 nMk
-mBh
 ftL
+mBh
 jzT
 jsl
 fUt
@@ -38394,11 +38251,11 @@ eBC
 eBC
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 czz
@@ -38409,7 +38266,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 eBC
 eKe
@@ -38488,24 +38345,24 @@ lDr
 iMp
 noq
 bSo
+bSo
+bSo
+bSo
+sDb
+bSo
+bSo
+sDb
+bSo
+bSo
+bSo
+bSo
+bSo
+bSo
+bSo
+sDb
+bSo
+bSo
 kSW
-bSo
-bSo
-sDb
-bSo
-bSo
-sDb
-bSo
-bSo
-bSo
-bSo
-bSo
-bSo
-bSo
-sDb
-bSo
-bSo
-bSo
 noq
 bSo
 bSo
@@ -38602,7 +38459,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 czz
@@ -38613,7 +38470,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -38623,7 +38480,7 @@ czz
 eBC
 czz
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -38715,7 +38572,7 @@ sDb
 sDb
 qdu
 sDb
-rhx
+sDb
 sDb
 sDb
 bSo
@@ -38728,7 +38585,7 @@ bSo
 bSo
 sDb
 bSo
-jXg
+ubP
 bSo
 noq
 bSo
@@ -38745,7 +38602,7 @@ pni
 gcu
 gcu
 mKA
-wva
+hag
 knY
 oVd
 knY
@@ -38822,7 +38679,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 eBC
 czz
@@ -38833,7 +38690,7 @@ hiB
 hiB
 hiB
 fMJ
-lQg
+adO
 hiB
 czz
 eBC
@@ -38842,7 +38699,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -38933,7 +38790,7 @@ mLd
 jsl
 mBh
 jsl
-jsl
+wui
 wtw
 mBh
 mBh
@@ -38946,8 +38803,8 @@ mBh
 mBh
 pHj
 jsl
-wui
-mLd
+jsl
+oKL
 bRr
 lyr
 jsl
@@ -39000,7 +38857,7 @@ knY
 iUm
 lDf
 rlF
-iPS
+vhg
 ops
 vhg
 vhg
@@ -39044,7 +38901,7 @@ hiB
 czz
 czz
 fMJ
-lQg
+adO
 hiB
 hiB
 hiB
@@ -39253,18 +39110,18 @@ czz
 czz
 czz
 hiB
-lQg
+adO
 hiB
 fMJ
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -39273,11 +39130,11 @@ czz
 eBC
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 czz
 eBC
@@ -39328,16 +39185,16 @@ eae
 eae
 mCN
 jcN
-mrZ
-mrZ
+fvS
+fvS
 mxq
-mrZ
-mrZ
+fvS
+fvS
 irF
 irF
 irF
-mrZ
-mrZ
+fvS
+fvS
 usY
 usY
 usY
@@ -39473,17 +39330,17 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -39492,7 +39349,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 czz
@@ -39693,7 +39550,7 @@ eBC
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -39705,13 +39562,13 @@ czz
 eBC
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 czz
 eBC
@@ -39755,7 +39612,7 @@ xrK
 rhU
 gVn
 lvx
-hJP
+gVn
 gVn
 eZI
 gVn
@@ -39763,11 +39620,11 @@ gVn
 gVn
 lvx
 ygF
-ygF
+lfm
 ygF
 ygF
 uGN
-lfm
+ygF
 ygF
 ygF
 ygF
@@ -39885,7 +39742,7 @@ hAt
 ofr
 bXZ
 pPq
-ffm
+jCA
 jCA
 skg
 bXZ
@@ -39904,7 +39761,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -39914,7 +39771,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -39998,7 +39855,7 @@ wrv
 roO
 tQV
 pxb
-qxG
+xlG
 gcu
 pni
 gcu
@@ -40095,7 +39952,7 @@ crc
 xiu
 gBr
 dTC
-dtY
+dTC
 dTC
 qGs
 gTo
@@ -40141,7 +39998,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 swG
 hiB
 hiB
@@ -40334,19 +40191,19 @@ pRU
 eBC
 czz
 czz
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 czz
 czz
 eBC
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -40355,7 +40212,7 @@ eBC
 eBC
 czz
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -40566,7 +40423,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 eBC
 czz
@@ -40577,7 +40434,7 @@ hiB
 hiB
 hiB
 fMJ
-lQg
+adO
 hiB
 hiB
 czz
@@ -40770,12 +40627,12 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -40791,12 +40648,12 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 eBC
 viN
@@ -40807,7 +40664,7 @@ bQg
 bQg
 bQg
 bQg
-oOz
+wTy
 wTy
 wTy
 kzK
@@ -40887,7 +40744,7 @@ tPu
 dcC
 tPu
 tPu
-hRv
+tPu
 tPu
 tPu
 tPu
@@ -40936,7 +40793,7 @@ uci
 mcg
 mcg
 mcg
-eVp
+mcg
 uci
 mcg
 mcg
@@ -40995,7 +40852,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -41215,7 +41072,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -41227,7 +41084,7 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -41418,7 +41275,7 @@ pRU
 (68,1,1) = {"
 eBC
 vjo
-lQg
+adO
 ryS
 hiB
 hiB
@@ -41428,7 +41285,7 @@ eBC
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 hiB
@@ -41446,7 +41303,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 czz
 czz
@@ -41638,12 +41495,12 @@ vjo
 hiB
 hiB
 hiB
-lQg
+adO
 ryS
 vjo
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -41654,7 +41511,7 @@ hiB
 eBC
 czz
 hiB
-lQg
+adO
 hiB
 czz
 eBC
@@ -41689,7 +41546,7 @@ oVu
 bgy
 jCf
 vdO
-qoK
+jCf
 ukm
 cyb
 cyb
@@ -41865,7 +41722,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 eBC
 eBC
@@ -41877,7 +41734,7 @@ hiB
 czz
 eBC
 czz
-lQg
+adO
 hiB
 hiB
 hiB
@@ -42078,7 +41935,7 @@ eag
 czz
 czz
 fMJ
-lQg
+adO
 czz
 hiB
 hiB
@@ -42090,7 +41947,7 @@ hiB
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 eBC
@@ -42098,7 +41955,7 @@ czz
 hiB
 hiB
 hiB
-lQg
+adO
 czz
 czz
 eBC
@@ -42289,7 +42146,7 @@ vjo
 hiB
 hiB
 hiB
-lQg
+adO
 hiB
 eag
 czz
@@ -42300,10 +42157,10 @@ czz
 czz
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
-lQg
+adO
 hiB
 hiB
 aHe
@@ -42480,9 +42337,9 @@ vjQ
 eQc
 mut
 fib
-djc
-htw
 fib
+htw
+djc
 fib
 fib
 htw
@@ -42511,11 +42368,11 @@ thT
 cny
 qyt
 thT
-hVV
+iHt
 thT
 ybg
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -42525,7 +42382,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 ybg
@@ -42658,7 +42515,7 @@ oaR
 erW
 jlU
 quP
-tKI
+oaR
 ooU
 aWr
 yly
@@ -42735,7 +42592,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 aEg
 thT
@@ -42747,7 +42604,7 @@ thT
 thT
 ybg
 ybg
-hVV
+iHt
 thT
 thT
 qyt
@@ -42785,7 +42642,7 @@ ajb
 cyb
 wkh
 ajb
-rWr
+cyb
 cyb
 cyb
 jLf
@@ -42815,7 +42672,7 @@ juO
 juO
 juO
 juO
-nCN
+juO
 juO
 juO
 juO
@@ -42944,7 +42801,7 @@ qyt
 ybg
 cny
 qyt
-hVV
+iHt
 thT
 thT
 ybg
@@ -42956,7 +42813,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -43055,7 +42912,7 @@ juO
 juO
 juO
 juO
-nCN
+juO
 juO
 juO
 khF
@@ -43163,7 +43020,7 @@ xrW
 qyt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 ybg
@@ -43171,7 +43028,7 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -43179,7 +43036,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -43522,7 +43379,7 @@ pTo
 xmq
 uqt
 oaR
-tKI
+oaR
 lab
 oaR
 ahm
@@ -43597,7 +43454,7 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -43610,14 +43467,14 @@ thT
 qyt
 ybg
 qyt
-hVV
+iHt
 thT
 thT
 thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 ybg
@@ -43816,14 +43673,14 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
 ybg
 qyt
@@ -43963,7 +43820,7 @@ jLh
 hzx
 hzx
 xmq
-hps
+hzx
 hzx
 saD
 xmq
@@ -44037,7 +43894,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -44048,7 +43905,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -44142,7 +43999,7 @@ ghx
 wyz
 qWI
 ghx
-rog
+wyz
 wyz
 ghx
 wyz
@@ -44251,7 +44108,7 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -44279,7 +44136,7 @@ eKe
 eKe
 gst
 wmH
-bgL
+wmH
 wmH
 oQt
 ppT
@@ -44430,7 +44287,7 @@ ajj
 cSa
 rLw
 qWZ
-hRY
+qWZ
 lEV
 yiT
 ajj
@@ -44473,14 +44330,14 @@ thT
 thT
 aEg
 thT
-hVV
+iHt
 thT
 qyt
 ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -44577,7 +44434,7 @@ wyz
 qWI
 ouG
 wyz
-wyz
+rog
 ouG
 wyz
 goe
@@ -44676,7 +44533,7 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -44687,7 +44544,7 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -44761,7 +44618,7 @@ eKe
 eKe
 eKe
 eKe
-kDw
+eVp
 pwp
 hoU
 hoU
@@ -44896,7 +44753,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -44977,9 +44834,9 @@ eKe
 eKe
 eKe
 eKe
-kDw
-kDw
-kDw
+eVp
+eVp
+eVp
 hoU
 hoU
 hoU
@@ -45109,13 +44966,13 @@ ybg
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 rCa
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -45193,11 +45050,11 @@ eKe
 eKe
 eKe
 jpY
-kDw
-kDw
-tmQ
-kDw
-xlV
+eVp
+eVp
+sma
+eVp
+wva
 bLd
 hoU
 hoU
@@ -45334,7 +45191,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 ybg
@@ -45350,7 +45207,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -45411,11 +45268,11 @@ eKe
 eKe
 eKe
 eKe
-kDw
-kDw
-kDw
-xlV
-xlV
+eVp
+eVp
+eVp
+wva
+wva
 sEi
 lBc
 hoU
@@ -45462,7 +45319,7 @@ sEi
 tMF
 kHy
 qBB
-cpb
+qBB
 qBB
 qFq
 tMF
@@ -45475,7 +45332,7 @@ tMF
 tMF
 jlt
 qBB
-cpb
+qBB
 xxV
 tMF
 tMF
@@ -45555,7 +45412,7 @@ thT
 thT
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -45564,7 +45421,7 @@ qyt
 qyt
 ybg
 ybg
-hVV
+iHt
 thT
 thT
 thT
@@ -45628,10 +45485,10 @@ eKe
 eKe
 eKe
 eKe
-kDw
-kDw
-kDw
-xlV
+eVp
+eVp
+eVp
+wva
 hoU
 hoU
 hoU
@@ -45763,7 +45620,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -45776,7 +45633,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -45785,19 +45642,19 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
 qyt
 cny
-cTa
-cTa
-cTa
-cTa
-cTa
-cTa
-cTa
+yiO
+yiO
+yiO
+yiO
+yiO
+yiO
+yiO
 lAY
 fQi
 pwp
@@ -45847,7 +45704,7 @@ eKe
 pwp
 pwp
 jpY
-kDw
+eVp
 hoU
 hoU
 ljS
@@ -45978,12 +45835,12 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -46014,7 +45871,7 @@ fEB
 eKe
 pwp
 pwp
-xUy
+oOf
 eKe
 eKe
 uNH
@@ -46208,7 +46065,7 @@ thT
 xFl
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -46217,7 +46074,7 @@ qyt
 qyt
 ybg
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -46227,11 +46084,11 @@ ybg
 cny
 eKe
 tre
-mFe
+iPS
 eKe
 pwp
 eKe
-cTa
+yiO
 eKe
 eKe
 eKe
@@ -46441,14 +46298,14 @@ thT
 qyt
 qyt
 ybg
-cTa
+yiO
 eKe
 eKe
 eKe
 jpY
 pwp
 eKe
-kEC
+tMZ
 tre
 eKe
 eKe
@@ -46631,17 +46488,17 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 qyt
 ybg
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 aEg
@@ -46654,18 +46511,18 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 ybg
-xUy
+oOf
 eKe
 eKe
 tre
 eKe
 eKe
 eKe
-cTa
+yiO
 eKe
 pwp
 pwp
@@ -46863,7 +46720,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -46875,14 +46732,14 @@ thT
 thT
 qyt
 ybg
-cTa
+yiO
 jpY
 eKe
 eKe
 eKe
 eKe
 eKe
-cTa
+yiO
 pwp
 pwp
 xMJ
@@ -47043,16 +46900,16 @@ cXs
 cXs
 cXs
 cXs
-hwi
-hwi
-hwi
-hwi
-hwi
-hwi
-hwi
-hwi
-hwi
-hwi
+fIq
+fIq
+fIq
+fIq
+fIq
+fIq
+fIq
+fIq
+fIq
+fIq
 ajj
 jdK
 pRU
@@ -47063,16 +46920,16 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 sHh
 ftz
@@ -47086,20 +46943,20 @@ ftz
 aGg
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
 thT
 ybg
-cTa
+yiO
 eKe
 eKe
 pwp
 pwp
 pwp
 pwp
-cjV
+inm
 pjx
 pjx
 yhR
@@ -47159,8 +47016,8 @@ bLd
 xmK
 tMF
 qBB
-qBB
-kHf
+cpb
+hce
 vxX
 sEi
 bLd
@@ -47260,7 +47117,7 @@ cXs
 cXs
 cXs
 cXs
-hwi
+fIq
 cXs
 cXs
 cXs
@@ -47269,7 +47126,7 @@ cXs
 cXs
 cXs
 cXs
-hwi
+fIq
 ajj
 jdK
 pRU
@@ -47287,7 +47144,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 sHh
 ftz
@@ -47307,16 +47164,16 @@ aGg
 thT
 thT
 thT
-hVV
+iHt
 ybg
-cTa
-cTa
-cjV
-wrN
-wrN
-wrN
-wrN
-wyq
+yiO
+yiO
+inm
+lDM
+lDM
+lDM
+lDM
+lhx
 tpA
 xxw
 tpA
@@ -47376,7 +47233,7 @@ sEi
 sEi
 tMF
 trM
-cpb
+qBB
 qBB
 tMF
 sEi
@@ -47477,7 +47334,7 @@ cXs
 cXs
 cXs
 cXs
-hwi
+fIq
 cXs
 cXs
 cXs
@@ -47486,7 +47343,7 @@ cXs
 cXs
 cXs
 cXs
-hwi
+fIq
 ajj
 jdK
 pRU
@@ -47498,7 +47355,7 @@ aGg
 qyt
 qyt
 thT
-hVV
+iHt
 sHh
 ftz
 ftz
@@ -47509,7 +47366,7 @@ sHh
 jDG
 xlm
 xlm
-hza
+dtY
 xlm
 xlm
 xlm
@@ -47527,7 +47384,7 @@ ftz
 ftz
 ftz
 pjx
-veN
+lIz
 yhR
 xxw
 xxw
@@ -47694,16 +47551,16 @@ ajj
 cXs
 cXs
 cXs
-hwi
+fIq
 cXs
 cXs
 cXs
 cXs
-rMh
+pcv
 cXs
 cXs
 cXs
-hwi
+fIq
 cXs
 jdK
 pRU
@@ -47720,7 +47577,7 @@ jDG
 xlm
 xlm
 xlm
-esb
+fzN
 ftz
 jDG
 xlm
@@ -47729,20 +47586,20 @@ ezS
 ezS
 ezS
 xlm
-hza
+dtY
 ezS
 ezS
 ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 xlm
 xlm
 xlm
 xlm
 xlm
-hza
+dtY
 xxw
 xxw
 xxw
@@ -47911,7 +47768,7 @@ ajj
 ajj
 ajj
 ajj
-hwi
+fIq
 cXs
 cXs
 cXs
@@ -47920,7 +47777,7 @@ cXs
 cXs
 cXs
 cXs
-hwi
+fIq
 ajj
 jdK
 pRU
@@ -47931,10 +47788,10 @@ xlm
 xlm
 xlm
 xlm
-hza
+dtY
 xlm
 xlm
-hza
+dtY
 ezS
 ezS
 ezS
@@ -47998,15 +47855,15 @@ xxw
 tpA
 eSp
 fqx
-mlX
-jAD
-jAD
-jAD
-hIt
-wzP
-wzP
-hAv
-xMo
+hrL
+hJP
+hJP
+hJP
+jxd
+qxG
+qxG
+hRv
+eud
 xxw
 xxw
 kzH
@@ -48128,7 +47985,7 @@ aJr
 lBp
 ajj
 ajj
-fvS
+dOd
 ajj
 cXs
 cXs
@@ -48137,7 +47994,7 @@ cXs
 cXs
 cXs
 cXs
-fvS
+dOd
 ajj
 jdK
 pRU
@@ -48159,7 +48016,7 @@ ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 ezS
 ezS
@@ -48173,7 +48030,7 @@ ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 ezS
 ezS
@@ -48215,7 +48072,7 @@ eSp
 fqx
 lQC
 aly
-bnl
+cNG
 iiy
 lvb
 lvb
@@ -48223,7 +48080,7 @@ aly
 aly
 aly
 jVy
-hAv
+hRv
 xxw
 xxw
 xxw
@@ -48345,7 +48202,7 @@ ygq
 sqp
 lBp
 ajj
-fvS
+dOd
 ajj
 ajj
 ajj
@@ -48354,7 +48211,7 @@ cXs
 cXs
 cXs
 cXs
-fvS
+dOd
 ajj
 jdK
 pRU
@@ -48370,7 +48227,7 @@ ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 ezS
 ezS
@@ -48379,14 +48236,14 @@ ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 ezS
 ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 ezS
 ezS
@@ -48432,7 +48289,7 @@ bNu
 aly
 aly
 aly
-bnl
+cNG
 veA
 mPt
 lvb
@@ -48440,7 +48297,7 @@ veA
 veA
 aly
 aly
-hIt
+jxd
 fqx
 sPx
 xxw
@@ -48562,7 +48419,7 @@ ygq
 gdp
 sqp
 aJr
-coa
+rWr
 aJr
 aJr
 lBp
@@ -48571,7 +48428,7 @@ ajj
 cXs
 cXs
 cXs
-fvS
+dOd
 ajj
 jdK
 pRU
@@ -48583,7 +48440,7 @@ ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 ezS
 ezS
@@ -48610,7 +48467,7 @@ xlm
 xlm
 xlm
 xlm
-hza
+dtY
 xxw
 xxw
 tpA
@@ -48649,15 +48506,15 @@ bbf
 vjf
 aly
 aly
-weT
+qfx
 veA
 veA
-qju
+lQg
 lvb
-iqr
+ody
 veA
 aly
-bnl
+cNG
 aly
 jVy
 sPx
@@ -48779,16 +48636,16 @@ gdp
 ygq
 ygq
 ygq
-ucq
-xGN
-xGN
-oMH
-ubh
-fvS
-fvS
-fvS
-fvS
-fvS
+voX
+guA
+guA
+nPP
+qAc
+dOd
+dOd
+dOd
+dOd
+dOd
 reW
 aJr
 pRU
@@ -48830,7 +48687,7 @@ ebd
 ebd
 fqx
 fqx
-tJf
+evP
 sPx
 xxw
 tpA
@@ -48866,7 +48723,7 @@ xxw
 uGV
 pjx
 vjf
-bnl
+cNG
 aly
 veA
 lvb
@@ -48874,7 +48731,7 @@ lvb
 lvb
 veA
 veA
-weT
+qfx
 iiy
 lvb
 jVy
@@ -49019,7 +48876,7 @@ ezS
 ezS
 ezS
 ezS
-hJz
+ezi
 ezS
 xlm
 ezS
@@ -49027,9 +48884,9 @@ ezS
 ezS
 xlm
 xlm
-hza
+dtY
 xlm
-hza
+dtY
 yhK
 ebd
 ebd
@@ -49037,10 +48894,10 @@ ebd
 ebd
 ebd
 oDQ
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -49083,7 +48940,7 @@ xxw
 xxw
 xxw
 uGV
-fsH
+qRq
 veA
 veA
 veA
@@ -49091,7 +48948,7 @@ lvb
 lvb
 iiy
 lvb
-jAD
+hJP
 lvb
 lvb
 iiy
@@ -49239,7 +49096,7 @@ xlm
 xlm
 xlm
 xlm
-hza
+dtY
 xlm
 xlm
 yhK
@@ -49250,7 +49107,7 @@ ebd
 oDQ
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -49259,7 +49116,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 ybg
@@ -49300,17 +49157,17 @@ kzH
 xxw
 tpA
 xxw
-nWs
+nVt
 aly
 aly
 aly
 lvb
-ovW
+aJW
 iiy
 jQG
-fHC
+qoK
 lvb
-ovW
+aJW
 veA
 aly
 fBm
@@ -49452,7 +49309,7 @@ xlm
 xlm
 xlm
 xlm
-hza
+dtY
 xlm
 xlm
 yhK
@@ -49470,7 +49327,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -49517,7 +49374,7 @@ kzH
 kzH
 xxw
 tpA
-mUy
+mPN
 pjx
 vjf
 iiy
@@ -49525,7 +49382,7 @@ lvb
 lvb
 lvb
 lvb
-fHC
+qoK
 ldH
 lvb
 veA
@@ -49666,16 +49523,16 @@ ybg
 xlm
 xlm
 xlm
-oNc
+wla
 ebd
 ebd
 ebd
 ebd
 ebd
 oDQ
-hVV
+iHt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -49734,15 +49591,15 @@ kzH
 kzH
 xxw
 xxw
-xMo
-cEx
-mUy
-fsH
-jAD
-weT
-weT
-weT
-fHC
+eud
+gKX
+mPN
+qRq
+hJP
+qfx
+qfx
+qfx
+qoK
 lvb
 iiy
 veA
@@ -49896,7 +49753,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -50105,13 +49962,13 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
 aEg
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -50180,7 +50037,7 @@ aly
 veA
 lvb
 veA
-mcP
+pHG
 veA
 veA
 aly
@@ -50320,7 +50177,7 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -50551,11 +50408,11 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -50757,7 +50614,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -50765,7 +50622,7 @@ ybg
 ybg
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -50791,7 +50648,7 @@ gAw
 rYI
 bQZ
 wBt
-fIq
+fSI
 wBt
 rYI
 rYI
@@ -50988,11 +50845,11 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -51190,11 +51047,11 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 xFl
 thT
-hVV
+iHt
 thT
 qyt
 ybg
@@ -51202,7 +51059,7 @@ ybg
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -51212,7 +51069,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -51423,10 +51280,10 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 thT
 aEg
@@ -51845,17 +51702,17 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 thT
 thT
@@ -51864,7 +51721,7 @@ thT
 xFl
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -52287,7 +52144,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 ybg
@@ -52295,7 +52152,7 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -52499,10 +52356,10 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -52517,7 +52374,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -52546,8 +52403,8 @@ gwK
 gSE
 gSE
 gSE
-gSE
 lxu
+gSE
 gSE
 oBL
 qYb
@@ -52723,7 +52580,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
 ybg
 ybg
@@ -52938,7 +52795,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -52948,7 +52805,7 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -52975,7 +52832,7 @@ uej
 uej
 uej
 uej
-xtD
+iLb
 iLb
 mMu
 lZe
@@ -53153,7 +53010,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -53360,31 +53217,31 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
-hVV
-thT
-qyt
-ybg
-ybg
-qyt
-thT
-thT
-thT
-thT
-thT
-thT
-thT
+iHt
 thT
 qyt
 ybg
 ybg
 qyt
+thT
+thT
+thT
+thT
+thT
+thT
+thT
+thT
+qyt
+ybg
+ybg
+qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -53428,7 +53285,7 @@ sUP
 wCk
 sUP
 xVu
-sUP
+jaR
 sUP
 sUP
 wCk
@@ -53603,7 +53460,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -53792,7 +53649,7 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -53806,10 +53663,10 @@ ybg
 ybg
 qyt
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -53860,7 +53717,7 @@ rug
 rug
 nNs
 fBe
-ezi
+nNs
 xnO
 xnO
 xnO
@@ -54011,11 +53868,11 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 aEg
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -54067,7 +53924,7 @@ uej
 iLb
 gAw
 gAw
-omw
+gAw
 gAw
 gAw
 jbk
@@ -54079,8 +53936,8 @@ uLe
 nNs
 nNs
 xnO
-agD
-ezi
+ajY
+nNs
 fBe
 nNs
 xIT
@@ -54225,7 +54082,7 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -54236,26 +54093,26 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
-hVV
+iHt
 thT
 thT
 thT
 qyt
 ybg
-ybg
-qyt
-qyt
-qyt
-qyt
 ybg
 qyt
 qyt
 qyt
+qyt
+ybg
+qyt
+qyt
+qyt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -54458,7 +54315,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -54533,7 +54390,7 @@ gwK
 rXf
 ykL
 mKV
-qTP
+ykL
 ykL
 ykL
 gwK
@@ -54660,7 +54517,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -54668,7 +54525,7 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -54690,7 +54547,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 ybg
@@ -54749,8 +54606,8 @@ faK
 mMu
 pOv
 ykL
-qTP
 ykL
+qTP
 ykL
 ykL
 gwK
@@ -54889,7 +54746,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -54904,7 +54761,7 @@ qyt
 ybg
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -54941,7 +54798,7 @@ iLb
 iLb
 jbk
 gAw
-omw
+gAw
 faK
 oCZ
 rug
@@ -55092,14 +54949,14 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -55111,10 +54968,10 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -55319,13 +55176,13 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
 aEg
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -55339,10 +55196,10 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 ybg
@@ -55384,7 +55241,7 @@ yef
 iLb
 iLb
 faK
-xtD
+iLb
 gAw
 gAw
 iLb
@@ -55529,17 +55386,17 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
-hVV
-thT
-thT
-thT
+iHt
 thT
 thT
 thT
-hVV
+thT
+thT
+thT
+iHt
 thT
 thT
 thT
@@ -55743,7 +55600,7 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 aEg
 thT
 thT
@@ -55752,7 +55609,7 @@ qyt
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -55764,15 +55621,15 @@ ybg
 qyt
 qyt
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 ybg
 ybg
-hVV
+iHt
 thT
 rCa
 thT
@@ -55789,9 +55646,9 @@ lia
 gae
 bTe
 uoX
-yeP
-bTe
 uoX
+bTe
+yeP
 uoX
 bTe
 uoX
@@ -55972,7 +55829,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -55993,7 +55850,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -56014,7 +55871,7 @@ uoX
 bTe
 gae
 kac
-nbe
+fFv
 fFv
 cfx
 cfx
@@ -56191,7 +56048,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -56202,7 +56059,7 @@ thT
 aEg
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -56396,7 +56253,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 ybg
@@ -56424,9 +56281,9 @@ thT
 thT
 qyt
 thT
-hVV
+iHt
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -56633,13 +56490,13 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 aEg
@@ -56828,7 +56685,7 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 thT
@@ -56853,7 +56710,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -56917,7 +56774,7 @@ uej
 iLb
 iLb
 gAw
-omw
+gAw
 gAw
 gAw
 gAw
@@ -56932,7 +56789,7 @@ iCN
 gwK
 gwK
 iLb
-xtD
+iLb
 iLb
 etz
 kaa
@@ -57048,7 +56905,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -57058,13 +56915,13 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
-hVV
+iHt
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -57075,7 +56932,7 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -57272,7 +57129,7 @@ xrW
 xrW
 thT
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -57289,7 +57146,7 @@ ybg
 ybg
 qyt
 thT
-hVV
+iHt
 thT
 thT
 thT
@@ -57536,7 +57393,7 @@ oNI
 oNI
 oNI
 fFv
-tvc
+cfx
 dgn
 cfx
 cfx
@@ -57697,10 +57554,10 @@ qyt
 qyt
 qyt
 gEC
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 sCw
 thT
 gEC
@@ -57709,17 +57566,17 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 thT
 aEg
 thT
 qyt
 thT
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 ybg
 ybg
@@ -57796,7 +57653,7 @@ gAw
 gwK
 ngD
 ykL
-qTP
+ykL
 ykL
 ykL
 gwK
@@ -57921,7 +57778,7 @@ thT
 thT
 thT
 gEC
-hVV
+iHt
 thT
 qyt
 qyt
@@ -58135,24 +57992,24 @@ thT
 thT
 thT
 thT
-hVV
+iHt
 thT
 gEC
 qyt
 qyt
 ybg
 qyt
-hVV
+iHt
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
 qyt
 thT
 thT
-hVV
+iHt
 aEg
 thT
 thT
@@ -58371,7 +58228,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 thT
 qyt
 qyt
@@ -58578,7 +58435,7 @@ qyt
 thT
 thT
 thT
-hVV
+iHt
 qyt
 qyt
 qyt
@@ -58661,7 +58518,7 @@ cfx
 cfx
 uej
 uej
-nPP
+uej
 iLb
 iLb
 faK
@@ -58793,7 +58650,7 @@ qyt
 qyt
 thT
 thT
-hVV
+iHt
 thT
 thT
 qyt
@@ -58802,7 +58659,7 @@ qyt
 qyt
 qyt
 qyt
-hVV
+iHt
 thT
 thT
 qyt
@@ -59012,7 +58869,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 rzk
@@ -59033,7 +58890,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -59225,7 +59082,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -59238,7 +59095,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 okU
@@ -59300,7 +59157,7 @@ fFv
 fFv
 mWu
 fFv
-nbe
+fFv
 cfx
 cfx
 fFv
@@ -59446,7 +59303,7 @@ sAv
 sAv
 nrp
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -59462,17 +59319,17 @@ okU
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
-qIK
-sAv
-sAv
-sAv
+dwA
 sAv
 sAv
 sAv
-qIK
+sAv
+sAv
+sAv
+dwA
 sAv
 rzk
 rzk
@@ -59656,7 +59513,7 @@ okU
 okU
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -59670,9 +59527,9 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
-qIK
+dwA
 rzk
 rzk
 okU
@@ -59708,7 +59565,7 @@ kqH
 tqo
 cWo
 uoX
-yeP
+uoX
 bTe
 cWo
 lia
@@ -59879,7 +59736,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -59924,7 +59781,7 @@ cWo
 cWo
 cWo
 cWo
-uoX
+yeP
 uoX
 wbm
 fLN
@@ -60088,11 +59945,11 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -60112,16 +59969,16 @@ rzk
 okU
 okU
 sAv
-qIK
+dwA
 sAv
-qIK
-sAv
-sAv
-qIK
+dwA
 sAv
 sAv
+dwA
 sAv
-qIK
+sAv
+sAv
+dwA
 sAv
 sAv
 sAv
@@ -60315,7 +60172,7 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -60390,7 +60247,7 @@ cvZ
 cvZ
 cvZ
 cvZ
-nbe
+fFv
 fFv
 kac
 cfx
@@ -60518,13 +60375,13 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -60535,11 +60392,11 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -60547,7 +60404,7 @@ rzk
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -60610,7 +60467,7 @@ cvZ
 cvZ
 fFv
 fFv
-fFv
+nbe
 cfx
 cfx
 cfx
@@ -60747,10 +60604,10 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -60775,7 +60632,7 @@ sAv
 sAv
 sAv
 jJT
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -60956,7 +60813,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 rzk
@@ -60976,19 +60833,19 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 rzk
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -61170,7 +61027,7 @@ rzk
 rzk
 sAv
 nmb
-qIK
+dwA
 jJT
 sAv
 sAv
@@ -61186,7 +61043,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 sAv
@@ -61391,7 +61248,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -61400,7 +61257,7 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -61424,7 +61281,7 @@ okU
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -61448,7 +61305,7 @@ cWo
 cWo
 cWo
 lia
-jyE
+lia
 cfx
 fFv
 cfx
@@ -61606,7 +61463,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -61632,7 +61489,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -61827,7 +61684,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 okU
 rzk
@@ -61836,13 +61693,13 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -61852,7 +61709,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 okU
@@ -61919,7 +61776,7 @@ xYf
 fXT
 kac
 fFv
-tvc
+cfx
 cfx
 cfx
 cfx
@@ -62042,7 +61899,7 @@ iVy
 iVy
 gfh
 iTI
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -62050,27 +61907,11 @@ rzk
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 rzk
-rzk
-okU
-rzk
-rzk
-jJT
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
-sAv
 rzk
 okU
 rzk
@@ -62078,7 +61919,23 @@ rzk
 jJT
 sAv
 sAv
-qIK
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+sAv
+rzk
+okU
+rzk
+rzk
+jJT
+sAv
+sAv
+dwA
 sAv
 rzk
 okU
@@ -62137,7 +61994,7 @@ fXT
 fFv
 fFv
 fFv
-fFv
+kac
 cfx
 fFv
 cfx
@@ -62281,7 +62138,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -62354,7 +62211,7 @@ fFv
 fFv
 fFv
 iHq
-kac
+fFv
 fFv
 cfx
 cfx
@@ -62477,7 +62334,7 @@ sAv
 okU
 gfh
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -62696,7 +62553,7 @@ iTI
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 okU
 rzk
@@ -62717,11 +62574,11 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 okU
 rzk
@@ -62910,7 +62767,7 @@ sAv
 sAv
 sAv
 iTI
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -62944,7 +62801,7 @@ okU
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -63205,7 +63062,7 @@ fFv
 kac
 fFv
 fFv
-vgG
+hNs
 fFv
 fFv
 fFv
@@ -63346,7 +63203,7 @@ sAv
 iTI
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -63417,7 +63274,7 @@ cdI
 cdI
 iRp
 oTN
-iRp
+qyl
 iRp
 iRp
 iRp
@@ -63559,7 +63416,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 iTI
 sAv
 sAv
@@ -63574,7 +63431,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -63597,7 +63454,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -63619,7 +63476,7 @@ lia
 lia
 fFv
 cfx
-cfx
+tvc
 cfx
 cfx
 cfx
@@ -63667,7 +63524,7 @@ fFv
 fFv
 lQm
 aPk
-dSG
+guq
 guq
 sZJ
 vYf
@@ -63781,7 +63638,7 @@ iTI
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -63799,13 +63656,13 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 okU
 okU
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 okU
@@ -64012,7 +63869,7 @@ sAv
 nrp
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -64028,7 +63885,7 @@ okU
 okU
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -64061,7 +63918,7 @@ cdI
 fFv
 vFD
 twE
-blh
+gKL
 twE
 gKL
 cQp
@@ -64191,13 +64048,13 @@ rGz
 csL
 csL
 csL
-dCb
-dCb
-dCb
-wmF
-dCb
-njA
-bzb
+nCN
+nCN
+nCN
+cri
+nCN
+gdf
+dSG
 pRU
 "}
 (173,1,1) = {"
@@ -64222,7 +64079,7 @@ rzk
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -64408,13 +64265,13 @@ csL
 csL
 eOV
 csL
-dCb
+nCN
 rGz
 csL
 rGz
 csL
 csL
-bzb
+dSG
 pRU
 "}
 (174,1,1) = {"
@@ -64431,7 +64288,7 @@ gfh
 gfh
 rzk
 sAv
-qIK
+dwA
 sAv
 jJT
 rzk
@@ -64625,13 +64482,13 @@ nMN
 csL
 rGz
 csL
-njA
+gdf
 csL
 rGz
 rGz
 rGz
 rGz
-bzb
+dSG
 pRU
 "}
 (175,1,1) = {"
@@ -64666,7 +64523,7 @@ sAv
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -64717,7 +64574,7 @@ vFD
 vFD
 vFD
 vFD
-qyl
+iRp
 pPG
 hpZ
 mna
@@ -64842,13 +64699,13 @@ csL
 csL
 csL
 csL
-njA
+gdf
 nMN
 csL
 rGz
-aiT
+gSd
 csL
-bzb
+dSG
 pRU
 "}
 (176,1,1) = {"
@@ -64877,7 +64734,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -64894,11 +64751,11 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -65059,13 +64916,13 @@ rGz
 rGz
 csL
 csL
-dCb
+nCN
 csL
 csL
 csL
 csL
 csL
-bzb
+dSG
 pRU
 "}
 (177,1,1) = {"
@@ -65106,7 +64963,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -65161,7 +65018,7 @@ gtR
 gtR
 gtR
 xnr
-ujL
+xnr
 gSm
 gSm
 gSm
@@ -65182,7 +65039,7 @@ fFv
 fFv
 kac
 fFv
-nbe
+fFv
 fFv
 lia
 lia
@@ -65276,13 +65133,13 @@ csL
 rGz
 rGz
 csL
-njA
+gdf
 csL
 csL
 rGz
 csL
 csL
-njA
+gdf
 pRU
 "}
 (178,1,1) = {"
@@ -65302,7 +65159,7 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 okU
 rzk
@@ -65359,7 +65216,7 @@ cfx
 cfx
 cfx
 cfx
-jaR
+uHN
 cdI
 egH
 myc
@@ -65493,13 +65350,13 @@ rGz
 csL
 csL
 csL
-njA
+gdf
 nMN
 csL
 rGz
 rGz
 rGz
-njA
+gdf
 pRU
 "}
 (179,1,1) = {"
@@ -65525,7 +65382,7 @@ okU
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -65537,7 +65394,7 @@ rzk
 jJT
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -65710,13 +65567,13 @@ csL
 csL
 csL
 rGz
-njA
-njA
-njA
-dCb
-dCb
-njA
-njA
+gdf
+gdf
+gdf
+nCN
+nCN
+gdf
+gdf
 pRU
 "}
 (180,1,1) = {"
@@ -65759,7 +65616,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -65818,7 +65675,7 @@ gSm
 gSm
 gSm
 iRp
-ujL
+xnr
 aqg
 fFv
 fFv
@@ -65980,7 +65837,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 jJT
@@ -66002,11 +65859,11 @@ lWl
 mGS
 tXL
 wlm
-lIz
+lWl
 hmu
 cWo
 fFv
-tvc
+cfx
 cfx
 cfx
 cfx
@@ -66179,7 +66036,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -66244,7 +66101,7 @@ xnr
 xnr
 xnr
 xnr
-xnr
+ujL
 xnr
 xnr
 gSm
@@ -66279,7 +66136,7 @@ hPs
 kwb
 fFv
 fFv
-jyE
+lia
 lia
 lia
 lqa
@@ -66386,7 +66243,7 @@ rzk
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -66452,10 +66309,10 @@ vFD
 fFv
 fFv
 kac
-fFv
+jCj
 xnr
 pPG
-ujL
+xnr
 xnr
 xnr
 xnr
@@ -66597,7 +66454,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -66651,7 +66508,7 @@ lia
 cWo
 mdl
 mdl
-lIz
+lWl
 sQG
 mdl
 lWl
@@ -67039,19 +66896,19 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67128,7 +66985,7 @@ fFv
 fFv
 fFv
 fFv
-nbe
+fFv
 fFv
 akR
 hPs
@@ -67252,7 +67109,7 @@ sAv
 jJT
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67273,7 +67130,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 jJT
 rzk
@@ -67488,7 +67345,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67680,7 +67537,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67693,7 +67550,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67710,7 +67567,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67919,18 +67776,18 @@ okU
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -67974,7 +67831,7 @@ sVZ
 xRa
 rXP
 uTF
-uTF
+nGf
 uTF
 uTF
 rXP
@@ -67989,7 +67846,7 @@ jFQ
 fVA
 mjj
 jFQ
-jFQ
+hps
 rBo
 nze
 fFv
@@ -68021,7 +67878,7 @@ kac
 rWk
 guq
 gwT
-dSG
+guq
 gwT
 guq
 sZJ
@@ -68151,7 +68008,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -68192,7 +68049,7 @@ eKh
 sVZ
 uTF
 nvT
-nGf
+uTF
 nJD
 rXP
 kac
@@ -68335,12 +68192,12 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 jJT
@@ -68364,7 +68221,7 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -68421,7 +68278,7 @@ gAy
 jdv
 jFQ
 jFQ
-jFQ
+hps
 fVA
 jFQ
 rBo
@@ -68567,7 +68424,7 @@ okU
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 ssH
 sAv
@@ -68578,13 +68435,13 @@ rzk
 okU
 okU
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -68804,7 +68661,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -68831,7 +68688,7 @@ fFv
 cfx
 cfx
 cfx
-tvc
+cfx
 fFv
 fDs
 bsp
@@ -69004,7 +68861,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -69156,7 +69013,7 @@ xYK
 xYK
 xYK
 xYK
-hKw
+jIA
 xYK
 xYK
 xYK
@@ -69210,7 +69067,7 @@ okU
 okU
 rzk
 sAv
-qIK
+dwA
 sAv
 jJT
 rzk
@@ -69236,7 +69093,7 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -69278,7 +69135,7 @@ rXP
 uTF
 nvT
 nvT
-uTF
+nGf
 rXP
 fFv
 fFv
@@ -69303,7 +69160,7 @@ lia
 lia
 fFv
 fFv
-nbe
+fFv
 lia
 lia
 tpO
@@ -69441,7 +69298,7 @@ rzk
 sAv
 nrp
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -69461,7 +69318,7 @@ sAv
 sAv
 fSy
 fSy
-bTd
+sCz
 fFv
 lia
 lia
@@ -69494,7 +69351,7 @@ rXP
 rXP
 uTF
 uTF
-nGf
+uTF
 uTF
 rXP
 fFv
@@ -69645,7 +69502,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -69855,10 +69712,10 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -69869,7 +69726,7 @@ iTI
 iTI
 iTI
 gfh
-kMp
+dhq
 iTI
 iTI
 sAv
@@ -69890,7 +69747,7 @@ rzk
 jJT
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 fSy
@@ -69941,7 +69798,7 @@ fFv
 fFv
 kac
 cfx
-tvc
+cfx
 cfx
 fFv
 kac
@@ -70069,7 +69926,7 @@ okU
 rzk
 ksP
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70084,7 +69941,7 @@ iTI
 sAv
 sAv
 sAv
-qIK
+dwA
 jho
 sAv
 sAv
@@ -70105,7 +69962,7 @@ okU
 okU
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70294,7 +70151,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 iTI
@@ -70306,7 +70163,7 @@ sAv
 sAv
 sAv
 iTI
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -70315,7 +70172,7 @@ okU
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -70338,8 +70195,8 @@ lia
 bzV
 bzV
 eIk
-eIk
 isv
+eIk
 eIk
 eIk
 bzV
@@ -70506,7 +70363,7 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70516,7 +70373,7 @@ sAv
 sAv
 iTI
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70541,7 +70398,7 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -70563,7 +70420,7 @@ rko
 fFv
 cfx
 cfx
-tvc
+cfx
 cfx
 cfx
 cfx
@@ -70625,7 +70482,7 @@ fFv
 fFv
 rWk
 gwT
-dSG
+guq
 gwT
 guq
 sZJ
@@ -70726,7 +70583,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 rzk
@@ -70738,7 +70595,7 @@ sAv
 sAv
 qGH
 sAv
-qIK
+dwA
 iTI
 sAv
 sAv
@@ -70753,9 +70610,9 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70789,7 +70646,7 @@ cfx
 fFv
 fFv
 fFv
-nbe
+fFv
 fFv
 fFv
 cfx
@@ -70937,7 +70794,7 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70965,7 +70822,7 @@ rzk
 rzk
 jJT
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -70975,7 +70832,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 rzk
@@ -71180,12 +71037,12 @@ okU
 okU
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -71252,7 +71109,7 @@ kac
 fFv
 kac
 fFv
-nbe
+fFv
 kac
 cfx
 cfx
@@ -71372,7 +71229,7 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -71385,7 +71242,7 @@ rzk
 iTI
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 jho
@@ -71406,7 +71263,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -71617,7 +71474,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -71626,7 +71483,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -71643,8 +71500,8 @@ bzV
 eIk
 eIk
 xMw
-eIk
 isv
+eIk
 eIk
 oUG
 bzV
@@ -71665,7 +71522,7 @@ qvL
 jbl
 dwG
 rwI
-mPN
+rwI
 jbl
 qvL
 qvL
@@ -71807,7 +71664,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 rzk
@@ -71832,16 +71689,16 @@ rzk
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -71871,7 +71728,7 @@ cWo
 kqH
 kqH
 cWo
-lIz
+lWl
 kqH
 sRg
 vCb
@@ -71898,7 +71755,7 @@ pXQ
 jbl
 jbl
 jbl
-hNs
+jbl
 xXL
 jbl
 jbl
@@ -72022,7 +71879,7 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -72046,7 +71903,7 @@ okU
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -72063,7 +71920,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 okU
@@ -72267,7 +72124,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 sAv
@@ -72479,7 +72336,7 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -72495,7 +72352,7 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 ksP
 okU
@@ -72675,7 +72532,7 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -72699,7 +72556,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -72763,7 +72620,7 @@ fFv
 fFv
 qvL
 jbl
-hNs
+jbl
 xXL
 jbl
 nQO
@@ -72890,7 +72747,7 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -73012,15 +72869,15 @@ mtS
 lia
 fFv
 gRx
-qve
-xjc
-mhS
-fwl
-fwl
-fwl
-rrA
-fwl
-fwl
+xtD
+cFf
+ffm
+tKI
+tKI
+tKI
+xHU
+tKI
+tKI
 vYf
 iUQ
 iUQ
@@ -73129,7 +72986,7 @@ rzk
 okU
 rzk
 iTI
-qIK
+dwA
 sAv
 nrp
 sAv
@@ -73152,7 +73009,7 @@ okU
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 okU
@@ -73229,7 +73086,7 @@ lia
 lia
 fFv
 gRx
-qve
+xtD
 iUQ
 iUQ
 iUQ
@@ -73237,7 +73094,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-fwl
+tKI
 fEp
 iUQ
 pDY
@@ -73329,7 +73186,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 jJT
 rzk
 rzk
@@ -73351,7 +73208,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -73438,15 +73295,15 @@ fFv
 fFv
 fFv
 oNI
-wwN
-wwN
-wwN
-qIf
-qIf
-qIf
-wwN
-qve
-qve
+jaM
+jaM
+jaM
+blh
+blh
+blh
+jaM
+xtD
+xtD
 vYf
 iUQ
 yeU
@@ -73454,7 +73311,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-fwl
+tKI
 iUQ
 iUQ
 iUQ
@@ -73538,7 +73395,7 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -73558,7 +73415,7 @@ rzk
 sAv
 sAv
 jho
-qIK
+dwA
 sAv
 rzk
 okU
@@ -73566,12 +73423,12 @@ gfh
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -73584,7 +73441,7 @@ sAv
 sAv
 jJT
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -73655,23 +73512,23 @@ fFv
 fFv
 fFv
 fFv
-wwN
+jaM
 fFv
 lia
 lia
 lia
 fFv
 fFv
-qve
-qve
+xtD
+xtD
 vYf
 iUQ
 iUQ
 iUQ
-pyx
+vFG
 iUQ
 iUQ
-fwl
+tKI
 iUQ
 iUQ
 iUQ
@@ -73758,10 +73615,10 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -73786,7 +73643,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -73798,14 +73655,14 @@ okU
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
 sAv
 jJT
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -73872,15 +73729,15 @@ lia
 lia
 fFv
 fFv
-qIf
+blh
 hvS
 fFv
 lia
 lia
 fFv
 fFv
-qve
-qve
+xtD
+xtD
 vYf
 iUQ
 iUQ
@@ -73888,7 +73745,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-fwl
+tKI
 yeU
 iUQ
 pDY
@@ -73981,14 +73838,14 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
-qIK
+dwA
 rzk
 rzk
 gfh
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -73998,17 +73855,17 @@ sAv
 rzk
 iVy
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74025,7 +73882,7 @@ qGH
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 okU
 okU
@@ -74089,15 +73946,15 @@ lia
 hvS
 lia
 lia
-qIf
+blh
 lia
 lia
 lia
-cmL
+mhj
 kac
 fFv
-qve
-qve
+xtD
+xtD
 lkG
 iUQ
 iUQ
@@ -74105,7 +73962,7 @@ vYf
 iUQ
 iUQ
 iUQ
-fwl
+tKI
 iUQ
 iUQ
 iUQ
@@ -74188,7 +74045,7 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74202,7 +74059,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 iTI
 sAv
 sAv
@@ -74219,7 +74076,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 rzk
 rzk
@@ -74229,7 +74086,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74240,7 +74097,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 nrp
 sAv
 jJT
@@ -74306,15 +74163,15 @@ hnD
 lia
 lia
 lia
-qIf
+blh
 lia
 jhp
 lia
 lia
 lia
 fFv
-qve
-qve
+xtD
+xtD
 vYf
 iUQ
 vYf
@@ -74322,7 +74179,7 @@ vYf
 njs
 iUQ
 iUQ
-fwl
+tKI
 pDY
 vYf
 iUQ
@@ -74408,12 +74265,12 @@ rzk
 rzk
 sAv
 sAv
-qIK
+dwA
 rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74442,7 +74299,7 @@ rzk
 rzk
 rzk
 rzk
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74451,7 +74308,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74461,7 +74318,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 okU
 luL
 lia
@@ -74523,15 +74380,15 @@ lia
 lia
 lia
 lia
-qIf
+blh
 lia
 lia
 lia
 lia
 lia
 fFv
-qve
-qve
+xtD
+xtD
 vYf
 rfT
 vYf
@@ -74539,7 +74396,7 @@ vYf
 vYf
 vYf
 vYf
-xjc
+cFf
 vYf
 vYf
 vYf
@@ -74634,7 +74491,7 @@ rzk
 rzk
 sAv
 jJT
-qIK
+dwA
 sAv
 sAv
 iTI
@@ -74645,13 +74502,13 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 iVy
 okU
 jJT
 sAv
-qIK
+dwA
 sAv
 sAv
 rzk
@@ -74664,7 +74521,7 @@ rzk
 rzk
 okU
 sAv
-qIK
+dwA
 sAv
 sAv
 jJT
@@ -74673,7 +74530,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74740,15 +74597,15 @@ lia
 lia
 lia
 lia
-qIf
+blh
 lia
 lia
 lia
 lqa
 lia
 fFv
-qve
-qve
+xtD
+xtD
 iUQ
 iUQ
 iUQ
@@ -74756,7 +74613,7 @@ iUQ
 iUQ
 iUQ
 iUQ
-fwl
+tKI
 iUQ
 iUQ
 iUQ
@@ -74853,11 +74710,11 @@ rzk
 rzk
 rzk
 sAv
-qIK
+dwA
 iTI
 sAv
 sAv
-qIK
+dwA
 sAv
 jho
 sAv
@@ -74892,7 +74749,7 @@ sAv
 sAv
 sAv
 sAv
-qIK
+dwA
 sAv
 sAv
 sAv
@@ -74957,23 +74814,23 @@ luL
 luL
 luL
 luL
-qIf
+blh
 lia
 lia
 lia
 lia
 lia
 lia
-qve
-qve
-vOc
-vOc
-vOc
-vOc
-vOc
-vOc
-vOc
-vOc
+xtD
+xtD
+rhx
+rhx
+rhx
+rhx
+rhx
+rhx
+rhx
+rhx
 iUQ
 fzU
 iUQ
@@ -75174,14 +75031,14 @@ luL
 luL
 luL
 luL
-vOc
-vOc
-vOc
-qIf
-qIf
-qIf
-qIf
-vOc
+rhx
+rhx
+rhx
+blh
+blh
+blh
+blh
+rhx
 luL
 luL
 luL

--- a/code/game/area/turkenden_3.dm
+++ b/code/game/area/turkenden_3.dm
@@ -736,6 +736,7 @@
 	name = "Turkenden-3 Excluzone - Caves - Hive"
 	icon_state = "t3e_ccaves"
 	minimap_color = MINIMAP_AREA_CAVES
+	ceiling = CEILING_DEEP_UNDERGROUND
 
 /area/turkenden3excluzone/indoors/caves/sw
 	name = "Turkenden-3 Excluzone - Caves - Southwest"

--- a/code/game/area/vietzhuo_8.dm
+++ b/code/game/area/vietzhuo_8.dm
@@ -736,6 +736,7 @@
 /area/vietzhuo8/indoors/caves
 	name = "Vietzhuo-8 - Caves"
 	minimap_color = MINIMAP_AREA_CAVES
+	ceiling = CEILING_DEEP_UNDERGROUND
 
 /area/vietzhuo8/indoors/caves/northwest
 	name = "Vietzhuo-8 - North Western Caverns"


### PR DESCRIPTION

## About The Pull Request

Second round of hotfixes for T3E & V8B after public tests on nuke war and zombie crash.

## Why It's Good For The Game

Hotfixes are good and optimizing V8B's NPC count by more than half of the total population is a good step in the direction of performance optimization.

## Changelog
:cl:
fix: makes caves on T3E & V8B deep_underground so CAS can't strafe them
balance: gives more silo spawns on T3E & sacrifices some xeno starting structures
balance: gives more silo spawns on V8B (for more potential zombie spawns)
balance: changes the total V8B civilian count from 116 to 48
add: more AI_nodes on V8B to help with AI pathfinding
/:cl:
