### PR TITLE
Add large vehicle skill to synths

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -420,6 +420,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	powerloader = SKILL_POWERLOADER_MASTER
 	chemistry = SKILL_CHEM_EXPERT
 	sex = SKILL_SEX_MASTER
+	large_vehicle = SKILL_LARGE_VEHICLE_EXPERIENCED
 
 /datum/skills/early_synthetic
 	name = "Early Synthetic"
@@ -436,6 +437,7 @@ engineer, construction, leadership, medical, surgery, pilot, police, powerloader
 	powerloader = SKILL_POWERLOADER_MASTER
 	chemistry = SKILL_CHEM_EXPERT
 	sex = SKILL_SEX_MASTER
+	large_vehicle = SKILL_LARGE_VEHICLE_EXPERIENCED
 
 /datum/skills/combat_robot
 	name = COMBAT_ROBOT


### PR DESCRIPTION
## About The Pull Request

Gives synths access to APC driver seat, also gives them access to tank interior- but they can NOT actually drive the tank or operate the gun. The most they can do is be the loading bitch (which they could of already done, since assault crewmen get pamphlets they can give to turn people into their loading bitch and they can give them to synths anyways- also loading bitch is a pretty synth-esque role)

## Why It's Good For The Game

I can larp as a synth paramedic in an ambulance (apc ambulance)


## Proof of Testing

I didn't test SHIT

## Changelog
:cl:
add: Level 2 large vehicles (driving APCs) to synths
/:cl:
