### PR TITLE
Fix simple interaction heal sex gating

### DIFF
--- a/ntf_modular/code/datums/sexcon/sex_action.dm
+++ b/ntf_modular/code/datums/sexcon/sex_action.dm
@@ -88,6 +88,9 @@
 /datum/sex_action/proc/shows_on_menu(mob/living/carbon/user, mob/living/carbon/target)
 	return TRUE
 
+/datum/sex_action/proc/can_heal(mob/living/carbon/user, mob/living/carbon/target, mob/living/action_target)
+	return heal_sex
+
 /mob/living/proc/sexcon_has_penis(require_exposed = FALSE)
 	if(ishuman(src))
 		var/mob/living/carbon/human/human = src

--- a/ntf_modular/code/datums/sexcon/sex_actions/splurt_adapted/simple_interactions.dm
+++ b/ntf_modular/code/datums/sexcon/sex_actions/splurt_adapted/simple_interactions.dm
@@ -34,7 +34,7 @@
 	continous = FALSE
 	stamina_cost = 0.1
 	check_incapacitated = FALSE
-	heal_sex = FALSE
+	heal_sex = TRUE
 	var/start_message
 	var/perform_message
 	var/finish_message
@@ -58,6 +58,7 @@
 	var/list/perform_sounds
 	var/perform_sound_volume = 20
 	var/replaced_by_base_action = FALSE
+	var/quick_heal_requires_target_pref = TRUE
 
 /datum/sex_action/simple_interaction/shows_on_menu(mob/living/carbon/user, mob/living/carbon/target)
 	if(replaced_by_base_action)
@@ -135,6 +136,14 @@
 	var/message = sexcon_interaction_message(finish_message, user, target)
 	if(message)
 		user.visible_message(span_warning(message))
+
+/datum/sex_action/simple_interaction/can_heal(mob/living/carbon/user, mob/living/carbon/target, mob/living/action_target)
+	if(quick_heal_requires_target_pref \
+		&& user?.sexcon?.drain_style == SEX_DRAIN_STYLE_HEAL_TARGET \
+		&& action_target?.mind \
+		&& !(action_target.client?.prefs.quick_sex_flags & QUICK_SEX_HEAL))
+		return FALSE
+	return ..()
 
 /datum/sex_action/simple_interaction/cheer
 	name = "Cheer"

--- a/ntf_modular/code/datums/sexcon/sexcon.dm
+++ b/ntf_modular/code/datums/sexcon/sexcon.dm
@@ -394,7 +394,7 @@
 
 /datum/sex_controller/proc/perform_sex_action(mob/living/action_target, arousal_amt, pain_amt, giving)
 	var/datum/sex_action/action = SEX_ACTION(current_action)
-	var/healing_amount = (action?.heal_sex) ? rand(1, 3) : 0
+	var/healing_amount = (action?.can_heal(user, target, action_target)) ? rand(1, 3) : 0
 	action_target.sexcon.receive_sex_action(arousal_amt, pain_amt, giving, force, speed, healing_amount, user)
 
 /datum/sex_controller/proc/receive_sex_action(arousal_amt, pain_amt, giving, applied_force, applied_speed, healing_amount, mob/living/blame_mob)


### PR DESCRIPTION
About The Pull Request
Fixes simple sexcon interactions not being able to apply heal-sex effects.
The sexcon rework added the simple interaction action type with heal_sex = FALSE, which meant those actions could still perform arousal/action effects but would always pass 0 healing into the sexcon controller. This adds an action-level can_heal() hook and lets simple interactions heal again while still respecting the target's quick-heal preference when using SEX_DRAIN_STYLE_HEAL_TARGET.

Why It's Good For The Game

This restores expected quick-heal/healsex behavior for the new sexcon interaction flow without changing the old MouseDrop quick-sex path or unrelated sex actions.
Players who have opted into quick-heal can receive healing from simple interactions again, while players who have not opted in remain protected from that heal-target behavior.
Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
</details>

Changelog
:cl:
fix: Fixed simple sexcon interactions not applying quick-heal/healsex effects for opted-in targets.
/:cl: